### PR TITLE
Add support for additional S3 CORS origins

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,7 @@ module "services" {
   api_handler_reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
   ai_proxy_reserved_concurrent_executions    = var.ai_proxy_reserved_concurrent_executions
   whitelisted_origins                        = var.whitelisted_origins
+  s3_additional_allowed_origins              = var.s3_additional_allowed_origins
   outbound_rate_limit_window_minutes         = var.outbound_rate_limit_window_minutes
   outbound_rate_limit_max_requests           = var.outbound_rate_limit_max_requests
   custom_domain                              = var.custom_domain

--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -4,6 +4,8 @@ locals {
     "https://*.braintrust.dev",
     "https://*.preview.braintrust.dev"
   ]
+
+  all_origins = concat(local.default_origins, var.s3_additional_allowed_origins)
 }
 
 resource "aws_s3_bucket" "code_bundle_bucket" {
@@ -37,7 +39,7 @@ resource "aws_s3_bucket_cors_configuration" "code_bundle_bucket" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT"]
-    allowed_origins = local.default_origins
+    allowed_origins = local.all_origins
     max_age_seconds = 3600
   }
 }
@@ -78,7 +80,7 @@ resource "aws_s3_bucket_cors_configuration" "lambda_responses_bucket" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "HEAD"]
-    allowed_origins = local.default_origins
+    allowed_origins = local.all_origins
     max_age_seconds = 3600
   }
 }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -138,6 +138,12 @@ variable "whitelisted_origins" {
   description = "List of origins to whitelist for CORS"
 }
 
+variable "s3_additional_allowed_origins" {
+  type        = list(string)
+  description = "Additional origins to allow for S3 bucket CORS configuration. Supports a wildcard in the domain name."
+  default     = []
+}
+
 variable "outbound_rate_limit_max_requests" {
   type        = number
   description = "The maximum number of requests per user allowed in the time frame specified by OutboundRateLimitMaxRequests. Setting to 0 will disable rate limits"

--- a/variables.tf
+++ b/variables.tf
@@ -209,6 +209,12 @@ variable "whitelisted_origins" {
   default     = []
 }
 
+variable "s3_additional_allowed_origins" {
+  description = "Additional origins to allow for S3 bucket CORS configuration. Supports a wildcard in the domain name."
+  type        = list(string)
+  default     = []
+}
+
 variable "outbound_rate_limit_max_requests" {
   description = "The maximum number of requests per user allowed in the time frame specified by OutboundRateLimitMaxRequests. Setting to 0 will disable rate limits"
   type        = number


### PR DESCRIPTION
Users can now optionally pass in `s3_additional_allowed_origins` to append to the existing braintrust CORS allowed origins for the service S3 buckets.