### PR TITLE
Allow RDS storage autoscaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,12 +49,13 @@ module "quarantine_vpc" {
 }
 
 module "database" {
-  source                 = "./modules/database"
-  deployment_name        = var.deployment_name
-  postgres_instance_type = var.postgres_instance_type
-  postgres_storage_size  = var.postgres_storage_size
-  postgres_storage_type  = var.postgres_storage_type
-  postgres_version       = var.postgres_version
+  source                    = "./modules/database"
+  deployment_name           = var.deployment_name
+  postgres_instance_type    = var.postgres_instance_type
+  postgres_storage_size     = var.postgres_storage_size
+  postgres_max_storage_size = var.postgres_max_storage_size
+  postgres_storage_type     = var.postgres_storage_type
+  postgres_version          = var.postgres_version
   database_subnet_ids = [
     module.main_vpc.private_subnet_1_id,
     module.main_vpc.private_subnet_2_id,

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -10,11 +10,12 @@ resource "aws_db_instance" "main" {
 
   instance_class = var.postgres_instance_type
 
-  storage_encrypted  = true
-  allocated_storage  = var.postgres_storage_size
-  storage_type       = var.postgres_storage_type
-  storage_throughput = var.postgres_storage_throughput
-  iops               = var.postgres_storage_iops
+  storage_encrypted     = true
+  allocated_storage     = var.postgres_storage_size
+  max_allocated_storage = var.postgres_max_storage_size
+  storage_type          = var.postgres_storage_type
+  storage_throughput    = var.postgres_storage_throughput
+  iops                  = var.postgres_storage_iops
 
   db_name  = "postgres"
   username = local.postgres_username

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -16,6 +16,12 @@ variable "postgres_storage_size" {
   default     = 100
 }
 
+variable "postgres_max_storage_size" {
+  description = "Maximum storage size (in GB) to allow the RDS instance to auto-scale to."
+  type        = number
+  default     = 1000
+}
+
 variable "postgres_storage_type" {
   description = "Storage type for the RDS instance."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "postgres_storage_size" {
   default     = 100
 }
 
+variable "postgres_max_storage_size" {
+  description = "Maximum storage size (in GB) to allow the RDS instance to auto-scale to."
+  type        = number
+  default     = 1000
+}
+
 variable "postgres_storage_type" {
   description = "Storage type for the RDS instance."
   type        = string


### PR DESCRIPTION
Expose `postgres_max_storage_size` and default it to 1TB. This allows the DB to transparently autoscale up storage size as needed rather than locking up into read only mode.