### PR TITLE
Services v1.1.15 and release script changes

### DIFF
--- a/lock_versions
+++ b/lock_versions
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S uv --quiet run --script
 # /// script
 # dependencies = [
-#   "boto3",
 # ]
 # ///
 
@@ -12,69 +11,13 @@ release process of the terraform module.
 Versions are written to a VERSIONS.json file in their respective module directories.
 The terraform module will look at these files to determine the versions to deploy.
 
-By default, this script will write the versions from the `latest` tag.
-You can specify a different tag (e.g. stable) by passing it as an argument.
-
 Usage:
-    ./lock_versions [version_tag]
-
-    If no version_tag is provided, "latest" is used by default.
+    ./lock_versions VERSION_TAG
 """
 
 import json
-import urllib.request
 import sys
 import os
-import boto3
-import botocore.exceptions
-import datetime
-
-
-def check_aws_authentication():
-    try:
-        session = boto3.Session()
-        sts_client = session.client("sts")
-        sts_client.get_caller_identity()
-        return True
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.TokenRetrievalError,
-    ) as e:
-        return False
-    except Exception as e:
-        print(f"Unexpected error checking AWS authentication: {str(e)}")
-        raise
-
-
-def get_lambda_versions(version_tag):
-    """
-    Fetches versions for all lambda functions based on the specified tag.
-    Returns a dictionary with lambda names as keys and versions as values.
-    """
-    print(f"Fetching lambda versions for tag: {version_tag}")
-
-    lambdas = [
-        "AIProxy",
-        "APIHandler",
-        "MigrateDatabaseFunction",
-        "QuarantineWarmupFunction",
-        "CatchupETL",
-        "BillingCron",
-    ]
-
-    lambda_base_url = (
-        "https://braintrust-assets-us-east-1.s3.us-east-1.amazonaws.com/lambda"
-    )
-    versions = {}
-    for lambda_name in lambdas:
-        print(f"Fetching {version_tag} version for {lambda_name}...")
-        with urllib.request.urlopen(
-            f"{lambda_base_url}/{lambda_name}/version-{version_tag}"
-        ) as response:
-            version = response.read().decode("utf-8").strip()
-            versions[lambda_name] = version
-
-    return versions
 
 
 def main():
@@ -87,25 +30,15 @@ def main():
     version_tag = sys.argv[1]
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    metadata = {
-        "_tag": version_tag,
-    }
 
-    if not check_aws_authentication():
-        print("ERROR: You are not authenticated with AWS.")
-        print("Please run 'aws sso login' or set up your AWS credentials.")
-        sys.exit(1)
-
-    # Get lambda versions and write to services/VERSIONS.json
-    lambda_versions = get_lambda_versions(version_tag)
-    lambda_versions.update(metadata)
-
-    print("Writing lambda versions to modules/services/VERSIONS.json...")
+    # Write lambda version tag to services/VERSIONS.json
+    print("Writing lambda version tag to modules/services/VERSIONS.json...")
     versions_path = f"{script_dir}/modules/services/VERSIONS.json"
+    lambda_versions = {"lambda_version_tag": version_tag}
     with open(versions_path, "w") as f:
         json.dump(lambda_versions, f, indent=4)
 
-    # Get brainstore version from ECR and write to brainstore/VERSIONS.json
+    # Write brainstore version to brainstore/VERSIONS.json
     print("Writing brainstore version to modules/brainstore/VERSIONS.json...")
     brainstore_versions_path = f"{script_dir}/modules/brainstore/VERSIONS.json"
     os.makedirs(os.path.dirname(brainstore_versions_path), exist_ok=True)

--- a/lock_versions
+++ b/lock_versions
@@ -46,42 +46,6 @@ def check_aws_authentication():
         raise
 
 
-def get_container_version(repository_name, version_tag):
-    """
-    Finds the commit hash for a container image based on a tag like "latest".
-    """
-    print(f"Fetching {repository_name} version from ECR for tag: {version_tag}...")
-
-    session = boto3.Session()
-    ecr_client = session.client("ecr-public", region_name="us-east-1")
-
-    response = ecr_client.describe_images(
-        repositoryName=repository_name, imageIds=[{"imageTag": version_tag}]
-    )
-
-    if not response["imageDetails"]:
-        raise Exception(f"No image found for {repository_name}:{version_tag}")
-
-    image_tags = response["imageDetails"][0].get("imageTags", [])
-
-    # Only include tags that are long enough to be commit hashes
-    # This is hacky, but is better than enumerating all the valid tags
-    version_tags = [tag for tag in image_tags if len(tag) >= 40]
-    if len(version_tags) == 0:
-        raise Exception(
-            f"No commit hash tags found for {repository_name}:{version_tag}. Can't find the specific version to lock onto."
-        )
-    elif len(version_tags) > 1:
-        raise Exception(
-            f"Multiple commit hash tags found for {repository_name}:{version_tag} : {version_tags}. Expected only one hash tag. Unsure which version to lock onto."
-        )
-
-    version = version_tags[0]
-
-    print(f"Found {repository_name} version: {version}")
-    return {repository_name: version}
-
-
 def get_lambda_versions(version_tag):
     """
     Fetches versions for all lambda functions based on the specified tag.
