### PR TITLE
Reduce CIDR sizes and ignore changes to sizes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,13 @@ module "main_vpc" {
   vpc_name        = "main"
   vpc_cidr        = var.vpc_cidr
 
-  public_subnet_1_cidr  = cidrsubnet(var.vpc_cidr, 8, 0)
+  public_subnet_1_cidr  = cidrsubnet(var.vpc_cidr, 3, 0)
   public_subnet_1_az    = local.public_subnet_1_az
-  private_subnet_1_cidr = cidrsubnet(var.vpc_cidr, 8, 1)
+  private_subnet_1_cidr = cidrsubnet(var.vpc_cidr, 3, 1)
   private_subnet_1_az   = local.private_subnet_1_az
-  private_subnet_2_cidr = cidrsubnet(var.vpc_cidr, 8, 2)
+  private_subnet_2_cidr = cidrsubnet(var.vpc_cidr, 3, 2)
   private_subnet_2_az   = local.private_subnet_2_az
-  private_subnet_3_cidr = cidrsubnet(var.vpc_cidr, 8, 3)
+  private_subnet_3_cidr = cidrsubnet(var.vpc_cidr, 3, 3)
   private_subnet_3_az   = local.private_subnet_3_az
 }
 
@@ -38,13 +38,13 @@ module "quarantine_vpc" {
   vpc_name        = "quarantine"
   vpc_cidr        = var.quarantine_vpc_cidr
 
-  public_subnet_1_cidr  = cidrsubnet(var.quarantine_vpc_cidr, 8, 0)
+  public_subnet_1_cidr  = cidrsubnet(var.quarantine_vpc_cidr, 3, 0)
   public_subnet_1_az    = local.quarantine_public_subnet_1_az
-  private_subnet_1_cidr = cidrsubnet(var.quarantine_vpc_cidr, 8, 1)
+  private_subnet_1_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 1)
   private_subnet_1_az   = local.quarantine_private_subnet_1_az
-  private_subnet_2_cidr = cidrsubnet(var.quarantine_vpc_cidr, 8, 2)
+  private_subnet_2_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 2)
   private_subnet_2_az   = local.quarantine_private_subnet_2_az
-  private_subnet_3_cidr = cidrsubnet(var.quarantine_vpc_cidr, 8, 3)
+  private_subnet_3_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 3)
   private_subnet_3_az   = local.quarantine_private_subnet_3_az
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -12,6 +12,10 @@ resource "aws_vpc" "vpc" {
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}"
   }, local.common_tags)
+
+  lifecycle {
+    ignore_changes = [cidr_block]
+  }
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
@@ -77,6 +81,10 @@ resource "aws_subnet" "public_subnet_1" {
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-public-subnet-1"
   }, local.common_tags)
+
+  lifecycle {
+    ignore_changes = [cidr_block]
+  }
 }
 
 resource "aws_subnet" "private_subnet_1" {
@@ -87,6 +95,10 @@ resource "aws_subnet" "private_subnet_1" {
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-private-subnet-1"
   }, local.common_tags)
+
+  lifecycle {
+    ignore_changes = [cidr_block]
+  }
 }
 
 resource "aws_subnet" "private_subnet_2" {
@@ -97,6 +109,10 @@ resource "aws_subnet" "private_subnet_2" {
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-private-subnet-2"
   }, local.common_tags)
+
+  lifecycle {
+    ignore_changes = [cidr_block]
+  }
 }
 
 resource "aws_subnet" "private_subnet_3" {
@@ -107,6 +123,10 @@ resource "aws_subnet" "private_subnet_3" {
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-private-subnet-3"
   }, local.common_tags)
+
+  lifecycle {
+    ignore_changes = [cidr_block]
+  }
 }
 
 resource "aws_route_table_association" "private_subnet_1_association" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "additional_kms_key_policies" {
 ## NETWORKING
 variable "vpc_cidr" {
   type        = string
-  default     = "10.175.0.0/16"
+  default     = "10.175.0.0/21"
   description = "CIDR block for the VPC"
 }
 
@@ -86,7 +86,7 @@ variable "enable_quarantine_vpc" {
 
 variable "quarantine_vpc_cidr" {
   type        = string
-  default     = "10.176.0.0/16"
+  default     = "10.175.8.0/21"
   description = "CIDR block for the Quarantined VPC"
 }
 


### PR DESCRIPTION
Our default CIDR size for the VPCs was huge and unnecessary. Also the subnets inside the VPC were calculated incorrectly and ended up being tiny.

This PR changes our default CIDR size to something more realistic. The subnets carve out half of the range to ensure we have room for growth later in case of changes. Terraform will also now ignore changes to the CIDR since changing them requires destroying the VPC or subnet and recreating it. That is never what we want.

Main VPC `10.175.0.0 - 10.175.7.255`
- Public Subnet 1: `10.175.0.0 - 10.175.0.255`
- Private Subnet 1: `10.175.1.0 - 10.175.1.255`
- Private Subnet 2: `10.175.2.0 - 10.175.2.255`
- Private Subnet 3: `10.175.3.0 - 10.175.3.255`

Quarantine VPC `10.175.8.0 - 10.175.15.255`
- Public Subnet 1: `10.175.8.0 - 10.175.8.255`
- Private Subnet 1: `10.175.9.0 - 10.175.9.255`
- Private Subnet 2: `10.175.10.0 - 10.175.10.255`
- Private Subnet 3: `10.175.11.0 - 10.175.11.255`
