### PR TITLE
Add missing env vars to AI Proxy

### DIFF
--- a/module-docs.md
+++ b/module-docs.md
@@ -583,6 +583,10 @@ Description: The primary endpoint for the dataplane API. This is the value that 
 
 Description: Instance ID of the bastion host that Braintrust support staff can connect to using EC2 Instance Connect. Share this with the Braintrust team.
 
+### <a name="output_brainstore_s3_bucket_name"></a> [brainstore\_s3\_bucket\_name](#output\_brainstore\_s3\_bucket\_name)
+
+Description: Name of the Brainstore S3 bucket
+
 ### <a name="output_brainstore_security_group_id"></a> [brainstore\_security\_group\_id](#output\_brainstore\_security\_group\_id)
 
 Description: ID of the security group for the Brainstore instances

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -25,21 +25,10 @@ resource "aws_lambda_function" "ai_proxy" {
   }
 
   environment {
-    variables = merge({
-      ORG_NAME                                          = var.braintrust_org_name
-      PG_URL                                            = local.postgres_url
-      REDIS_HOST                                        = var.redis_host
-      REDIS_PORT                                        = var.redis_port
-      CODE_BUNDLE_BUCKET                                = aws_s3_bucket.code_bundle_bucket.id
-      FUNCTION_SECRET_KEY                               = aws_secretsmanager_secret_version.function_tools_secret.secret_string
-      QUARANTINE_FUNCTION_ROLE                          = var.use_quarantine_vpc ? aws_iam_role.quarantine_function_role.arn : ""
-      QUARANTINE_INVOKE_ROLE                            = var.use_quarantine_vpc ? aws_iam_role.quarantine_invoke_role.arn : ""
-      QUARANTINE_PRIVATE_SUBNET_1_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[0] : ""
-      QUARANTINE_PRIVATE_SUBNET_2_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[1] : ""
-      QUARANTINE_PRIVATE_SUBNET_3_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[2] : ""
-      QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? aws_security_group.quarantine_lambda[0].id : ""
-      QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
-    }, var.extra_env_vars.AIProxy)
+    variables = merge(
+      local.api_common_env_vars,
+      var.extra_env_vars.AIProxy
+    )
   }
 
   vpc_config {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -1,6 +1,51 @@
 locals {
   api_handler_function_name = "${var.deployment_name}-APIHandler"
+  # Shared between the AI Proxy and API Handler
+  api_common_env_vars = {
+    ORG_NAME                   = var.braintrust_org_name
+    BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
+
+    PG_URL             = local.postgres_url
+    REDIS_HOST         = var.redis_host
+    REDIS_PORT         = var.redis_port
+    RESPONSE_BUCKET    = aws_s3_bucket.lambda_responses_bucket.id
+    CODE_BUNDLE_BUCKET = aws_s3_bucket.code_bundle_bucket.id
+
+    WHITELISTED_ORIGINS                = join(",", var.whitelisted_origins)
+    OUTBOUND_RATE_LIMIT_WINDOW_MINUTES = var.outbound_rate_limit_window_minutes
+    OUTBOUND_RATE_LIMIT_MAX_REQUESTS   = var.outbound_rate_limit_max_requests
+
+    QUARANTINE_INVOKE_ROLE                            = var.use_quarantine_vpc ? aws_iam_role.quarantine_invoke_role.arn : ""
+    QUARANTINE_FUNCTION_ROLE                          = var.use_quarantine_vpc ? aws_iam_role.quarantine_function_role.arn : ""
+    QUARANTINE_PRIVATE_SUBNET_1_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[0] : ""
+    QUARANTINE_PRIVATE_SUBNET_2_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[1] : ""
+    QUARANTINE_PRIVATE_SUBNET_3_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[2] : ""
+    QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? aws_security_group.quarantine_lambda[0].id : ""
+    QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
+
+    FUNCTION_SECRET_KEY = aws_secretsmanager_secret_version.function_tools_secret.secret_string
+
+    BRAINSTORE_ENABLED                         = var.brainstore_enabled
+    BRAINSTORE_DEFAULT                         = var.brainstore_default
+    BRAINSTORE_URL                             = local.brainstore_url
+    BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
+    BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
+    BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
+    BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects
+    BRAINSTORE_INSERT_ROW_REFS                 = "true"
+
+    CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
+    CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url
+  }
+  # There env vars are specific to the API Handler. Don't add env vars here if you need them for the AI Proxy as well.
+  api_handler_specific_env_vars = {
+    AI_PROXY_FN_ARN      = aws_lambda_function.ai_proxy.arn
+    AI_PROXY_FN_URL      = aws_lambda_function_url.ai_proxy.function_url
+    AI_PROXY_INVOKE_ROLE = aws_iam_role.ai_proxy_invoke_role.arn
+    CATCHUP_ETL_ARN      = aws_lambda_function.catchup_etl.arn
+  }
 }
+
 resource "aws_lambda_function" "api_handler" {
   # Require the DB migrations to be run before the API handler is deployed
   depends_on = [aws_lambda_invocation.invoke_database_migration]
@@ -33,47 +78,11 @@ resource "aws_lambda_function" "api_handler" {
   }
 
   environment {
-    variables = merge({
-      ORG_NAME                   = var.braintrust_org_name
-      BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
-
-      PG_URL              = local.postgres_url
-      REDIS_HOST          = var.redis_host
-      REDIS_PORT          = var.redis_port
-      CATCHUP_ETL_ARN     = aws_lambda_function.catchup_etl.arn
-      WHITELISTED_ORIGINS = join(",", var.whitelisted_origins)
-      RESPONSE_BUCKET     = aws_s3_bucket.lambda_responses_bucket.id
-      CODE_BUNDLE_BUCKET  = aws_s3_bucket.code_bundle_bucket.id
-
-      OUTBOUND_RATE_LIMIT_WINDOW_MINUTES = var.outbound_rate_limit_window_minutes
-      OUTBOUND_RATE_LIMIT_MAX_REQUESTS   = var.outbound_rate_limit_max_requests
-
-      AI_PROXY_FN_ARN      = aws_lambda_function.ai_proxy.arn
-      AI_PROXY_FN_URL      = aws_lambda_function_url.ai_proxy.function_url
-      AI_PROXY_INVOKE_ROLE = aws_iam_role.ai_proxy_invoke_role.arn
-
-      QUARANTINE_INVOKE_ROLE                            = var.use_quarantine_vpc ? aws_iam_role.quarantine_invoke_role.arn : ""
-      QUARANTINE_FUNCTION_ROLE                          = var.use_quarantine_vpc ? aws_iam_role.quarantine_function_role.arn : ""
-      QUARANTINE_PRIVATE_SUBNET_1_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[0] : ""
-      QUARANTINE_PRIVATE_SUBNET_2_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[1] : ""
-      QUARANTINE_PRIVATE_SUBNET_3_ID                    = var.use_quarantine_vpc ? var.quarantine_vpc_private_subnets[2] : ""
-      QUARANTINE_PUB_PRIVATE_VPC_DEFAULT_SECURITY_GROUP = var.use_quarantine_vpc ? aws_security_group.quarantine_lambda[0].id : ""
-      QUARANTINE_PUB_PRIVATE_VPC_ID                     = var.use_quarantine_vpc ? var.quarantine_vpc_id : ""
-
-      FUNCTION_SECRET_KEY = aws_secretsmanager_secret_version.function_tools_secret.secret_string
-
-      BRAINSTORE_ENABLED                         = var.brainstore_enabled
-      BRAINSTORE_DEFAULT                         = var.brainstore_default
-      BRAINSTORE_URL                             = local.brainstore_url
-      BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
-      BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
-      BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
-      BRAINSTORE_BACKFILL_NEW_OBJECTS            = var.brainstore_backfill_new_objects
-      BRAINSTORE_INSERT_ROW_REFS                 = "true"
-
-      CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
-      CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url
-    }, var.extra_env_vars.APIHandler)
+    variables = merge(
+      local.api_common_env_vars,
+      local.api_handler_specific_env_vars,
+      var.extra_env_vars.APIHandler
+    )
   }
 
   vpc_config {

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,7 +44,7 @@ output "main_vpc_private_route_table_id" {
 }
 
 output "brainstore_security_group_id" {
-  value       = module.brainstore[0].brainstore_instance_security_group_id
+  value       = var.enable_brainstore ? module.brainstore[0].brainstore_instance_security_group_id : null
   description = "ID of the security group for the Brainstore instances"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "brainstore_security_group_id" {
   description = "ID of the security group for the Brainstore instances"
 }
 
+output "brainstore_s3_bucket_name" {
+  value       = var.enable_brainstore ? module.brainstore[0].s3_bucket : null
+  description = "Name of the Brainstore S3 bucket"
+}
+
 output "rds_security_group_id" {
   value       = module.database.rds_security_group_id
   description = "ID of the security group for the RDS instance"


### PR DESCRIPTION
The API Handler and AI Proxy were not sharing common env vars and required manually updating both of them. We missed adding some important Brainstore env vars to the AI Proxy. This PR changes it so there is now a common shared set of env vars. This fixes a current issue with the AI Proxy not having access to the Brainstore Realtime WAL bucket and also helps prevent future mistakes like this.

Additional Changes:
* Added the Brainstore bucket to outputs