### PR TITLE
Add Automations Lambda + Proxy route fix

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -107,6 +107,7 @@ module "braintrust-data-plane" {
   #   CatchupETL               = {}
   #   MigrateDatabaseFunction  = {}
   #   QuarantineWarmupFunction = {}
+  #   AutomationCron           = {}
   # }
 
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -531,6 +531,7 @@ object({
     BillingCron              = map(string)
     MigrateDatabaseFunction  = map(string)
     QuarantineWarmupFunction = map(string)
+    AutomationCron           = map(string)
   })
 ```
 
@@ -543,7 +544,8 @@ Default:
   "BillingCron": {},
   "CatchupETL": {},
   "MigrateDatabaseFunction": {},
-  "QuarantineWarmupFunction": {}
+  "QuarantineWarmupFunction": {},
+  "AutomationCron": {}
 }
 ```
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -541,11 +541,11 @@ Default:
 {
   "AIProxy": {},
   "APIHandler": {},
+  "AutomationCron": {},
   "BillingCron": {},
   "CatchupETL": {},
   "MigrateDatabaseFunction": {},
-  "QuarantineWarmupFunction": {},
-  "AutomationCron": {}
+  "QuarantineWarmupFunction": {}
 }
 ```
 

--- a/modules/services/cloudfront.tf
+++ b/modules/services/cloudfront.tf
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
     for_each = toset([
       "/v1/proxy", "/v1/proxy/*",
       "/v1/eval", "/v1/eval/*",
-      "/v1/function/*",
+      "/v1/function/*/?*",
       "/function/*"
     ])
     content {

--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -243,6 +243,16 @@ resource "aws_iam_policy" "api_handler_policy" {
           "kms:DescribeKey"
         ]
         Resource = var.kms_key_arn
+      },
+      {
+        Action   = "sts:AssumeRole"
+        Effect   = "Allow"
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "sts:ExternalId" = "bt:*"
+          }
+        }
       }
     ]
     Version = "2012-10-17"

--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -245,6 +245,7 @@ resource "aws_iam_policy" "api_handler_policy" {
         Resource = var.kms_key_arn
       },
       {
+        Sid      = "AssumeRoleInCustomerAccountForS3Export"
         Action   = "sts:AssumeRole"
         Effect   = "Allow"
         Resource = "*"

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -1,0 +1,75 @@
+locals {
+  automation_cron_function_name = "${var.deployment_name}-AutomationCron"
+}
+
+resource "aws_lambda_function" "automation_cron" {
+  function_name = local.automation_cron_function_name
+  s3_bucket     = local.lambda_s3_bucket
+  s3_key        = local.lambda_versions["AutomationCron"]
+  role          = aws_iam_role.default_role.arn
+  handler       = "lambda.handler"
+  runtime       = "nodejs22.x"
+  timeout       = 300
+  memory_size   = 1024
+  architectures = ["arm64"]
+
+  layers = [
+    "arn:aws:lambda:${data.aws_region.current.name}:041475135427:layer:duckdb-nodejs-arm64:14"
+  ]
+
+  environment {
+    variables = merge({
+      ORG_NAME                                   = var.braintrust_org_name
+      PG_URL                                     = local.postgres_url
+      REDIS_HOST                                 = var.redis_host
+      REDIS_PORT                                 = var.redis_port
+      REDIS_URL                                  = "redis://${var.redis_host}:${var.redis_port}"
+      BRAINSTORE_ENABLED                         = var.brainstore_enabled
+      BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL = var.brainstore_enable_historical_full_backfill
+      BRAINSTORE_BACKFILL_HISTORICAL_BATCH_SIZE  = var.brainstore_etl_batch_size
+      BRAINSTORE_BACKFILL_DISABLE_HISTORICAL     = var.brainstore_backfill_new_objects
+      BRAINSTORE_BACKFILL_ENABLE_NONHISTORICAL   = var.brainstore_default
+      BRAINSTORE_URL                             = local.brainstore_url
+      BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
+      BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
+      FUNCTION_SECRET_KEY                        = random_password.service_token_secret_key[0].result
+    }, var.extra_env_vars.AutomationCron)
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group  = "/braintrust/${var.deployment_name}/${local.automation_cron_function_name}"
+  }
+
+  vpc_config {
+    subnet_ids         = var.service_subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_event_rule" "automation_cron_schedule" {
+  name                = "${var.deployment_name}-automation-cron-schedule"
+  description         = "Trigger automation cron Lambda function."
+  schedule_expression = "rate(10 minutes)"
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_event_target" "automation_cron_target" {
+  rule      = aws_cloudwatch_event_rule.automation_cron_schedule.name
+  target_id = "AutomationCronLambdaTarget"
+  arn       = aws_lambda_function.automation_cron.arn
+}
+
+resource "aws_lambda_permission" "allow_automation_cron_eventbridge" {
+  statement_id  = "AllowEventBridgeInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.automation_cron.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.automation_cron_schedule.arn
+}

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "automation_cron" {
   function_name = local.automation_cron_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["AutomationCron"]
-  role          = aws_iam_role.default_role.arn
+  role          = aws_iam_role.api_handler_role.arn
   handler       = "lambda.handler"
   runtime       = "nodejs22.x"
   timeout       = 300
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "automation_cron" {
       BRAINSTORE_URL                             = local.brainstore_url
       BRAINSTORE_WRITER_URL                      = local.brainstore_writer_url
       BRAINSTORE_REALTIME_WAL_BUCKET             = local.brainstore_s3_bucket
-      FUNCTION_SECRET_KEY                        = random_password.service_token_secret_key[0].result
+      FUNCTION_SECRET_KEY                        = aws_secretsmanager_secret_version.function_tools_secret.secret_string
     }, var.extra_env_vars.AutomationCron)
   }
 

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "automation_cron" {
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions["AutomationCron"]
   role          = aws_iam_role.api_handler_role.arn
-  handler       = "lambda.handler"
+  handler       = "index.handler"
   runtime       = "nodejs22.x"
   timeout       = 300
   memory_size   = 1024

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -4,7 +4,7 @@ locals {
   # Contact support if you need a new region to be supported.
   supported_regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1", "ca-central-1", "ap-southeast-2"]
   lambda_s3_bucket  = "braintrust-assets-${data.aws_region.current.name}"
-  lambda_names      = ["AIProxy", "APIHandler", "MigrateDatabaseFunction", "QuarantineWarmupFunction", "CatchupETL", "BillingCron"]
+  lambda_names      = ["AIProxy", "APIHandler", "MigrateDatabaseFunction", "QuarantineWarmupFunction", "CatchupETL", "BillingCron", "AutomationCron"]
 
   # Lambda versions can be specified statically through VERSIONS.json or dynamically via lambda_version_tag_override
   # If lambda_version_tag_override is provided, use it. Otherwise, use the lambda_version_tag from VERSIONS.json

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -247,6 +247,7 @@ variable "extra_env_vars" {
     CatchupETL               = map(string)
     MigrateDatabaseFunction  = map(string)
     QuarantineWarmupFunction = map(string)
+    AutomationCron           = map(string)
   })
   description = "Extra environment variables to set for services"
   default = {
@@ -256,6 +257,7 @@ variable "extra_env_vars" {
     CatchupETL               = {}
     MigrateDatabaseFunction  = {}
     QuarantineWarmupFunction = {}
+    AutomationCron           = {}
   }
 }
 

--- a/scripts/dump-logs.sh
+++ b/scripts/dump-logs.sh
@@ -3,7 +3,16 @@
 # Usage:
 #   ./dump_logs.sh <deployment_name> [--minutes N] [--service <svc1,svc2,...|all>]
 
-ALL_SERVICES=("brainstore" "AIProxy" "APIHandler" "CatchupETL" "MigrateDatabaseFunction" "QuarantineWarmupFunction" "BillingCron")
+ALL_SERVICES=(
+  "brainstore"
+  "AIProxy"
+  "APIHandler"
+  "CatchupETL"
+  "MigrateDatabaseFunction"
+  "QuarantineWarmupFunction"
+  "BillingCron"
+  "AutomationCron"
+)
 SERVICES="APIHandler,brainstore"
 
 if [ -z "$1" ]; then

--- a/variables.tf
+++ b/variables.tf
@@ -420,6 +420,7 @@ variable "service_extra_env_vars" {
     BillingCron              = map(string)
     MigrateDatabaseFunction  = map(string)
     QuarantineWarmupFunction = map(string)
+    AutomationCron           = map(string)
   })
   description = "Extra environment variables to set for services"
   default = {
@@ -429,6 +430,7 @@ variable "service_extra_env_vars" {
     BillingCron              = {}
     MigrateDatabaseFunction  = {}
     QuarantineWarmupFunction = {}
+    AutomationCron           = {}
   }
 }
 


### PR DESCRIPTION
The Automation Cron Lambda powers newer features like webhooks and S3 exports in Braintrust

See more here: https://www.braintrust.dev/docs/guides/automations

Other fixes:
* Currently `/v1/function/{id}` is routed to the AI proxy, but our handler for it only exists in the API Handler. Changed the Cloudfront path pattern to only route paths at `/v1/function/{id}/*` to the AI Proxy