### PR TITLE
Fixes for Brainstore apt timeout and ephemeral volume detection

### DIFF
--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -4,26 +4,20 @@
 echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
 
 # Mount the local SSD if it exists
+apt-get install -y nvme-cli
 MOUNT_DIR="/mnt/tmp/brainstore"
 mkdir -p "$MOUNT_DIR"
-NVME_DEV=$(lsblk -o NAME,MOUNTPOINT | grep -v MOUNTPOINT | grep nvme1n1 | awk '{print $1}' | head -n 1)
-if [ -n "$NVME_DEV" ]; then
-  echo "Local SSD detected: $NVME_DEV"
-
-  if ! file -s "/dev/$NVME_DEV" | grep -q "filesystem"; then
-    echo "Formatting /dev/$NVME_DEV as ext4..."
-    mkfs.ext4 "/dev/$NVME_DEV"
-  fi
-  echo "Mounting /dev/$NVME_DEV at $MOUNT_DIR..."
-  mount "/dev/$NVME_DEV" "$MOUNT_DIR"
-
-  # Add the mount to /etc/fstab to make it persistent.
-  # Note this will only survive reboots and not an EC2 stop/start
-  if ! grep -q "$MOUNT_DIR" /etc/fstab; then
-    echo "/dev/$NVME_DEV $MOUNT_DIR ext4 defaults,nofail 0 2" >> /etc/fstab
-  fi
+DEVICE=$(nvme list | grep 'Instance Storage' | head -n1 | awk '{print $1}')
+if [ -n "$DEVICE" ]; then
+  echo "Ephemeral device: $DEVICE"
+  blkid "$DEVICE" >/dev/null || mkfs.ext4 -F "$DEVICE"
+  mount "$DEVICE" "$MOUNT_DIR"
+  # Add to fstab using UUID rather than device name
+  UUID=$(blkid -s UUID -o value "$DEVICE")
+  echo "UUID=$UUID $MOUNT_DIR ext4 defaults 0 2" >> /etc/fstab
 else
-  echo "No local SSD detected. Brainstore will use EBS instead."
+  echo "No ephemeral device found. Exiting with failure."
+  exit 1
 fi
 
 # Raise the file descriptor limit

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Help prevent immediate failure of apt commands if another background process is holding the lock
+echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
+
 # Mount the local SSD if it exists
 MOUNT_DIR="/mnt/tmp/brainstore"
 mkdir -p "$MOUNT_DIR"


### PR DESCRIPTION
### Context
Apt:
Sometimes when brainstore instances start up they fail to install certain things due to another process already holding the apt lock. The default apt behavior is to instantly fail and continue on with additional steps in the user-data init script. This would manifest as Drainstore instances that don't have certain things installed. Unsure what is running in the background that is using apt. Likely something like Ubuntu auto-upgrades.

Ephemeral Volume:
We were mounting the ephemeral drive by assuming that /dev/nvme0n1 was always the ephemeral volume. That is not the case and even between reboots it can end up being at /dev/nvme1n1 instead.

### Description
There is a hidden apt config that allows apt to wait to acquire the lock. It isn't even documented but it has existing since Ubuntu 20.04. This PR adds it to the global apt.conf so that all commands use it by default. It should hopefully help reduce the chance of this happening in the future.

User-data script is now using the nvme cli to detect which is the instance volume and then formatting and mounting it by UUID rather than device name. The boot process will also fail early rather than continuing.