### PR TITLE
Include services version in release notes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,12 +53,24 @@ jobs:
           git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
           git push origin main
 
-
       - name: Create GitHub Release
         run: |
-          gh release create ${{ inputs.module_version }} \
-            --draft \
-            --generate-notes \
-            --title "${{ inputs.module_version }}"
+          if [ "${{ inputs.services_version }}" != "" ]; then
+            cat > release_notes.md << EOF
+
+          ## Braintrust Services
+          * Updated Braintrust Services to \`${{ inputs.services_version }}\`
+          EOF
+            gh release create ${{ inputs.module_version }} \
+              --draft \
+              --generate-notes \
+              --notes-file release_notes.md \
+              --title "${{ inputs.module_version }}"
+          else
+            gh release create ${{ inputs.module_version }} \
+              --draft \
+              --generate-notes \
+              --title "${{ inputs.module_version }}"
+          fi
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
The new release process commits directly to main when updating the Braintrust Services versions. This means the generated release notes won't detect it because it wasn't a PR. 

This change manually updates the release notes to include the version if it changed.

<img width="2706" height="1690" alt="CleanShot 2025-07-16 at 12 19 47@2x" src="https://github.com/user-attachments/assets/05118ee3-906b-4cdf-b7cd-a0d3f062e703" />
