### PR TITLE
Fixes for Lambda responses CORS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "database" {
   source                    = "./modules/database"
   deployment_name           = var.deployment_name
   postgres_instance_type    = var.postgres_instance_type
+  multi_az                  = var.postgres_multi_az
   postgres_storage_size     = var.postgres_storage_size
   postgres_max_storage_size = var.postgres_max_storage_size
   postgres_storage_type     = var.postgres_storage_type

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -19,6 +19,7 @@ resource "aws_db_instance" "main" {
   storage_type          = var.postgres_storage_type
   storage_throughput    = var.postgres_storage_throughput
   iops                  = var.postgres_storage_iops
+  multi_az              = var.multi_az
 
   db_name  = "postgres"
   username = local.postgres_username

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -61,3 +61,9 @@ variable "kms_key_arn" {
   type        = string
   default     = null
 }
+
+variable "multi_az" {
+  description = "Specifies if the RDS instance is multi-AZ. Increases cost but provides higher availability. Recommended for production environments."
+  type        = bool
+  default     = false
+}

--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -43,6 +43,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "lambda_responses_bucket" {
     id     = "ExpireObjectsAfterOneDay"
     status = "Enabled"
 
+    filter {
+      prefix = ""
+    }
+
     expiration {
       days = 1
     }

--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -36,6 +36,30 @@ resource "aws_s3_bucket" "lambda_responses_bucket" {
   tags = local.common_tags
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "lambda_responses_bucket" {
+  bucket = aws_s3_bucket.lambda_responses_bucket.id
+
+  rule {
+    id     = "ExpireObjectsAfterOneDay"
+    status = "Enabled"
+
+    expiration {
+      days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "lambda_responses_bucket" {
+  bucket = aws_s3_bucket.lambda_responses_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_responses_bucket" {
   bucket = aws_s3_bucket.lambda_responses_bucket.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,12 @@ variable "postgres_version" {
   default     = "15.7"
 }
 
+variable "postgres_multi_az" {
+  description = "Specifies if the RDS instance is multi-AZ. Increases cost but provides higher availability. Recommended for production environments."
+  type        = bool
+  default     = false
+}
+
 ## Redis
 variable "redis_instance_type" {
   description = "Instance type for the Redis cluster"


### PR DESCRIPTION
When porting from CF we missed the cors and lifecycle rules for the lambda responses bucket.

Other changes:
* Can now specify if the RDS instance is multi_az or not. Production environments will likely want multi-az.