### PR TITLE
Expose ETL batch size variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ module "services" {
   brainstore_backfill_new_objects            = var.brainstore_backfill_new_objects
   brainstore_backfill_disable_historical     = var.brainstore_backfill_disable_historical
   brainstore_backfill_disable_nonhistorical  = var.brainstore_backfill_disable_nonhistorical
+  brainstore_etl_batch_size                  = var.brainstore_etl_batch_size
 
   # Service configuration
   braintrust_org_name                 = var.braintrust_org_name

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -27,6 +27,7 @@ resource "aws_lambda_function" "catchup_etl" {
       BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects
       BRAINSTORE_BACKFILL_DISABLE_HISTORICAL     = var.brainstore_backfill_disable_historical
       BRAINSTORE_BACKFILL_DISABLE_NONHISTORICAL  = var.brainstore_backfill_disable_nonhistorical
+      CLICKHOUSE_ETL_BATCH_SIZE                  = var.brainstore_etl_batch_size
       CLICKHOUSE_PG_URL                          = local.clickhouse_pg_url
       CLICKHOUSE_CONNECT_URL                     = local.clickhouse_connect_url
     }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -209,6 +209,12 @@ variable "brainstore_backfill_disable_nonhistorical" {
   default     = false
 }
 
+variable "brainstore_etl_batch_size" {
+  type        = number
+  description = "The batch size for the ETL process"
+  default     = null
+}
+
 variable "lambda_version_tag_override" {
   description = "Optional override for the lambda version tag. If not provided, will use locked versions from VERSIONS.json"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -312,3 +312,9 @@ variable "brainstore_backfill_disable_nonhistorical" {
   description = "Disable non-historical backfill for Brainstore. Don't modify this unless instructed by Braintrust."
   default     = false
 }
+
+variable "brainstore_etl_batch_size" {
+  type        = number
+  description = "The batch size for the ETL process"
+  default     = null
+}


### PR DESCRIPTION
Can now pass `brainstore_etl_batch_size` which corresponds to the env var `CLICKHOUSE_ETL_BATCH_SIZE` (historical name). By default it is null and so the env var won't be passed at all, relying on the service defaults.