### PR TITLE
Add cors for attachments. Set default domains.

### DIFF
--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -1,3 +1,11 @@
+locals {
+  default_origins = [
+    "https://braintrust.dev",
+    "https://*.braintrust.dev",
+    "https://*.preview.braintrust.dev"
+  ]
+}
+
 resource "aws_s3_bucket" "code_bundle_bucket" {
   # S3 bucket names are globally unique so we have to use a prefix and let terraform
   # generate a random suffix to ensure uniqueness
@@ -20,6 +28,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "code_bundle_bucke
       kms_master_key_id = var.kms_key_arn
     }
     bucket_key_enabled = var.kms_key_arn != null
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "code_bundle_bucket" {
+  bucket = aws_s3_bucket.code_bundle_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = local.default_origins
+    max_age_seconds = 3600
   }
 }
 
@@ -59,7 +78,7 @@ resource "aws_s3_bucket_cors_configuration" "lambda_responses_bucket" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "HEAD"]
-    allowed_origins = ["*"]
+    allowed_origins = local.default_origins
     max_age_seconds = 3600
   }
 }


### PR DESCRIPTION
Add missing CORS config for attachments (which are stored in the code-bundles bucket).
Restrict to braintrust domains.