### PR TITLE
Rename brainstore segment endpoint

### DIFF
--- a/modules/services/api-gateway-openapi-spec.tf
+++ b/modules/services/api-gateway-openapi-spec.tf
@@ -124,7 +124,7 @@ locals {
       "/brainstore/backfill/track" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }
-      "/brainstore/segment/{segment_id}/object_id" = {
+      "/brainstore/segment/{segment_id}" = {
         for method in ["get", "options"] : method => merge(local.snippet_api_json_text_method, {
           parameters = [
             {


### PR DESCRIPTION
We decided to make the endpoint more general (PR has finally merged so this is the endpoint now).