### PR TITLE
Brainstore enhanced monitoring

### DIFF
--- a/modules/brainstore/VERSIONS.json
+++ b/modules/brainstore/VERSIONS.json
@@ -1,5 +1,5 @@
 {
-    "brainstore": "d3c7e30e993b1dbb354ba894cde9ad14fd196b97",
+    "brainstore": "ebf7dee636204e938bbd1eae2dc87e9539e43103",
     "_tag": "latest",
-    "_timestamp": "2025-03-18T11:25:34.153500"
+    "_timestamp": "2025-04-01T12:43:15.185684"
 }

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -36,6 +36,10 @@ resource "aws_launch_template" "brainstore" {
     instance_metadata_tags      = "enabled"
   }
 
+  monitoring {
+    enabled = true
+  }
+
   user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
     aws_region                  = data.aws_region.current.name
     deployment_name             = var.deployment_name

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,9 +1,9 @@
 {
-    "AIProxy": "lambda/AIProxy/versions/d3e1d5e1a6dc764705a199f318d0c8b9.zip",
-    "APIHandler": "lambda/APIHandler/versions/a5c12700e46b9b3aaff10abfe94d2a72.zip",
-    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/187903b95e71a12a4a8218dffb23a730.zip",
-    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/38cfac7c3c8d1dde6ac8020c15faf93e.zip",
-    "CatchupETL": "lambda/CatchupETL/versions/79f082e16ff2071e406caf6ff6a8c709.zip",
+    "AIProxy": "lambda/AIProxy/versions/1ed11aee16e0835fbeb9b7ae6efe0558.zip",
+    "APIHandler": "lambda/APIHandler/versions/1a4c87cc987a3e98bcfd9feb370c5bf2.zip",
+    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/32043c58f3152dbf76f7687a79aa8dbe.zip",
+    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/89af7eae3f74a72055eeddc8148b87a1.zip",
+    "CatchupETL": "lambda/CatchupETL/versions/f0bc0918c23c4d46df922ffb5432b0c6.zip",
     "_tag": "latest",
-    "_timestamp": "2025-03-18T11:25:34.153500"
+    "_timestamp": "2025-04-01T12:43:15.185684"
 }


### PR DESCRIPTION
Enable Cloudwatch enhanced monitoring on Brainstore. Gives us 1m resolution for a small cost increase.
Bump lambda and brainstore versions to latest.