### PR TITLE
Allow setting arbitrary environment variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,7 @@ module "services" {
   custom_domain                       = var.custom_domain
   custom_certificate_arn              = var.custom_certificate_arn
   service_additional_policy_arns      = var.service_additional_policy_arns
+  extra_env_vars                      = var.service_extra_env_vars
 
   # Networking
   service_security_group_ids = [module.main_vpc.default_security_group_id]
@@ -167,6 +168,7 @@ module "brainstore" {
   port                   = var.brainstore_port
   license_key            = var.brainstore_license_key
   version_override       = var.brainstore_version_override
+  extra_env_vars         = var.brainstore_extra_env_vars
 
   database_host       = module.database.postgres_database_address
   database_port       = module.database.postgres_database_port

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -53,6 +53,7 @@ resource "aws_launch_template" "brainstore" {
     brainstore_license_key      = var.license_key
     brainstore_version_override = var.version_override == null ? "" : var.version_override
     brainstore_release_version  = local.brainstore_release_version
+    extra_env_vars              = var.extra_env_vars
   }))
 
   tags = merge({

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -94,6 +94,9 @@ BRAINSTORE_LICENSE_KEY=${brainstore_license_key}
 NO_COLOR=1
 AWS_DEFAULT_REGION=${aws_region}
 AWS_REGION=${aws_region}
+%{ for env_key, env_value in extra_env_vars ~}
+${env_key}=${env_value}
+%{ endfor ~}
 EOF
 
 BRAINSTORE_RELEASE_VERSION=${brainstore_release_version}

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -92,3 +92,9 @@ variable "redis_port" {
   type        = string
   description = "The port of the Redis instance"
 }
+
+variable "extra_env_vars" {
+  type        = map(string)
+  description = "Extra environment variables to set for Brainstore"
+  default     = {}
+}

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "ai_proxy" {
   }
 
   environment {
-    variables = {
+    variables = merge({
       ORG_NAME                                          = var.braintrust_org_name
       PG_URL                                            = local.postgres_url
       REDIS_HOST                                        = var.redis_host
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "ai_proxy" {
       QUARANTINE_PRIVATE_SUBNET_3_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[2] : ""
       QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? var.quarantine_vpc_default_security_group_id : ""
       QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
-    }
+    }, var.extra_env_vars.AIProxy)
   }
 
   vpc_config {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "api_handler" {
   }
 
   environment {
-    variables = {
+    variables = merge({
       ORG_NAME                   = var.braintrust_org_name
       BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
 
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "api_handler" {
 
       CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
       CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url
-    }
+    }, var.extra_env_vars.APIHandler)
   }
 
   vpc_config {

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "catchup_etl" {
   kms_key_arn   = var.kms_key_arn
 
   environment {
-    variables = {
+    variables = merge({
       ORG_NAME                                   = var.braintrust_org_name
       PG_URL                                     = local.postgres_url
       REDIS_HOST                                 = var.redis_host
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "catchup_etl" {
       CLICKHOUSE_ETL_BATCH_SIZE                  = var.brainstore_etl_batch_size
       CLICKHOUSE_PG_URL                          = local.clickhouse_pg_url
       CLICKHOUSE_CONNECT_URL                     = local.clickhouse_connect_url
-    }
+    }, var.extra_env_vars.CatchupETL)
   }
 
   logging_config {

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -19,11 +19,11 @@ resource "aws_lambda_function" "migrate_database" {
     log_group  = "/braintrust/${var.deployment_name}/${local.migrate_database_function_name}"
   }
   environment {
-    variables = {
+    variables = merge({
       BRAINTRUST_RUN_DRAFT_MIGRATIONS = var.run_draft_migrations
       PG_URL                          = local.postgres_url
       CLICKHOUSE_CONNECT_URL          = local.clickhouse_connect_url
-    }
+    }, var.extra_env_vars.MigrateDatabaseFunction)
   }
 
   vpc_config {

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "quarantine_warmup" {
   kms_key_arn   = var.kms_key_arn
 
   environment {
-    variables = {
+    variables = merge({
       ORG_NAME                   = var.braintrust_org_name
       BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
 
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "quarantine_warmup" {
       QUARANTINE_PRIVATE_SUBNET_3_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[2] : ""
       QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? var.quarantine_vpc_default_security_group_id : ""
       QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
-    }
+    }, var.extra_env_vars.QuarantineWarmupFunction)
   }
 
   logging_config {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -221,3 +221,21 @@ variable "lambda_version_tag_override" {
   default     = null
 }
 
+variable "extra_env_vars" {
+  type = object({
+    APIHandler               = map(string)
+    AIProxy                  = map(string)
+    CatchupETL               = map(string)
+    MigrateDatabaseFunction  = map(string)
+    QuarantineWarmupFunction = map(string)
+  })
+  description = "Extra environment variables to set for services"
+  default = {
+    APIHandler               = {}
+    AIProxy                  = {}
+    CatchupETL               = {}
+    MigrateDatabaseFunction  = {}
+    QuarantineWarmupFunction = {}
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -324,3 +324,27 @@ variable "brainstore_etl_batch_size" {
   description = "The batch size for the ETL process"
   default     = null
 }
+
+variable "brainstore_extra_env_vars" {
+  type        = map(string)
+  description = "Extra environment variables to set for Brainstore"
+  default     = {}
+}
+
+variable "service_extra_env_vars" {
+  type = object({
+    APIHandler               = map(string)
+    AIProxy                  = map(string)
+    CatchupETL               = map(string)
+    MigrateDatabaseFunction  = map(string)
+    QuarantineWarmupFunction = map(string)
+  })
+  description = "Extra environment variables to set for services"
+  default = {
+    APIHandler               = {}
+    AIProxy                  = {}
+    CatchupETL               = {}
+    MigrateDatabaseFunction  = {}
+    QuarantineWarmupFunction = {}
+  }
+}


### PR DESCRIPTION
Rather than exposing individual vars for every environment variable we want to set we can now pass a map or object that gets merged with existing env vars.

Notes: 
* You must pass all defined object keys to `service_extra_env_vars` even if you don't want to add any env vars to other services. Leave them as empty maps if you don't want to add anything.
* Values in extra_env_vars will override any existing env vars that have the same key

```
module "braintrust-data-plane" {
  ...other settings...

  brainstore_extra_env_vars = {
    BRAINSTORE_CUSTOM_VAR = "something"
  }

  service_extra_env_vars = {
    APIHandler = {
        BRAINTRUST_CUSTOM_VAR = "value"
        BRAINTRUST_ANOTHER_VAR = "othervalue"
    }
    AIProxy = {}
    CatchupETL = {}
    MigrateDatabaseFunction = {}
    QuarantineWarmupFunction = {}
  }
}
```