### PR TITLE
Deletion protection + Docker log rotation

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -30,7 +30,9 @@ module "braintrust-data-plane" {
   # postgres_instance_type                = "db.t4g.xlarge"
 
   # Storage size (in GB) for the RDS instance. Recommended 1000GB for production.
-  # postgres_storage_size                 = 100
+  # postgres_storage_size                 = 1000
+  # Maximum storage size (in GB) to allow the RDS instance to auto-scale to.
+  # postgres_max_storage_size             = 4000
 
   # Storage type for the RDS instance. Recommended io2 for large production deployments.
   # postgres_storage_type                 = "gp3"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -64,9 +64,9 @@ module "braintrust-data-plane" {
   # The license key for the Brainstore instance. You can get this from the Braintrust UI in Settings > API URL.
   brainstore_license_key = var.brainstore_license_key
 
-  # The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data.
-  # The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge.
-  # brainstore_instance_type             = "c7gd.xlarge"
+  # The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data.
+  # Recommended for production deployments is c7gd.8xlarge.
+  # brainstore_instance_type             = "c7gd.8xlarge"
 
   # The number of Brainstore instances to provision
   # brainstore_instance_count            = 1

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -3,6 +3,7 @@ locals {
   common_tags = {
     BraintrustDeploymentName = var.deployment_name
   }
+  architecture = data.aws_ec2_instance_type.brainstore.supported_architectures[0]
 }
 
 resource "aws_launch_template" "brainstore" {
@@ -183,7 +184,7 @@ data "aws_ami" "ubuntu_24_04" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-arm64-server-*"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-*-server-*"]
   }
   filter {
     name   = "virtualization-type"
@@ -191,8 +192,12 @@ data "aws_ami" "ubuntu_24_04" {
   }
   filter {
     name   = "architecture"
-    values = ["arm64"]
+    values = [local.architecture]
   }
+}
+
+data "aws_ec2_instance_type" "brainstore" {
+  instance_type = var.instance_type
 }
 
 data "aws_region" "current" {}

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -37,6 +37,17 @@ EOF
 export AWS_DEFAULT_REGION=${aws_region}
 
 sudo snap install aws-cli --classic
+# Set up docker log rotation
+mkdir -p /etc/docker
+cat <<EOF > /etc/docker/daemon.json
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m",
+    "max-file": "3"
+  }
+}
+EOF
 apt-get update
 apt-get install -y docker.io jq earlyoom dstat
 systemctl start docker

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -5,13 +5,8 @@ variable "deployment_name" {
 
 variable "instance_type" {
   type        = string
-  description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
+  description = "The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
   default     = "c7gd.8xlarge"
-
-  validation {
-    condition     = can(regex("[a-z0-9]*g[a-z0-9]*\\.", var.instance_type))
-    error_message = "Must be a Graviton instance type."
-  }
 }
 
 variable "license_key" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -43,6 +43,7 @@ resource "aws_db_instance" "main" {
   performance_insights_retention_period = 7
 
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  deletion_protection        = var.deletion_protection
 
   kms_key_id = var.kms_key_arn
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -73,3 +73,9 @@ variable "auto_minor_version_upgrade" {
   type        = bool
   default     = true
 }
+
+variable "deletion_protection" {
+  description = "Indicates that the DB instance should be protected against deletion. The database can't be deleted when this value is set to true."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -274,7 +274,7 @@ variable "clickhouse_instance_type" {
 variable "enable_brainstore" {
   type        = bool
   description = "Enable Brainstore for faster analytics"
-  default     = false
+  default     = true
 }
 
 variable "brainstore_default" {

--- a/variables.tf
+++ b/variables.tf
@@ -289,8 +289,8 @@ variable "brainstore_default" {
 
 variable "brainstore_instance_type" {
   type        = string
-  description = "The instance type to use for the Brainstore. Must be a Graviton instance type. Preferably with 16GB of memory and a local SSD for cache data. The default value is for tiny deployments. Recommended for production deployments is c7gd.8xlarge."
-  default     = "c7gd.xlarge"
+  description = "The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
+  default     = "c8gd.8xlarge"
 }
 
 variable "brainstore_instance_count" {


### PR DESCRIPTION
RDS:
* RDS now has deletion protection enabled. 
* RDS max storage size is now included in the example terraform

Brainstore:
* Graviton is no longer forced for brainstore
* Brainstore default instance type is now prod sized
* Brainstore is now created by default so users don't have to specify it in their module declaration
* Docker logs now rotate at 100m