### PR TITLE
Use dedicated brainstore writer nodes

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -58,23 +58,18 @@ module "braintrust-data-plane" {
   # postgres_multi_az                     = true
 
   ### Brainstore configuration
-  # Enable Brainstore for faster analytics
-  enable_brainstore = true
-
   # The license key for the Brainstore instance. You can get this from the Braintrust UI in Settings > API URL.
   brainstore_license_key = var.brainstore_license_key
 
-  # The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data.
-  # If you're using dedicated writer nodes, you can run a smaller instance type for the reader nodes.
-  # Recommended for production deployments is c8gd.8xlarge.
-  # brainstore_instance_type             = "c8gd.8xlarge"
+  # The number of Brainstore reader instances to provision
+  # Recommended Graviton instance type with 16GB of memory
+  brainstore_instance_count = 2
+  brainstore_instance_type  = "c8gd.2xlarge"
 
-  # The number of Brainstore instances to provision
-  # brainstore_instance_count            = 1
-
-  # Optional: The number of dedicated Brainstore writer nodes to create
-  # brainstore_writer_instance_count      = 1
-  # brainstore_writer_instance_type       = "c8gd.8xlarge"
+  # The number of dedicated Brainstore writer nodes to create
+  # Recommended Graviton instance type with 32GB of memory
+  brainstore_writer_instance_count = 1
+  brainstore_writer_instance_type  = "c8gd.8xlarge"
 
   ### Redis configuration
   # Default is acceptable for small production deployments. Recommended cache.m7g.large for larger deployments.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -27,7 +27,7 @@ module "braintrust-data-plane" {
 
   ### Postgres configuration
   # The default is small for development and testing purposes. Recommended db.r8g.2xlarge for production.
-  # postgres_instance_type                = "db.t4g.xlarge"
+  # postgres_instance_type                = "db.r8g.2xlarge"
 
   # Storage size (in GB) for the RDS instance. Recommended 1000GB for production.
   # postgres_storage_size                 = 1000
@@ -64,7 +64,7 @@ module "braintrust-data-plane" {
   # The number of Brainstore reader instances to provision
   # Recommended Graviton instance type with 16GB of memory
   brainstore_instance_count = 2
-  brainstore_instance_type  = "c8gd.2xlarge"
+  brainstore_instance_type  = "c8gd.4xlarge"
 
   # The number of dedicated Brainstore writer nodes to create
   # Recommended Graviton instance type with 32GB of memory

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -103,4 +103,10 @@ module "braintrust-data-plane" {
   # The time frame in minutes over which rate per-user rate limits are accumulated
   # outbound_rate_limit_window_minutes    = 1
 
+  ## Braintrust Support
+  # Enable sharing of Cloudwatch logs with Braintrust staff
+  # enable_braintrust_support_logs_access = true
+
+  # Enable Bastion SSH access for Braintrust staff. This will create a bastion host and a security group that allows EC2 instance connect access from the Braintrust IAM Role.
+  # enable_braintrust_support_shell_access = true
 }

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -65,12 +65,16 @@ module "braintrust-data-plane" {
   brainstore_license_key = var.brainstore_license_key
 
   # The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data.
-  # Recommended for production deployments is c7gd.8xlarge.
-  # brainstore_instance_type             = "c7gd.8xlarge"
+  # If you're using dedicated writer nodes, you can run a smaller instance type for the reader nodes.
+  # Recommended for production deployments is c8gd.8xlarge.
+  # brainstore_instance_type             = "c8gd.8xlarge"
 
   # The number of Brainstore instances to provision
   # brainstore_instance_count            = 1
 
+  # Optional: The number of dedicated Brainstore writer nodes to create
+  # brainstore_writer_instance_count      = 1
+  # brainstore_writer_instance_type       = "c8gd.8xlarge"
 
   ### Redis configuration
   # Default is acceptable for small production deployments. Recommended cache.m7g.large for larger deployments.

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ module "services" {
   brainstore_enabled                         = var.enable_brainstore
   brainstore_default                         = var.brainstore_default
   brainstore_hostname                        = var.enable_brainstore ? module.brainstore[0].dns_name : null
+  brainstore_writer_hostname                 = var.enable_brainstore && var.brainstore_writer_instance_count > 0 ? module.brainstore[0].writer_dns_name : null
   brainstore_s3_bucket_name                  = var.enable_brainstore ? module.brainstore[0].s3_bucket : null
   brainstore_port                            = var.enable_brainstore ? module.brainstore[0].port : null
   brainstore_enable_historical_full_backfill = var.brainstore_enable_historical_full_backfill
@@ -165,20 +166,25 @@ module "brainstore" {
   source = "./modules/brainstore"
   count  = var.enable_brainstore ? 1 : 0
 
-  deployment_name        = var.deployment_name
-  instance_count         = var.brainstore_instance_count
-  instance_type          = var.brainstore_instance_type
-  instance_key_pair_name = var.brainstore_instance_key_pair_name
-  port                   = var.brainstore_port
-  license_key            = var.brainstore_license_key
-  version_override       = var.brainstore_version_override
-  extra_env_vars         = var.brainstore_extra_env_vars
-
-  database_host       = module.database.postgres_database_address
-  database_port       = module.database.postgres_database_port
-  database_secret_arn = module.database.postgres_database_secret_arn
-  redis_host          = module.redis.redis_endpoint
-  redis_port          = module.redis.redis_port
+  deployment_name                          = var.deployment_name
+  instance_count                           = var.brainstore_instance_count
+  instance_type                            = var.brainstore_instance_type
+  instance_key_pair_name                   = var.brainstore_instance_key_pair_name
+  port                                     = var.brainstore_port
+  license_key                              = var.brainstore_license_key
+  version_override                         = var.brainstore_version_override
+  extra_env_vars                           = var.brainstore_extra_env_vars
+  writer_instance_count                    = var.brainstore_writer_instance_count
+  writer_instance_type                     = var.brainstore_writer_instance_type
+  brainstore_disable_optimization_worker   = var.brainstore_disable_optimization_worker
+  brainstore_vacuum_object_all             = var.brainstore_vacuum_object_all
+  brainstore_enable_index_validation       = var.brainstore_enable_index_validation
+  brainstore_index_validation_only_deletes = var.brainstore_index_validation_only_deletes
+  database_host                            = module.database.postgres_database_address
+  database_port                            = module.database.postgres_database_port
+  database_secret_arn                      = module.database.postgres_database_secret_arn
+  redis_host                               = module.redis.redis_endpoint
+  redis_port                               = module.redis.redis_port
 
   vpc_id            = module.main_vpc.vpc_id
   security_group_id = module.main_vpc.default_security_group_id

--- a/modules/brainstore/main-writer.tf
+++ b/modules/brainstore/main-writer.tf
@@ -1,0 +1,179 @@
+
+resource "aws_launch_template" "brainstore_writer" {
+  count                  = local.has_writer_nodes ? 1 : 0
+  name                   = "${var.deployment_name}-brainstore-writer"
+  image_id               = data.aws_ami.ubuntu_24_04.id
+  instance_type          = var.writer_instance_type
+  key_name               = var.instance_key_pair_name
+  update_default_version = true
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.brainstore.arn
+  }
+
+  vpc_security_group_ids = [var.security_group_id]
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size           = 200
+      volume_type           = "gp3"
+      encrypted             = true
+      kms_key_id            = var.kms_key_arn
+      delete_on_termination = true
+    }
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+    instance_metadata_tags      = "enabled"
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
+    aws_region                               = data.aws_region.current.name
+    deployment_name                          = var.deployment_name
+    database_secret_arn                      = var.database_secret_arn
+    database_host                            = var.database_host
+    database_port                            = var.database_port
+    redis_host                               = var.redis_host
+    redis_port                               = var.redis_port
+    brainstore_port                          = var.port
+    brainstore_s3_bucket                     = aws_s3_bucket.brainstore.id
+    brainstore_license_key                   = var.license_key
+    brainstore_version_override              = var.version_override == null ? "" : var.version_override
+    brainstore_release_version               = local.brainstore_release_version
+    brainstore_disable_optimization_worker   = var.brainstore_disable_optimization_worker
+    brainstore_vacuum_object_all             = var.brainstore_vacuum_object_all
+    brainstore_enable_index_validation       = var.brainstore_enable_index_validation
+    brainstore_index_validation_only_deletes = var.brainstore_index_validation_only_deletes
+    is_dedicated_writer_node                 = "true"
+    extra_env_vars                           = var.extra_env_vars
+  }))
+
+  tags = merge({
+    Name = "${var.deployment_name}-brainstore-writer"
+  }, local.common_tags)
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge({
+      Name           = "${var.deployment_name}-brainstore-writer"
+      BrainstoreRole = "Writer"
+    }, local.common_tags)
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge({
+      Name           = "${var.deployment_name}-brainstore-writer"
+      BrainstoreRole = "Writer"
+    }, local.common_tags)
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = merge({
+      Name           = "${var.deployment_name}-brainstore-writer"
+      BrainstoreRole = "Writer"
+    }, local.common_tags)
+  }
+}
+
+resource "aws_lb" "brainstore_writer" {
+  count              = local.has_writer_nodes ? 1 : 0
+  name               = "${var.deployment_name}-bstr-w"
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = var.private_subnet_ids
+  security_groups    = [var.security_group_id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_lb_target_group" "brainstore_writer" {
+  count       = local.has_writer_nodes ? 1 : 0
+  name        = "${var.deployment_name}-bstr-w"
+  port        = var.port
+  protocol    = "TCP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    protocol            = "TCP"
+    port                = var.port
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 10
+    interval            = 10
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_lb_listener" "brainstore_writer" {
+  count             = local.has_writer_nodes ? 1 : 0
+  load_balancer_arn = aws_lb.brainstore_writer[0].arn
+  port              = var.port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.brainstore_writer[0].arn
+  }
+  tags = local.common_tags
+}
+
+resource "aws_autoscaling_group" "brainstore_writer" {
+  count                     = local.has_writer_nodes ? 1 : 0
+  name_prefix               = "${var.deployment_name}-brainstore-writer"
+  min_size                  = var.writer_instance_count
+  max_size                  = var.writer_instance_count * 2
+  desired_capacity          = var.writer_instance_count
+  vpc_zone_identifier       = var.private_subnet_ids
+  health_check_type         = "EBS,ELB"
+  health_check_grace_period = 60
+  target_group_arns         = [aws_lb_target_group.brainstore_writer[0].arn]
+  wait_for_elb_capacity     = var.writer_instance_count
+  launch_template {
+    id      = aws_launch_template.brainstore_writer[0].id
+    version = aws_launch_template.brainstore_writer[0].latest_version
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 100
+      max_healthy_percentage = 200
+    }
+    triggers = ["tag"]
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.deployment_name}-brainstore-writer"
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = local.common_tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}

