### PR TITLE
Bump services to 1.0.13. Lock provider versions

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.99.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.5.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:dl73+8wzQR++HFGoJgDqY3mj3pm14HUuH/CekVyOj5s=",
+    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
+    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
+    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
+    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
+    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
+    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
+    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
+    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
+    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
+    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = ">= 3.6.3"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/modules/brainstore/VERSIONS.json
+++ b/modules/brainstore/VERSIONS.json
@@ -1,5 +1,5 @@
 {
-    "brainstore": "8300af1e4f7e66790504bbfc2e524ebe65eef7f3",
-    "_tag": "v1.0.9",
-    "_timestamp": "2025-05-23T15:21:45.330895"
+    "brainstore": "9feeb76925b4a5682e96bea9cb5b667959f97c4c",
+    "_tag": "v1.0.13",
+    "_timestamp": "2025-06-03T11:36:12.815066"
 }

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,9 +1,9 @@
 {
-    "AIProxy": "lambda/AIProxy/versions/96130cd4316f07d470a49fe316b21a58.zip",
-    "APIHandler": "lambda/APIHandler/versions/7436567ec72e8f2e529c8dd32240fc45.zip",
-    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/3729cb25d49b67eeba6a3a9bb1e4a621.zip",
-    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/afd5e22864d0bfe0abf1490761ee8ce5.zip",
-    "CatchupETL": "lambda/CatchupETL/versions/f00a9d6a6f6a4f5fe30ff10c0e8854c9.zip",
-    "_tag": "v1.0.9",
-    "_timestamp": "2025-05-23T15:21:45.330895"
+    "AIProxy": "lambda/AIProxy/versions/39aa5dafef41a5d8fae89e63d0ef2e10.zip",
+    "APIHandler": "lambda/APIHandler/versions/b8e1799f1aa744ba87c34110ec49e7c2.zip",
+    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/d0af87d4d4caa7d36605e9c5276b7347.zip",
+    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/f3e73ec9719d89bd5d6b9c8b4aedc9c8.zip",
+    "CatchupETL": "lambda/CatchupETL/versions/87e229a75e03d5f27475c9f336a8297b.zip",
+    "_tag": "v1.0.13",
+    "_timestamp": "2025-06-03T11:36:12.815066"
 }


### PR DESCRIPTION
Including the lock file prevents differences in plan/apply behavior in different customer environments. The downside is we have to regularly upgrade this and commit it.