### PR TITLE
Bump migrations lambda to python 3.13

### DIFF
--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "migrate_database" {
   s3_key        = local.lambda_versions["MigrateDatabaseFunction"]
   role          = aws_iam_role.default_role.arn
   handler       = "lambda_function.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.13"
   memory_size   = 1024
   timeout       = 900
   publish       = true


### PR DESCRIPTION
Python 3.9 is EOL in December. Update to Python 3.13

Note: This change requires v1.1.16 of the Braintrust Services. Do not merge until v1.1.16 is released.