--- a/modules/brainstore/outputs.tf
+++ b/modules/brainstore/outputs.tf
@@ -8,6 +8,11 @@ output "dns_name" {
   value       = aws_lb.brainstore.dns_name
 }
 
+output "writer_dns_name" {
+  description = "The DNS name of the Brainstore writer NLB, if enabled"
+  value       = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
+}
+
 output "port" {
   description = "The port used by Brainstore"
   value       = var.port

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -102,6 +102,10 @@ BRAINSTORE_METADATA_URI=postgres://$DB_USERNAME:$DB_PASSWORD@${database_host}:${
 BRAINSTORE_WAL_URI=postgres://$DB_USERNAME:$DB_PASSWORD@${database_host}:${database_port}/postgres
 BRAINSTORE_CACHE_DIR=/mnt/tmp/brainstore
 BRAINSTORE_LICENSE_KEY=${brainstore_license_key}
+BRAINSTORE_DISABLE_OPTIMIZATION_WORKER=${brainstore_disable_optimization_worker}
+BRAINSTORE_VACUUM_OBJECT_ALL=${brainstore_vacuum_object_all}
+BRAINSTORE_INDEX_WRITER_VALIDATE=${brainstore_enable_index_validation}
+BRAINSTORE_INDEX_WRITER_VALIDATE_ONLY_DELETES=${brainstore_index_validation_only_deletes}
 NO_COLOR=1
 AWS_DEFAULT_REGION=${aws_region}
 AWS_REGION=${aws_region}
@@ -109,6 +113,11 @@ AWS_REGION=${aws_region}
 ${env_key}=${env_value}
 %{ endfor ~}
 EOF
+
+if [ "${is_dedicated_writer_node}" = "true" ]; then
+  # Until we are comfortable with stability
+  echo '0 * * * * root /usr/bin/docker restart brainstore > /var/log/brainstore-restart.log 2>&1' > /etc/cron.d/restart-brainstore
+fi
 
 BRAINSTORE_RELEASE_VERSION=${brainstore_release_version}
 BRAINSTORE_VERSION_OVERRIDE=${brainstore_version_override}

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -6,7 +6,7 @@ variable "deployment_name" {
 variable "instance_type" {
   type        = string
   description = "The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
-  default     = "c7gd.8xlarge"
+  default     = "c8gd.8xlarge"
 }
 
 variable "license_key" {
@@ -92,4 +92,40 @@ variable "extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to set for Brainstore"
   default     = {}
+}
+
+variable "writer_instance_count" {
+  type        = number
+  description = "The number of dedicated writer nodes to create"
+  default     = 0
+}
+
+variable "writer_instance_type" {
+  type        = string
+  description = "The instance type to use for the Brainstore writer nodes"
+  default     = "c8gd.8xlarge"
+}
+
+variable "brainstore_disable_optimization_worker" {
+  type        = bool
+  description = "Whether to disable the optimization worker in Brainstore"
+  default     = true
+}
+
+variable "brainstore_vacuum_object_all" {
+  type        = bool
+  description = "Whether to vacuum all objects in Brainstore"
+  default     = false
+}
+
+variable "brainstore_enable_index_validation" {
+  type        = bool
+  description = "Enable index validation for Brainstore"
+  default     = false
+}
+
+variable "brainstore_index_validation_only_deletes" {
+  type        = bool
+  description = "Scope index validation to only deletes in Brainstore. Only applies if brainstore_enable_index_validation is true"
+  default     = true
 }

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -109,7 +109,7 @@ variable "writer_instance_type" {
 variable "brainstore_disable_optimization_worker" {
   type        = bool
   description = "Whether to disable the optimization worker in Brainstore"
-  default     = true
+  default     = false
 }
 
 variable "brainstore_vacuum_object_all" {

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -5,8 +5,8 @@ variable "deployment_name" {
 
 variable "instance_type" {
   type        = string
-  description = "The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
-  default     = "c8gd.8xlarge"
+  description = "The instance type to use for the Brainstore reader nodes.  Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
+  default     = "c8gd.2xlarge"
 }
 
 variable "license_key" {
@@ -20,8 +20,8 @@ variable "license_key" {
 
 variable "instance_count" {
   type        = number
-  description = "The number of instances to create"
-  default     = 1
+  description = "The number of reader instances to create"
+  default     = 2
 }
 
 variable "port" {
@@ -97,7 +97,7 @@ variable "extra_env_vars" {
 variable "writer_instance_count" {
   type        = number
   description = "The number of dedicated writer nodes to create"
-  default     = 0
+  default     = 1
 }
 
 variable "writer_instance_type" {

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -6,7 +6,7 @@ variable "deployment_name" {
 variable "instance_type" {
   type        = string
   description = "The instance type to use for the Brainstore reader nodes.  Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
-  default     = "c8gd.2xlarge"
+  default     = "c8gd.4xlarge"
 }
 
 variable "license_key" {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -65,6 +65,7 @@ resource "aws_lambda_function" "api_handler" {
       BRAINSTORE_ENABLED                         = var.brainstore_enabled
       BRAINSTORE_DEFAULT                         = var.brainstore_default
       BRAINSTORE_URL                             = local.brainstore_url
+      BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
       BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
       BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "catchup_etl" {
       REDIS_PORT                                 = var.redis_port
       BRAINSTORE_ENABLED                         = var.brainstore_enabled
       BRAINSTORE_URL                             = local.brainstore_url
+      BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
       BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
       BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -11,11 +11,13 @@ locals {
     lambda => trimspace(data.http.lambda_versions[lambda].response_body)
   } : jsondecode(file("${path.module}/VERSIONS.json"))
 
-  postgres_url           = "postgres://${var.postgres_username}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/postgres"
-  brainstore_url         = var.brainstore_enabled ? "http://${var.brainstore_hostname}:${var.brainstore_port}" : ""
-  brainstore_s3_bucket   = var.brainstore_enabled ? var.brainstore_s3_bucket_name : ""
-  clickhouse_pg_url      = var.clickhouse_host != null ? "postgres://default:${var.clickhouse_secret}@${var.clickhouse_host}:9005/default" : ""
-  clickhouse_connect_url = var.clickhouse_host != null ? "http://default:${var.clickhouse_secret}@${var.clickhouse_host}:8123/default" : ""
+  postgres_url            = "postgres://${var.postgres_username}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/postgres"
+  using_brainstore_writer = var.brainstore_writer_hostname != null && var.brainstore_writer_hostname != ""
+  brainstore_url          = var.brainstore_enabled ? "http://${var.brainstore_hostname}:${var.brainstore_port}" : ""
+  brainstore_writer_url   = var.brainstore_enabled && local.using_brainstore_writer ? "http://${var.brainstore_writer_hostname}:${var.brainstore_port}" : ""
+  brainstore_s3_bucket    = var.brainstore_enabled ? var.brainstore_s3_bucket_name : ""
+  clickhouse_pg_url       = var.clickhouse_host != null ? "postgres://default:${var.clickhouse_secret}@${var.clickhouse_host}:9005/default" : ""
+  clickhouse_connect_url  = var.clickhouse_host != null ? "http://default:${var.clickhouse_secret}@${var.clickhouse_host}:8123/default" : ""
   common_tags = {
     BraintrustDeploymentName = var.deployment_name
   }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -243,6 +243,31 @@ variable "brainstore_default" {
   }
 }
 
+variable "brainstore_disable_optimization_worker" {
+  type        = bool
+  description = "Whether to disable the optimization worker in Brainstore"
+  default     = false
+}
+
+variable "brainstore_vacuum_object_all" {
+  type        = bool
+  description = "Whether to vacuum all objects in Brainstore"
+  default     = false
+}
+
+variable "brainstore_enable_index_validation" {
+  type        = bool
+  description = "Enable index validation for Brainstore"
+  default     = false
+}
+
+variable "brainstore_index_validation_only_deletes" {
+  type        = bool
+  description = "Scope index validation to only deletes in Brainstore. Only applies if brainstore_enable_index_validation is true"
+  default     = true
+}
+
+
 variable "lambda_version_tag_override" {
   description = "Optional override for the lambda version tag. If not provided, will use locked versions from VERSIONS.json"
   type        = string

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -107,6 +107,12 @@ variable "brainstore_hostname" {
   }
 }
 
+variable "brainstore_writer_hostname" {
+  type        = string
+  description = "Hostname for the dedicated Brainstore writer nodes, if enabled"
+  default     = null
+}
+
 variable "brainstore_port" {
   type        = number
   description = "Port for Brainstore"

--- a/variables.tf
+++ b/variables.tf
@@ -289,20 +289,20 @@ variable "brainstore_default" {
 
 variable "brainstore_instance_type" {
   type        = string
-  description = "The instance type to use for the Brainstore. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
-  default     = "c8gd.8xlarge"
+  description = "The instance type to use for Brainstore reader nodes. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
+  default     = "c8gd.2xlarge"
 }
 
 variable "brainstore_instance_count" {
   type        = number
-  description = "The number of Brainstore instances to provision"
-  default     = 1
+  description = "The number of Brainstore reader instances to provision"
+  default     = 2
 }
 
 variable "brainstore_writer_instance_count" {
   type        = number
-  description = "Optional: The number of dedicated writer nodes to create"
-  default     = 0
+  description = "The number of dedicated writer nodes to create"
+  default     = 1
 }
 
 variable "brainstore_writer_instance_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -290,7 +290,7 @@ variable "brainstore_default" {
 variable "brainstore_instance_type" {
   type        = string
   description = "The instance type to use for Brainstore reader nodes. Recommended Graviton instance type with 16GB of memory and a local SSD for cache data."
-  default     = "c8gd.2xlarge"
+  default     = "c8gd.4xlarge"
 }
 
 variable "brainstore_instance_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -299,6 +299,18 @@ variable "brainstore_instance_count" {
   default     = 1
 }
 
+variable "brainstore_writer_instance_count" {
+  type        = number
+  description = "Optional: The number of dedicated writer nodes to create"
+  default     = 0
+}
+
+variable "brainstore_writer_instance_type" {
+  type        = string
+  description = "The instance type to use for the Brainstore writer nodes"
+  default     = "c8gd.8xlarge"
+}
+
 variable "brainstore_instance_key_pair_name" {
   type        = string
   description = "The name of the key pair to use for the Brainstore instance"
@@ -357,6 +369,32 @@ variable "brainstore_extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to set for Brainstore"
   default     = {}
+}
+
+
+
+variable "brainstore_enable_index_validation" {
+  type        = bool
+  description = "Enable index validation for Brainstore"
+  default     = false
+}
+
+variable "brainstore_index_validation_only_deletes" {
+  type        = bool
+  description = "Scope index validation to only deletes in Brainstore. Only applies if brainstore_enable_index_validation is true"
+  default     = true
+}
+
+variable "brainstore_disable_optimization_worker" {
+  type        = bool
+  description = "Disable the optimization worker in Brainstore"
+  default     = true
+}
+
+variable "brainstore_vacuum_object_all" {
+  type        = bool
+  description = "Enable vacuuming of all objects in Brainstore"
+  default     = false
 }
 
 variable "service_extra_env_vars" {

--- a/variables.tf
+++ b/variables.tf
@@ -388,7 +388,7 @@ variable "brainstore_index_validation_only_deletes" {
 variable "brainstore_disable_optimization_worker" {
   type        = bool
   description = "Disable the optimization worker in Brainstore"
-  default     = true
+  default     = false
 }
 
 variable "brainstore_vacuum_object_all" {


### PR DESCRIPTION
Brainstore will now operate in a split mode with a dedicated set of nodes for handling reads and a dedicated set for handling writes and other background optimization work. 

**Split mode is now enabled by default**. When operating in split mode, you can downgrade the sizing of the reader nodes. The default sizing of the reader nodes was reduced, but you may need to adjust your own values.

Sample configs here: https://github.com/braintrustdata/terraform-aws-braintrust-data-plane/blob/aca50b092aa03149e9cb2f803ca665856f429150/examples/braintrust-data-plane/main.tf#L64-L72

**To opt-out**, you can set `brainstore_writer_instance_count` to 0. This will keep a single type of brainstore nodes that handle both reads and writes.

Other changes:
* The example code now [includes vars](https://github.com/braintrustdata/terraform-aws-braintrust-data-plane/blob/0d9ffb67119b4562187c4c194989fd8847dbb78f/examples/braintrust-data-plane/main.tf#L110C1-L115C50) for sharing logs and a bastion host with braintrust support staff
* Added brainstore vars that were in CF but not in TF
  * `brainstore_disable_optimization_worker` (false by default, always true on reader nodes)
  * `brainstore_vacuum_object_all` (false by default, always false on reader nodes)
  * `brainstore_enable_index_validation` (disabled by default)
  * `brainstore_index_validation_only_deletes` (enabled by default, but dependent on brainstore_enable_index_validation)