@@ -95,7 +59,7 @@ def get_lambda_versions(version_tag):
         "MigrateDatabaseFunction",
         "QuarantineWarmupFunction",
         "CatchupETL",
-        "BillingCron"
+        "BillingCron",
     ]
 
     lambda_base_url = (
@@ -114,14 +78,17 @@ def get_lambda_versions(version_tag):
 
 
 def main():
-    version_tag = "latest"
-    if len(sys.argv) > 1:
-        version_tag = sys.argv[1]
+    if len(sys.argv) < 2:
+        print("ERROR: Version tag is required.")
+        print("Usage: ./lock_versions <version_tag>")
+        print("Example: ./lock_versions v1.0.0")
+        sys.exit(1)
+
+    version_tag = sys.argv[1]
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     metadata = {
         "_tag": version_tag,
-        "_timestamp": datetime.datetime.now().isoformat(),
     }
 
     if not check_aws_authentication():
@@ -139,13 +106,11 @@ def main():
         json.dump(lambda_versions, f, indent=4)
 
     # Get brainstore version from ECR and write to brainstore/VERSIONS.json
-    brainstore_version = get_container_version("brainstore", version_tag)
-    brainstore_version.update(metadata)
     print("Writing brainstore version to modules/brainstore/VERSIONS.json...")
     brainstore_versions_path = f"{script_dir}/modules/brainstore/VERSIONS.json"
     os.makedirs(os.path.dirname(brainstore_versions_path), exist_ok=True)
     with open(brainstore_versions_path, "w") as f:
-        json.dump(brainstore_version, f, indent=4)
+        json.dump({"brainstore": version_tag}, f, indent=4)
 
 
 if __name__ == "__main__":

--- a/modules/brainstore/VERSIONS.json
+++ b/modules/brainstore/VERSIONS.json
@@ -1,5 +1,3 @@
 {
-    "brainstore": "0a6b1596a436ee27df0e837d2e3ec39b99c08e38",
-    "_tag": "v1.1.14",
-    "_timestamp": "2025-07-16T19:19:35.080416"
+    "brainstore": "v1.1.15"
 }

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,10 +1,9 @@
 {
-    "AIProxy": "lambda/AIProxy/versions/08585353761ac8408fd95b30c366028f.zip",
-    "APIHandler": "lambda/APIHandler/versions/07e9daf558842858f5eb4b505eb0430e.zip",
-    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/15e65d1dea9fb140ff794c24e5df020c.zip",
-    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/a3cc247ec349370c2747bd24cd5681d5.zip",
-    "CatchupETL": "lambda/CatchupETL/versions/6711b31b0414fa3be5a5b76a2f844672.zip",
-    "BillingCron": "lambda/BillingCron/versions/8db5133448e5efe577e5e9c15a4cf66a.zip",
-    "_tag": "v1.1.14",
-    "_timestamp": "2025-07-16T19:19:35.080416"
+    "AIProxy": "lambda/AIProxy/versions/b766282d3421d0c7bf093b2f5a51cb53.zip",
+    "APIHandler": "lambda/APIHandler/versions/aa6ff8b64cf423eebb6f759288bb88fb.zip",
+    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/be0ad840da6f5be385917cff86d03d03.zip",
+    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/e543fbc98b3e30fe9bef1d7b2cc16f83.zip",
+    "CatchupETL": "lambda/CatchupETL/versions/f39a0d980516d4334b54757d929cf7a2.zip",
+    "BillingCron": "lambda/BillingCron/versions/03bad5e0b39ad8d59f0bb9fafb28cb82.zip",
+    "_tag": "v1.1.15"
 }

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,9 +1,3 @@
 {
-    "AIProxy": "lambda/AIProxy/versions/b766282d3421d0c7bf093b2f5a51cb53.zip",
-    "APIHandler": "lambda/APIHandler/versions/aa6ff8b64cf423eebb6f759288bb88fb.zip",
-    "MigrateDatabaseFunction": "lambda/MigrateDatabaseFunction/versions/be0ad840da6f5be385917cff86d03d03.zip",
-    "QuarantineWarmupFunction": "lambda/QuarantineWarmupFunction/versions/e543fbc98b3e30fe9bef1d7b2cc16f83.zip",
-    "CatchupETL": "lambda/CatchupETL/versions/f39a0d980516d4334b54757d929cf7a2.zip",
-    "BillingCron": "lambda/BillingCron/versions/03bad5e0b39ad8d59f0bb9fafb28cb82.zip",
-    "_tag": "v1.1.15"
+    "lambda_version_tag": "v1.1.15"
 }


### PR DESCRIPTION
Bump braintrust services to v1.1.15

The original intent of the lock_version script was to ensure users didn't point at `latest` and get a new version of services every time they apply terraform. Now that we have proper versioning this isn't necessary.
* Change the lock_versions script to no longer lookup SHAs and instead just lock on the labeled version.
* Version tag is now a required arg rather than assuming `latest`
* Remove _timestamp to avoid unnecessary diffs when running twice