### PR TITLE
Add CI. Remove unused brainstore variables

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,0 +1,28 @@
+name: Terraform CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: Terraform Lint & Validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Mise
+        uses: jdx/mise-action@v2
+
+      - name: Run setup task
+        run: mise run setup
+
+      - name: Run lint task
+        run: mise run lint
+
+      - name: Run validate task
+        run: mise run validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,5 @@ repos:
 - repo: https://github.com/terraform-docs/terraform-docs
   rev: v0.12.0
   hooks:
-    - id: terraform-docs-root-module
+    - id: terraform-docs-go
       args: ["."]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
   hooks:
     - id: terraform_fmt
     - id: terraform_tflint
+- repo: https://github.com/terraform-docs/terraform-docs
+  rev: v0.12.0
+  hooks:
+    - id: terraform-docs-root-module
+      args: ["."]

--- a/.terraform-docs
+++ b/.terraform-docs
@@ -1,3 +1,6 @@
 formatter: "markdown document"
 sections:
   show: ['header', 'inputs', 'outputs']
+output:
+  mode: "replace"
+  file: "module-docs.md"

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -5,6 +5,6 @@ plugin "terraform" {
 
 plugin "aws" {
     enabled = true
-    version = "0.37.0"
+    version = "0.40.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/main.tf
+++ b/main.tf
@@ -110,8 +110,6 @@ module "services" {
   brainstore_port                            = var.enable_brainstore ? module.brainstore[0].port : null
   brainstore_enable_historical_full_backfill = var.brainstore_enable_historical_full_backfill
   brainstore_backfill_new_objects            = var.brainstore_backfill_new_objects
-  brainstore_backfill_disable_historical     = var.brainstore_backfill_disable_historical
-  brainstore_backfill_disable_nonhistorical  = var.brainstore_backfill_disable_nonhistorical
   brainstore_etl_batch_size                  = var.brainstore_etl_batch_size
 
   # Service configuration

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "ai_proxy" {
   role                           = aws_iam_role.api_handler_role.arn
   handler                        = "index.handler"
   runtime                        = "nodejs22.x"
-  architectures = ["arm64"]
+  architectures                  = ["arm64"]
   memory_size                    = 1024
   reserved_concurrent_executions = var.ai_proxy_reserved_concurrent_executions
   timeout                        = 900

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -69,8 +69,6 @@ resource "aws_lambda_function" "api_handler" {
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
       BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
       BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects
-      BRAINSTORE_BACKFILL_DISABLE_HISTORICAL     = var.brainstore_backfill_disable_historical
-      BRAINSTORE_BACKFILL_DISABLE_NONHISTORICAL  = var.brainstore_backfill_disable_nonhistorical
 
       CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
       CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -221,18 +221,6 @@ variable "brainstore_backfill_new_objects" {
   default     = true
 }
 
-variable "brainstore_backfill_disable_historical" {
-  type        = bool
-  description = "Disable historical backfill for Brainstore"
-  default     = false
-}
-
-variable "brainstore_backfill_disable_nonhistorical" {
-  type        = bool
-  description = "Disable non-historical backfill for Brainstore"
-  default     = false
-}
-
 variable "brainstore_etl_batch_size" {
   type        = number
   description = "The batch size for the ETL process"
@@ -248,25 +236,6 @@ variable "brainstore_default" {
     error_message = "brainstore_default must be true, false, or forced."
   }
 }
-
-variable "brainstore_disable_optimization_worker" {
-  type        = bool
-  description = "Whether to disable the optimization worker in Brainstore"
-  default     = false
-}
-
-variable "brainstore_enable_index_validation" {
-  type        = bool
-  description = "Enable index validation for Brainstore"
-  default     = false
-}
-
-variable "brainstore_index_validation_only_deletes" {
-  type        = bool
-  description = "Scope index validation to only deletes in Brainstore. Only applies if brainstore_enable_index_validation is true"
-  default     = true
-}
-
 
 variable "lambda_version_tag_override" {
   description = "Optional override for the lambda version tag. If not provided, will use locked versions from VERSIONS.json"

--- a/variables.tf
+++ b/variables.tf
@@ -347,18 +347,6 @@ variable "brainstore_backfill_new_objects" {
   default     = true
 }
 
-variable "brainstore_backfill_disable_historical" {
-  type        = bool
-  description = "Disable historical backfill for Brainstore. Don't modify this unless instructed by Braintrust."
-  default     = false
-}
-
-variable "brainstore_backfill_disable_nonhistorical" {
-  type        = bool
-  description = "Disable non-historical backfill for Brainstore. Don't modify this unless instructed by Braintrust."
-  default     = false
-}
-
 variable "brainstore_etl_batch_size" {
   type        = number
   description = "The batch size for the ETL process"


### PR DESCRIPTION
Add lint and validate steps to Github actions

Remove these variables since they were mainly for debugging while launching Brainstore
* `brainstore_backfill_disable_historical`
* `brainstore_backfill_disable_nonhistorical`

Remove these unused variables that were incorrectly added to the services module
* `brainstore_disable_optimization_worker`
* `brainstore_enable_index_validation`
* `brainstore_index_validation_only_deletes`