### PR TITLE
Enable row references and force Brainstore as default

### DIFF
--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -69,6 +69,7 @@ resource "aws_lambda_function" "api_handler" {
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
       BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
       BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects
+      BRAINSTORE_INSERT_ROW_REFS                 = "true"
 
       CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
       CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -230,10 +230,10 @@ variable "brainstore_etl_batch_size" {
 variable "brainstore_default" {
   type        = string
   description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag."
-  default     = "true"
+  default     = "force"
   validation {
-    condition     = contains(["true", "false", "forced"], var.brainstore_default)
-    error_message = "brainstore_default must be true, false, or forced."
+    condition     = contains(["true", "false", "force"], var.brainstore_default)
+    error_message = "brainstore_default must be true, false, or force."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -280,10 +280,10 @@ variable "enable_brainstore" {
 variable "brainstore_default" {
   type        = string
   description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag. Don't set this if you have a large backfill ongoing and are migrating from Clickhouse."
-  default     = "true"
+  default     = "force"
   validation {
-    condition     = contains(["true", "false", "forced"], var.brainstore_default)
-    error_message = "brainstore_default must be true, false, or forced."
+    condition     = contains(["true", "false", "force"], var.brainstore_default)
+    error_message = "brainstore_default must be true, false, or force."
   }
 }
 


### PR DESCRIPTION
This instructs the API to write object store references into the database instead of full payloads. It greatly reduces the amount of data being inserted into postgres and improves performance. This feature requires Brainstore and so BRAINSTORE_DEFAULT is now set to `force`.

The only users who might be negatively impacted by this are ones who are still using Clickhouse or not using Brainstore at all (PG only). There aren't any known Terraform Clickhouse users anymore and PG only mode is no longer supported (much of the UI refuses to operate in this mode already)