### PR TITLE
Add script for service-linked roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This module is used to create the VPC, Databases, Lambdas, and associated resour
 
 To use this module, **copy the [`examples/braintrust-data-plane`](examples/braintrust-data-plane) directory to a new Terraform directory in your own repository**. Follow the instructions in the [`README.md`](examples/braintrust-data-plane/README.md) file in that directory to configure the module for your environment.
 
+If you're using a brand new AWS account for your Braintrust data plane you will need to run ./scripts/create-service-linked-roles.sh once to ensure IAM service-linked roles are created.
+
 
 ## Customized Deployments
 

--- a/examples/braintrust-data-plane/README.md
+++ b/examples/braintrust-data-plane/README.md
@@ -11,6 +11,9 @@ This is an example of a standard Braintrust data plane deployment. Copy this dir
   * Pass it into terraform as a flag `terraform apply -var 'brainstore_license_key=your-key'`
   * Add it to an uncommitted `terraform.tfvars` or `.auto.tfvars` file.
 
+## Initialize your AWS account
+If you're using a brand new AWS account for your Braintrust data plane you will need to run ./scripts/create-service-linked-roles.sh once to ensure IAM service-linked roles are created.
+
 ## Pointing your Organization to your data plane
 
 After applying this configuration you will have a Braintrust data plane deployed in your AWS account. You can then run `terraform output` to get the API URL you need to enter into the Braintrust UI for your Organization.

--- a/scripts/create-service-linked-roles.sh
+++ b/scripts/create-service-linked-roles.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVICE_NAME="autoscaling.amazonaws.com"
+
+# Try to create the service-linked role
+if CREATE_ROLE_OUTPUT=$(aws iam create-service-linked-role --aws-service-name "$SERVICE_NAME" 2>&1); then
+    echo "Service-linked role for '$SERVICE_NAME' created successfully."
+else
+
+    # Check if the error indicates the role already exists
+    if echo "$CREATE_ROLE_OUTPUT" | grep -q "has been taken in this account"; then
+        echo "Service-linked role for '$SERVICE_NAME' already exists."
+    else
+        echo "Failed to create service-linked role: $CREATE_ROLE_OUTPUT" >&2
+        exit 1
+    fi
+fi
+echo "AWS account is ready to use for the Braintrust data plane."


### PR DESCRIPTION
Related to #35 

Fresh AWS accounts will be missing a service-linked role for autoscaling. There isn't a good way in terraform to create the role and then also not track it in the state (see ticket for more details).

For now we'll just have to let users know they need to run a script once against their AWS accounts. Right now only there is only a role for autoscaling but we likely will have more in the future.