### PR TITLE
Fix KMS apply. Bump lambda versions

### DIFF
--- a/lock_versions
+++ b/lock_versions
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# dependencies = [
+#   "boto3",
+# ]
+# ///
+
 """
 This script locks specific versions of lambdas and containers as a part of the
 release process of the terraform module.

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 module "kms" {
   source = "./modules/kms"
-  count  = var.kms_key_arn == null ? 1 : 0
+  count  = var.kms_key_arn == "" ? 1 : 0
 
   deployment_name         = var.deployment_name
   additional_key_policies = var.additional_kms_key_policies
 }
 
 locals {
-  kms_key_arn = var.kms_key_arn != null ? var.kms_key_arn : module.kms[0].key_arn
+  kms_key_arn = var.kms_key_arn != "" ? var.kms_key_arn : module.kms[0].key_arn
   clickhouse_address = var.use_external_clickhouse_address != null ? var.use_external_clickhouse_address : (
     var.enable_clickhouse ? module.clickhouse[0].clickhouse_instance_private_ip : null
   )

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 tflint = "latest"
 pre-commit = "latest"
 terraform = "1.10"
+uv = "latest"
 
 [tasks]
 lint = ["terraform fmt -recursive", "tflint --recursive"]

--- a/modules/brainstore/VERSIONS.json
+++ b/modules/brainstore/VERSIONS.json
@@ -1,5 +1,5 @@
 {
-    "brainstore": "efd5fa953283329dde40866e9006c869837b7e67",
+    "brainstore": "d3c7e30e993b1dbb354ba894cde9ad14fd196b97",
     "_tag": "latest",
-    "_timestamp": "2025-03-14T15:45:57.352992"
+    "_timestamp": "2025-03-18T11:25:34.153500"
 }

--- a/modules/brainstore/iam.tf
+++ b/modules/brainstore/iam.tf
@@ -85,8 +85,6 @@ resource "aws_iam_role_policy" "brainstore_cloudwatch_logs_access" {
 }
 
 resource "aws_iam_role_policy" "brainstore_kms_policy" {
-  count = var.kms_key_arn != null ? 1 : 0
-
   name = "${var.deployment_name}-brainstore-kms-policy"
   role = aws_iam_role.brainstore_ec2_role.id
 

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -50,7 +50,6 @@ variable "instance_key_pair_name" {
 variable "kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key to use for encrypting the Brainstore disks and S3 bucket. If not provided, AWS managed keys will be used."
-  default     = null
 }
 
 variable "vpc_id" {

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,9 +1,9 @@
 {
-    "AIProxy": "lambda/AIProxy/versions/25fc7cbdb108be9db641ec47b7f5acab.zip",
-    "APIHandler": "lambda/APIHandler/versions/b532daac63efc30982f34aca75f1880d.zip",
-    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/78d320c5049782073f58b5f1ba0fdac4.zip",
-    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/81d03621748d93167a2ad8ff78753191.zip",
-    "CatchupETL": "lambda/CatchupETL/versions/9dddcd4d0f4d897d6edb3ac4d104c3c5.zip",
+    "AIProxy": "lambda/AIProxy/versions/d3e1d5e1a6dc764705a199f318d0c8b9.zip",
+    "APIHandler": "lambda/APIHandler/versions/a5c12700e46b9b3aaff10abfe94d2a72.zip",
+    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/187903b95e71a12a4a8218dffb23a730.zip",
+    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/38cfac7c3c8d1dde6ac8020c15faf93e.zip",
+    "CatchupETL": "lambda/CatchupETL/versions/79f082e16ff2071e406caf6ff6a8c709.zip",
     "_tag": "latest",
-    "_timestamp": "2025-03-14T15:45:57.352992"
+    "_timestamp": "2025-03-18T11:25:34.153500"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "deployment_name" {
 variable "kms_key_arn" {
   description = "Existing KMS key ARN to use for encrypting resources. If not provided, a new key will be created. DO NOT change this after deployment. If you do, it will attempt to destroy your DB and prior S3 objects will no longer be readable."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "additional_kms_key_policies" {


### PR DESCRIPTION
Terraform couldn't apply the stack because it couldn't determine if kms_key_id was null or not. I don't fully understand this but changing it from null fixes this case.

Also, bump the lambda versions to latest and make the lock_versions script a self-contained uv script. No venv needed.