### PR TITLE
Expose variable to disable auto minor version upgrade for Postgres

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -46,12 +46,18 @@ module "braintrust-data-plane" {
   # PostgreSQL engine version for the RDS instance.
   # postgres_version                      = "15.7"
 
+  # Automatic upgrades of PostgreSQL minor engine version.
+  # If true, AWS will automatically upgrade the minor version of the PostgreSQL engine for you.
+  # Note: Don't include the minor version in your postgres_version if you want to use this.
+  # If false, you will need to manually upgrade the minor version of the PostgreSQL engine.
+  # postgres_auto_minor_version_upgrade   = false
+
   # Multi-AZ RDS instance. Enabling increases cost but provides higher availability. Recommended for production environments.
   # postgres_multi_az                     = true
 
   ### Brainstore configuration
   # Enable Brainstore for faster analytics
-  enable_brainstore = false
+  enable_brainstore = true
 
   # The license key for the Brainstore instance. You can get this from the Braintrust UI in Settings > API URL.
   brainstore_license_key = var.brainstore_license_key

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ module "database" {
 
   postgres_storage_iops       = var.postgres_storage_iops
   postgres_storage_throughput = var.postgres_storage_throughput
-  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  auto_minor_version_upgrade  = var.postgres_auto_minor_version_upgrade
 
   kms_key_arn = local.kms_key_arn
 }

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ module "database" {
 
   postgres_storage_iops       = var.postgres_storage_iops
   postgres_storage_throughput = var.postgres_storage_throughput
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
 
   kms_key_arn = local.kms_key_arn
 }

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -6,7 +6,7 @@ variable "deployment_name" {
 variable "instance_type" {
   type        = string
   description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
-  default     = "c7gd.xlarge"
+  default     = "c7gd.8xlarge"
 
   validation {
     condition     = can(regex("[a-z0-9]*g[a-z0-9]*\\.", var.instance_type))

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -42,6 +42,8 @@ resource "aws_db_instance" "main" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
 
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+
   kms_key_id = var.kms_key_arn
 
   tags = local.common_tags

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,3 +67,9 @@ variable "multi_az" {
   type        = bool
   default     = false
 }
+
+variable "auto_minor_version_upgrade" {
+  description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. When true you will have to set your postgres_version to only the major number or you will see drift. e.g. '15' instead of '15.7'"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -164,7 +164,7 @@ variable "postgres_multi_az" {
   default     = false
 }
 
-variable "auto_minor_version_upgrade" {
+variable "postgres_auto_minor_version_upgrade" {
   description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. When true you will have to set your postgres_version to only the major number or you will see drift. e.g. '15' instead of '15.7'"
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,12 @@ variable "postgres_multi_az" {
   default     = false
 }
 
+variable "auto_minor_version_upgrade" {
+  description = "Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. When true you will have to set your postgres_version to only the major number or you will see drift. e.g. '15' instead of '15.7'"
+  type        = bool
+  default     = true
+}
+
 ## Redis
 variable "redis_instance_type" {
   description = "Instance type for the Redis cluster"


### PR DESCRIPTION
If `postgres_ auto_minor_version_upgrade` is true, then AWS will automatically upgrade the minor version of postgres (Default stays as `true` to maintain backward compatibility). To avoid drift the terraform docs seem to recommend setting `engine_version` (which we expose as `postgres_version`) to only include the major version. e.g. "15" instead of "15.7".

Setting it to false means users will have to manually bump the postgres_version var. Some teams prefer this.

Also, bumping the default size of brainstore nodes to production sizing. Too many cases of users leaving it default and then having production scale issues.