### PR TITLE
Set Brainstore as default enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ module "services" {
   clickhouse_secret = var.enable_clickhouse ? module.clickhouse[0].clickhouse_secret : null
 
   brainstore_enabled                         = var.enable_brainstore
+  brainstore_default                         = var.brainstore_default
   brainstore_hostname                        = var.enable_brainstore ? module.brainstore[0].dns_name : null
   brainstore_s3_bucket_name                  = var.enable_brainstore ? module.brainstore[0].s3_bucket : null
   brainstore_port                            = var.enable_brainstore ? module.brainstore[0].port : null

--- a/modules/remote-support/main-bastion.tf
+++ b/modules/remote-support/main-bastion.tf
@@ -9,7 +9,7 @@ resource "aws_ec2_instance_connect_endpoint" "endpoint" {
     Name = "${var.deployment_name}-instance-connect-endpoint"
   }, local.common_tags)
 }
-
+# nosemgrep
 resource "aws_instance" "bastion" {
   count = var.enable_braintrust_support_shell_access ? 1 : 0
 

--- a/modules/remote-support/main-bastion.tf
+++ b/modules/remote-support/main-bastion.tf
@@ -109,7 +109,7 @@ resource "aws_iam_role" "bastion" {
 
   name = "${var.deployment_name}-bastion"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -139,7 +139,7 @@ resource "aws_iam_role_policy" "bastion" {
   name = "bastion-permissions"
   role = aws_iam_role.bastion[0].id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -212,7 +212,7 @@ resource "aws_iam_role_policy" "braintrust_support_ec2_connect" {
   name = "ec2-instance-connect-bastion"
   role = aws_iam_role.braintrust_support[0].id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -62,6 +62,7 @@ resource "aws_lambda_function" "api_handler" {
       FUNCTION_SECRET_KEY = aws_secretsmanager_secret_version.function_tools_secret.secret_string
 
       BRAINSTORE_ENABLED                         = var.brainstore_enabled
+      BRAINSTORE_DEFAULT                         = var.brainstore_default
       BRAINSTORE_URL                             = local.brainstore_url
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
       BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -216,9 +216,13 @@ variable "brainstore_etl_batch_size" {
 }
 
 variable "brainstore_default" {
-  type        = bool
-  description = "Whether to set Brainstore as the default rather than opting in each project. Don't set this if you have a large backfill and are migrating from Clickhouse."
-  default     = true
+  type        = string
+  description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag."
+  default     = "true"
+  validation {
+    condition     = var.brainstore_default == "true" || var.brainstore_default == "false" || var.brainstore_default == "forced"
+    error_message = "brainstore_default must be true, false, or forced."
+  }
 }
 
 variable "lambda_version_tag_override" {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -220,7 +220,7 @@ variable "brainstore_default" {
   description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag."
   default     = "true"
   validation {
-    condition     = var.brainstore_default == "true" || var.brainstore_default == "false" || var.brainstore_default == "forced"
+    condition     = contains(["true", "false", "forced"], var.brainstore_default)
     error_message = "brainstore_default must be true, false, or forced."
   }
 }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -215,6 +215,12 @@ variable "brainstore_etl_batch_size" {
   default     = null
 }
 
+variable "brainstore_default" {
+  type        = bool
+  description = "Whether to set Brainstore as the default rather than opting in each project. Don't set this if you have a large backfill and are migrating from Clickhouse."
+  default     = true
+}
+
 variable "lambda_version_tag_override" {
   description = "Optional override for the lambda version tag. If not provided, will use locked versions from VERSIONS.json"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -264,7 +264,7 @@ variable "brainstore_default" {
   description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag. Don't set this if you have a large backfill ongoing and are migrating from Clickhouse."
   default     = "true"
   validation {
-    condition     = var.brainstore_default == "true" || var.brainstore_default == "false" || var.brainstore_default == "forced"
+    condition     = contains(["true", "false", "forced"], var.brainstore_default)
     error_message = "brainstore_default must be true, false, or forced."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -259,6 +259,12 @@ variable "enable_brainstore" {
   default     = false
 }
 
+variable "brainstore_default" {
+  type        = bool
+  description = "Whether to set Brainstore as the default rather than opting in each project. Don't set this if you have a large backfill and are migrating from Clickhouse."
+  default     = true
+}
+
 variable "brainstore_instance_type" {
   type        = string
   description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."

--- a/variables.tf
+++ b/variables.tf
@@ -260,9 +260,13 @@ variable "enable_brainstore" {
 }
 
 variable "brainstore_default" {
-  type        = bool
-  description = "Whether to set Brainstore as the default rather than opting in each project. Don't set this if you have a large backfill and are migrating from Clickhouse."
-  default     = true
+  type        = string
+  description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag. Don't set this if you have a large backfill ongoing and are migrating from Clickhouse."
+  default     = "true"
+  validation {
+    condition     = var.brainstore_default == "true" || var.brainstore_default == "false" || var.brainstore_default == "forced"
+    error_message = "brainstore_default must be true, false, or forced."
+  }
 }
 
 variable "brainstore_instance_type" {


### PR DESCRIPTION
Users can now pass: `brainstore_default: true|false|forced`

Defaulting this to `true` for everyone using this module from here on. Users will no longer have to opt-in via feature flag manually. Though users can still pass use_brainstore=false in API calls to use Clickhouse. 

Setting it to `forced` will use brainstore no matter what users pass in to the API. No fallback to Clickhouse or Postgres will be allowed.

Setting it to `false` is only needed in cases where the backfill is temporarily not functioning properly. This is only a viable option if there is still a Clickhouse node in parallel with brainstore.