### PR TITLE
Support for Lambda Reserved Concurrency

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -13,6 +13,18 @@ module "braintrust-data-plane" {
   deployment_name     = local.deployment_name
   braintrust_org_name = "" # Add your organization name from the Braintrust UI here
 
+  ### Service Configuration
+  # The maximum number of concurrent executions to reserve and constrain Braintrust lambdas to.
+  # If you run Braintrust in a shared account you should set these to a reasonable limit to avoid
+  # impacting other non-Braintrust Lambdas. AWS has a global shared limit of 1000 concurrent executions per account.
+  # By default these are unlimited which is ideal for dedicated AWS account.
+  # Recommended 100 to 1000 for production in a shared account.
+  # api_handler_reserved_concurrent_executions = 100
+  # ai_proxy_reserved_concurrent_executions    = 100
+
+  # The number API Handler instances to provision and keep alive. This reduces cold start times and improves latency, with some increase in cost.
+  # api_handler_provisioned_concurrency   = 0
+
   ### Postgres configuration
   # The default is small for development and testing purposes. Recommended db.r8g.2xlarge for production.
   # postgres_instance_type                = "db.t4g.xlarge"
@@ -68,9 +80,6 @@ module "braintrust-data-plane" {
   # quarantine_vpc_cidr                   = "10.175.8.0/21"
 
   ### Advanced configuration
-  # The number API Handler instances to provision and keep alive. This reduces cold start times and improves latency, with some increase in cost.
-  # api_handler_provisioned_concurrency   = 0
-
   # List of origins to whitelist for CORS
   # whitelisted_origins                   = []
 

--- a/main.tf
+++ b/main.tf
@@ -113,15 +113,17 @@ module "services" {
   brainstore_etl_batch_size                  = var.brainstore_etl_batch_size
 
   # Service configuration
-  braintrust_org_name                 = var.braintrust_org_name
-  api_handler_provisioned_concurrency = var.api_handler_provisioned_concurrency
-  whitelisted_origins                 = var.whitelisted_origins
-  outbound_rate_limit_window_minutes  = var.outbound_rate_limit_window_minutes
-  outbound_rate_limit_max_requests    = var.outbound_rate_limit_max_requests
-  custom_domain                       = var.custom_domain
-  custom_certificate_arn              = var.custom_certificate_arn
-  service_additional_policy_arns      = var.service_additional_policy_arns
-  extra_env_vars                      = var.service_extra_env_vars
+  braintrust_org_name                        = var.braintrust_org_name
+  api_handler_provisioned_concurrency        = var.api_handler_provisioned_concurrency
+  api_handler_reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
+  ai_proxy_reserved_concurrent_executions    = var.ai_proxy_reserved_concurrent_executions
+  whitelisted_origins                        = var.whitelisted_origins
+  outbound_rate_limit_window_minutes         = var.outbound_rate_limit_window_minutes
+  outbound_rate_limit_max_requests           = var.outbound_rate_limit_max_requests
+  custom_domain                              = var.custom_domain
+  custom_certificate_arn                     = var.custom_certificate_arn
+  service_additional_policy_arns             = var.service_additional_policy_arns
+  extra_env_vars                             = var.service_extra_env_vars
 
   # Networking
   service_security_group_ids = [module.main_vpc.default_security_group_id]

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -2,16 +2,17 @@ locals {
   ai_proxy_function_name = "${var.deployment_name}-AIProxy"
 }
 resource "aws_lambda_function" "ai_proxy" {
-  function_name = local.ai_proxy_function_name
-  s3_bucket     = local.lambda_s3_bucket
-  s3_key        = local.lambda_versions["AIProxy"]
-  role          = aws_iam_role.api_handler_role.arn
-  handler       = "index.handler"
-  runtime       = "nodejs20.x"
-  memory_size   = 1024
-  timeout       = 900
-  publish       = true
-  kms_key_arn   = var.kms_key_arn
+  function_name                  = local.ai_proxy_function_name
+  s3_bucket                      = local.lambda_s3_bucket
+  s3_key                         = local.lambda_versions["AIProxy"]
+  role                           = aws_iam_role.api_handler_role.arn
+  handler                        = "index.handler"
+  runtime                        = "nodejs20.x"
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.ai_proxy_reserved_concurrent_executions
+  timeout                        = 900
+  publish                        = true
+  kms_key_arn                    = var.kms_key_arn
 
   logging_config {
     log_format = "Text"

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -5,17 +5,18 @@ resource "aws_lambda_function" "api_handler" {
   # Require the DB migrations to be run before the API handler is deployed
   depends_on = [aws_lambda_invocation.invoke_database_migration]
 
-  function_name = local.api_handler_function_name
-  s3_bucket     = local.lambda_s3_bucket
-  s3_key        = local.lambda_versions["APIHandler"]
-  role          = aws_iam_role.api_handler_role.arn
-  handler       = "index.handler"
-  runtime       = "nodejs20.x"
-  memory_size   = 10240 # Max that lambda supports
-  timeout       = 600
-  publish       = true
-  architectures = ["arm64"]
-  kms_key_arn   = var.kms_key_arn
+  function_name                  = local.api_handler_function_name
+  s3_bucket                      = local.lambda_s3_bucket
+  s3_key                         = local.lambda_versions["APIHandler"]
+  role                           = aws_iam_role.api_handler_role.arn
+  handler                        = "index.handler"
+  runtime                        = "nodejs20.x"
+  memory_size                    = 10240 # Max that lambda supports
+  reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
+  timeout                        = 600
+  publish                        = true
+  architectures                  = ["arm64"]
+  kms_key_arn                    = var.kms_key_arn
 
   logging_config {
     log_format = "Text"

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -151,7 +151,7 @@ variable "api_handler_provisioned_concurrency" {
 
 variable "api_handler_reserved_concurrent_executions" {
   type        = number
-  description = "The number of concurrent executions to reserve for the API Handler. Setting this will prevent the API Handler from throttling other lambdas in your account.Note this will take away from your global concurrency limit in your AWS account."
+  description = "The number of concurrent executions to reserve for the API Handler. Setting this will prevent the API Handler from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
 }
 

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -149,6 +149,18 @@ variable "api_handler_provisioned_concurrency" {
   default     = 1
 }
 
+variable "api_handler_reserved_concurrent_executions" {
+  type        = number
+  description = "The number of concurrent executions to reserve for the API Handler. Setting this will prevent the API Handler from throttling other lambdas in your account.Note this will take away from your global concurrency limit in your AWS account."
+  default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
+variable "ai_proxy_reserved_concurrent_executions" {
+  type        = number
+  description = "The number of concurrent executions to reserve for the AI Proxy. Setting this will prevent the AI Proxy from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
+  default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
 variable "run_draft_migrations" {
   type        = bool
   description = "Enable draft migrations for database schema updates"

--- a/variables.tf
+++ b/variables.tf
@@ -185,6 +185,18 @@ variable "api_handler_provisioned_concurrency" {
   default     = 0
 }
 
+variable "api_handler_reserved_concurrent_executions" {
+  description = "The number of concurrent executions to reserve for the API Handler. Setting this will prevent the API Handler from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
+  type        = number
+  default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
+variable "ai_proxy_reserved_concurrent_executions" {
+  description = "The number of concurrent executions to reserve for the AI Proxy. Setting this will prevent the AI Proxy from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
+  type        = number
+  default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
 variable "whitelisted_origins" {
   description = "List of origins to whitelist for CORS"
   type        = list(string)


### PR DESCRIPTION
The API Handler and AI Proxy can now be assigned reserved concurrency with these two vars:
* `api_handler_reserved_concurrent_executions`
* `ai_proxy_reserved_concurrent_executions`

AWS has an account-wide regional limit on the maximum concurrency for **all** Lambdas, and not just Braintrust's lambdas. Typically this defaults to 1000. 

By default, these reserved concurrency params are set to unlimited (`-1`). That means a large sudden spike in traffic to the API Handler can cause other Lambdas in your account to get throttled and fail to execute.

Setting these values will allow you to reserve and constraint the maximum concurrency for the Braintrust lambdas. Note that setting these values takes away from your account-wide AWS limit and holds it in reserve for the Lambda. In other words, if you set both of these to 100, then you will only have 800 remaining concurrency for your other Lambdas in your account.

If you host Braintrust in a shared AWS account **it is highly recommended you set these**. For small deployments, 10 is fine. For larger deployments 100-1000 is likely needed. You will need to inspect Cloudwatch graphs to confirm historical usage.
