### PR TITLE
Ensure the ASG checks ELB and EBS health

### DIFF
--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -125,7 +125,7 @@ resource "aws_autoscaling_group" "brainstore" {
   max_size            = var.instance_count * 2
   desired_capacity    = var.instance_count
   vpc_zone_identifier = var.private_subnet_ids
-  health_check_type   = "EC2"
+  health_check_type   = "ELB,EBS"
   # This is essentially the expected boot and setup time of the instance.
   # If too low, the ASG may terminate the instance before it has a chance to boot.
   health_check_grace_period = 60


### PR DESCRIPTION
By default the Auto Scaling Group doesn't even bother to look at the load balancer healthchecks. It's a bit of an insane default, but it makes sense because sometimes there just isn't an ELB at all.

This PR makes the ASG consider the ELB and also any detected stalls of the EBS volume. The standard EC2 check remains and actually can't be removed at all.

So now it checks: Is the EC2 instance alive, is the EBS volume healthy, and is the ELB health check passing.