### PR TITLE
Add support for passing additional IAM policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ module "services" {
   outbound_rate_limit_max_requests    = var.outbound_rate_limit_max_requests
   custom_domain                       = var.custom_domain
   custom_certificate_arn              = var.custom_certificate_arn
+  service_additional_policy_arns      = var.service_additional_policy_arns
 
   # Networking
   service_security_group_ids = [module.main_vpc.default_security_group_id]

--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -102,6 +102,12 @@ resource "aws_iam_role_policy_attachment" "api_handler_policy" {
   policy_arn = aws_iam_policy.api_handler_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "api_handler_additional_policy" {
+  count      = length(var.service_additional_policy_arns)
+  role       = aws_iam_role.api_handler_role.name
+  policy_arn = var.service_additional_policy_arns[count.index]
+}
+
 resource "aws_iam_role_policy_attachment" "api_handler_quarantine" {
   count      = var.use_quarantine_vpc ? 1 : 0
   role       = aws_iam_role.api_handler_role.name

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -18,6 +18,11 @@ variable "service_subnet_ids" {
   description = "The subnet ids for the lambda functions that are the main braintrust service"
 }
 
+variable "service_additional_policy_arns" {
+  type        = list(string)
+  description = "Additional policy ARNs to attach to the lambda functions that are the main braintrust service"
+  default     = []
+}
 variable "postgres_username" {
   type        = string
   description = "The username of the postgres database"

--- a/variables.tf
+++ b/variables.tf
@@ -209,6 +209,12 @@ variable "custom_certificate_arn" {
   default     = null
 }
 
+variable "service_additional_policy_arns" {
+  type        = list(string)
+  description = "Additional policy ARNs to attach to the lambda functions that are the main braintrust service"
+  default     = []
+}
+
 ## Clickhouse
 variable "enable_clickhouse" {
   type        = bool


### PR DESCRIPTION
Users can attach additional IAM policies to our API handler role that our main lambdas use. This is primarily to support external attachments in other s3 buckets, but could be used for any other permission customization that users need.

Simply pass a list of arns into `service_additional_policy_arns`.

Example usage:
![CleanShot 2025-03-25 at 14 09 00@2x](https://github.com/user-attachments/assets/c50879d8-dc4e-4d53-b061-121932f6f23b)
