### PR TITLE
Add dump-logs script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ braintrust-sandbox/*
 
 # Ignore IntelliJ IDEA project files
 .idea
+
+scripts/logs*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ To use this module, **copy the [`examples/braintrust-data-plane`](examples/brain
 
 If you're using a brand new AWS account for your Braintrust data plane you will need to run ./scripts/create-service-linked-roles.sh once to ensure IAM service-linked roles are created.
 
+## Useful scripts
+
+### dump-logs.sh
+This script will dump the logs for the given deployment and services to the `logs-<deployment_name>` directory. This is useful for debugging issues with the data plane and sharing with the Braintrust team.
+
+```
+# ./dump-logs.sh <deployment_name> [--minutes N] [--service <svc1,svc2,...|all>]
+
+./dump-logs.sh bt-sandbox
+Fetching logs for the last 60 minutes for APIHandler...
+Fetching logs for the last 60 minutes for brainstore...
+✅ Saved logs for brainstore to logs-bt-sandbox/brainstore.log
+✅ Saved logs for APIHandler to logs-bt-sandbox/APIHandler.log
+```
+
+### create-service-linked-roles.sh
+Required for new AWS accounts to ensure IAM service-linked roles are created.
+```
+./scripts/create-service-linked-roles.sh
+```
 
 ## Customized Deployments
 

--- a/scripts/dump-logs.sh
+++ b/scripts/dump-logs.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Usage:
+#   ./dump_logs.sh <deployment_name> [--minutes N] [--service <svc1,svc2,...|all>]
+
+ALL_SERVICES=("brainstore" "AIProxy" "APIHandler" "CatchupETL" "MigrateDatabaseFunction" "QuarantineWarmupFunction")
+SERVICES="APIHandler,brainstore"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <deployment_name> [--minutes N] [--service <svc1,svc2,...|all>]"
+  echo "  deployment_name"
+  echo "    The value you used for deployment_name in your terraform module"
+  echo "  --minutes N"
+  echo "    The number of minutes to fetch logs for (default: 60)"
+  echo "  --service <svc1,svc2,...|all>"
+  echo "    The services to fetch logs for (default: $SERVICES)"
+  echo "    Valid services are: "
+  for svc in "${ALL_SERVICES[@]}"; do
+    echo "      $svc"
+  done
+  exit 1
+fi
+
+DEPLOYMENT_NAME="$1"
+shift
+MINUTES=60
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --minutes)
+      MINUTES="$2"
+      shift 2
+      ;;
+    --service)
+      SERVICES="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$SERVICES" == "all" ]]; then
+  SELECTED_SERVICES=("${ALL_SERVICES[@]}")
+else
+  IFS=',' read -ra SELECTED_SERVICES <<< "$SERVICES"
+fi
+
+# Timestamps
+NOW=$(date -u +%s)
+START=$((NOW - MINUTES * 60))
+
+mkdir -p "logs-$DEPLOYMENT_NAME"
+
+for svc in "${SELECTED_SERVICES[@]}"; do
+  if [[ "$svc" == "brainstore" ]]; then
+    LOG_GROUP="/braintrust/$DEPLOYMENT_NAME/brainstore"
+    LOG_FILE="logs-$DEPLOYMENT_NAME/brainstore.log"
+  else
+    LOG_GROUP="/braintrust/$DEPLOYMENT_NAME/${DEPLOYMENT_NAME}-$svc"
+    LOG_FILE="logs-$DEPLOYMENT_NAME/$svc.log"
+  fi
+
+  echo "Fetching logs for the last $MINUTES minutes for $svc..."
+  (
+    if aws logs filter-log-events \
+      --log-group-name "$LOG_GROUP" \
+      --start-time $((START * 1000)) \
+      --end-time $((NOW * 1000)) \
+      --query 'events[*].{timestamp:timestamp, message:message}' \
+      --output text > "$LOG_FILE"; then
+      echo "✅ Saved logs for $svc to $LOG_FILE"
+    else
+      echo "❌ Failed to fetch logs for $svc"
+      rm -f "$LOG_FILE"
+    fi
+  ) &
+done
+
+wait
+


### PR DESCRIPTION
Useful for teams that can't directly share logs with us via AWS roles. They can dump logs, inspect them, and then share them.

```
# ./dump-logs.sh <deployment_name> [--minutes N] [--service <svc1,svc2,...|all>]

./dump-logs.sh bt-sandbox
Fetching logs for the last 60 minutes for APIHandler...
Fetching logs for the last 60 minutes for brainstore...
✅ Saved logs for brainstore to logs-bt-sandbox/brainstore.log
✅ Saved logs for APIHandler to logs-bt-sandbox/APIHandler.log
```