### PR TITLE
Add `monitoring_telemetry` to control enabled telemetry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -202,6 +202,7 @@ module "brainstore" {
   writer_instance_type                   = var.brainstore_writer_instance_type
   brainstore_disable_optimization_worker = var.brainstore_disable_optimization_worker
   brainstore_vacuum_all_objects          = var.brainstore_vacuum_all_objects
+  monitoring_telemetry                   = var.monitoring_telemetry
   database_host                          = module.database.postgres_database_address
   database_port                          = module.database.postgres_database_port
   database_secret_arn                    = module.database.postgres_database_secret_arn

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,9 @@ module "services" {
   deployment_name             = var.deployment_name
   lambda_version_tag_override = var.lambda_version_tag_override
 
+  # Telemetry
+  monitoring_telemetry                  = var.monitoring_telemetry
+
   # Data stores
   postgres_username = module.database.postgres_database_username
   postgres_password = module.database.postgres_database_password
@@ -142,10 +145,10 @@ module "services" {
   service_additional_policy_arns             = var.service_additional_policy_arns
   extra_env_vars                             = var.service_extra_env_vars
 
-  # Billing telemetry
-  enable_billing_telemetry              = var.enable_billing_telemetry
+  # Billing usage telemetry
   disable_billing_telemetry_aggregation = var.disable_billing_telemetry_aggregation
   billing_telemetry_log_level           = var.billing_telemetry_log_level
+  billing_telemetry_url                 = var.billing_telemetry_url
 
   # Networking
   vpc_id = module.main_vpc.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,6 @@ module "services" {
   # Billing usage telemetry
   disable_billing_telemetry_aggregation = var.disable_billing_telemetry_aggregation
   billing_telemetry_log_level           = var.billing_telemetry_log_level
-  billing_telemetry_url                 = var.billing_telemetry_url
 
   # Networking
   vpc_id = module.main_vpc.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ module "services" {
   lambda_version_tag_override = var.lambda_version_tag_override
 
   # Telemetry
-  monitoring_telemetry                  = var.monitoring_telemetry
+  monitoring_telemetry = var.monitoring_telemetry
 
   # Data stores
   postgres_username = module.database.postgres_database_username

--- a/module-docs.md
+++ b/module-docs.md
@@ -319,7 +319,15 @@ Default: `null`
 
 ### <a name="input_monitoring_telemetry"></a> [monitoring\_telemetry](#input\_monitoring\_telemetry)
 
-Description: The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage.
+Description: The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values.
+
+Available options:
+- status: Health check information (default)
+- metrics: System metrics (CPU/memory) and Braintrust-specific metrics like indexing lag (default)
+- usage: Billing usage telemetry for aggregate usage metrics
+- memprof: Memory profiling statistics and heap usage patterns
+- logs: Application logs
+- traces: Distributed tracing data
 
 Type: `string`
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -53,6 +53,14 @@ Type: `string`
 
 Default: `""`
 
+### <a name="input_billing_telemetry_url"></a> [billing\_telemetry\_url](#input\_billing\_telemetry\_url)
+
+Description: The URL endpoint for sending telemetry data. Do not change this unless instructed by support.
+
+Type: `string`
+
+Default: `"https://www.braintrust.dev/api/billing/telemetry/v1/events"`
+
 ### <a name="input_brainstore_backfill_new_objects"></a> [brainstore\_backfill\_new\_objects](#input\_brainstore\_backfill\_new\_objects)
 
 Description: Enable backfill for new objects for Brainstore. Don't modify this unless instructed by Braintrust.
@@ -239,11 +247,11 @@ Default: `false`
 
 ### <a name="input_enable_billing_telemetry"></a> [enable\_billing\_telemetry](#input\_enable\_billing\_telemetry)
 
-Description: Enable billing telemetry. Do not enable this unless instructed by support.
+Description: DEPRECATED: Billing telemetry is now always enabled. This parameter is ignored.
 
 Type: `bool`
 
-Default: `false`
+Default: `true`
 
 ### <a name="input_enable_brainstore"></a> [enable\_brainstore](#input\_enable\_brainstore)
 
@@ -324,6 +332,14 @@ Description: Optional override for the lambda version tag. Don't set this unless
 Type: `string`
 
 Default: `null`
+
+### <a name="input_monitoring_telemetry"></a> [monitoring\_telemetry](#input\_monitoring\_telemetry)
+
+Description: Support for internal monitoring telemetry. Do not set this unless instructed by support.
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_outbound_rate_limit_max_requests"></a> [outbound\_rate\_limit\_max\_requests](#input\_outbound\_rate\_limit\_max\_requests)
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -335,11 +335,11 @@ Default: `null`
 
 ### <a name="input_monitoring_telemetry"></a> [monitoring\_telemetry](#input\_monitoring\_telemetry)
 
-Description: Support for internal monitoring telemetry. Do not set this unless instructed by support.
+Description: The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage.
 
 Type: `string`
 
-Default: `""`
+Default: `"status,metrics"`
 
 ### <a name="input_outbound_rate_limit_max_requests"></a> [outbound\_rate\_limit\_max\_requests](#input\_outbound\_rate\_limit\_max\_requests)
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -53,14 +53,6 @@ Type: `string`
 
 Default: `""`
 
-### <a name="input_billing_telemetry_url"></a> [billing\_telemetry\_url](#input\_billing\_telemetry\_url)
-
-Description: The URL endpoint for sending telemetry data. Do not change this unless instructed by support.
-
-Type: `string`
-
-Default: `"https://www.braintrust.dev/api/billing/telemetry/v1/events"`
-
 ### <a name="input_brainstore_backfill_new_objects"></a> [brainstore\_backfill\_new\_objects](#input\_brainstore\_backfill\_new\_objects)
 
 Description: Enable backfill for new objects for Brainstore. Don't modify this unless instructed by Braintrust.

--- a/module-docs.md
+++ b/module-docs.md
@@ -237,14 +237,6 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_enable_billing_telemetry"></a> [enable\_billing\_telemetry](#input\_enable\_billing\_telemetry)
-
-Description: DEPRECATED: Billing telemetry is now always enabled. This parameter is ignored.
-
-Type: `bool`
-
-Default: `true`
-
 ### <a name="input_enable_brainstore"></a> [enable\_brainstore](#input\_enable\_brainstore)
 
 Description: Enable Brainstore for faster analytics

--- a/modules/brainstore/main-writer.tf
+++ b/modules/brainstore/main-writer.tf
@@ -49,6 +49,7 @@ resource "aws_launch_template" "brainstore_writer" {
     brainstore_version_override            = var.version_override == null ? "" : var.version_override
     brainstore_release_version             = local.brainstore_release_version
     brainstore_disable_optimization_worker = var.brainstore_disable_optimization_worker
+    monitoring_telemetry                   = var.monitoring_telemetry
     brainstore_vacuum_all_objects          = var.brainstore_vacuum_all_objects
     is_dedicated_writer_node               = "true"
     extra_env_vars                         = var.extra_env_vars_writer

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -55,6 +55,7 @@ resource "aws_launch_template" "brainstore" {
     brainstore_license_key      = var.license_key
     brainstore_version_override = var.version_override == null ? "" : var.version_override
     brainstore_release_version  = local.brainstore_release_version
+    monitoring_telemetry        = var.monitoring_telemetry
     # Important note: if there are no dedicated writer nodes, this node serves as a read/writer node
     brainstore_disable_optimization_worker = local.has_writer_nodes ? true : var.brainstore_disable_optimization_worker
     brainstore_vacuum_all_objects          = local.has_writer_nodes ? false : var.brainstore_vacuum_all_objects

--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -101,6 +101,7 @@ BRAINSTORE_CACHE_DIR=/mnt/tmp/brainstore
 BRAINSTORE_LICENSE_KEY=${brainstore_license_key}
 BRAINSTORE_DISABLE_OPTIMIZATION_WORKER=${brainstore_disable_optimization_worker}
 BRAINSTORE_VACUUM_OBJECT_ALL=${brainstore_vacuum_all_objects}
+BRAINSTORE_CONTROL_PLANE_TELEMETRY=${monitoring_telemetry}
 NO_COLOR=1
 AWS_DEFAULT_REGION=${aws_region}
 AWS_REGION=${aws_region}

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -131,6 +131,12 @@ variable "brainstore_vacuum_all_objects" {
   default     = false
 }
 
+variable "monitoring_telemetry" {
+  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  type        = string
+  default     = "status,metrics"
+}
+
 variable "s3_bucket_retention_days" {
   type        = number
   description = "The number of days to retain non-current S3 objects. e.g. deleted objects"

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -147,7 +147,7 @@ variable "monitoring_telemetry" {
   default     = "status,metrics"
 
   validation {
-    condition = alltrue([
+    condition = var.monitoring_telemetry == "" || alltrue([
       for item in split(",", var.monitoring_telemetry) :
       contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
     ])

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -132,9 +132,27 @@ variable "brainstore_vacuum_all_objects" {
 }
 
 variable "monitoring_telemetry" {
-  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  description = <<-EOT
+    The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values.
+
+    Available options:
+    - status: Health check information (default)
+    - metrics: System metrics (CPU/memory) and Braintrust-specific metrics like indexing lag (default)
+    - usage: Billing usage telemetry for aggregate usage metrics
+    - memprof: Memory profiling statistics and heap usage patterns
+    - logs: Application logs
+    - traces: Distributed tracing data
+  EOT
   type        = string
   default     = "status,metrics"
+
+  validation {
+    condition = alltrue([
+      for item in split(",", var.monitoring_telemetry) :
+      contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
+    ])
+    error_message = "The monitoring_telemetry value must be a comma-separated list containing only: metrics, logs, traces, status, memprof, usage."
+  }
 }
 
 variable "s3_bucket_retention_days" {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -36,6 +36,11 @@ locals {
 
     CLICKHOUSE_PG_URL      = local.clickhouse_pg_url
     CLICKHOUSE_CONNECT_URL = local.clickhouse_connect_url
+
+    CONTROL_PLANE_TELEMETRY       = var.monitoring_telemetry
+    TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
+    TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
+    TELEMETRY_URL                 = var.billing_telemetry_url
   }
   # There env vars are specific to the API Handler. Don't add env vars here if you need them for the AI Proxy as well.
   api_handler_specific_env_vars = {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -40,7 +40,6 @@ locals {
     CONTROL_PLANE_TELEMETRY       = var.monitoring_telemetry
     TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
     TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
-    TELEMETRY_URL                 = var.billing_telemetry_url
   }
   # There env vars are specific to the API Handler. Don't add env vars here if you need them for the AI Proxy as well.
   api_handler_specific_env_vars = {

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -21,7 +21,6 @@ resource "aws_lambda_function" "billing_cron" {
       PG_URL                        = local.postgres_url
       REDIS_HOST                    = var.redis_host
       REDIS_PORT                    = var.redis_port
-      TELEMETRY_URL                 = var.billing_telemetry_url
       TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
       TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
       SERVICE_TOKEN_SECRET_KEY      = random_password.service_token_secret_key.result

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -1,11 +1,9 @@
 locals {
-  billing_cron_function_name            = "${var.deployment_name}-BillingCron"
-  production_billing_telemetry_endpoint = "https://www.braintrust.dev/api/billing/telemetry/v1/events"
+  billing_cron_function_name = "${var.deployment_name}-BillingCron"
 }
 
 
 resource "aws_lambda_function" "billing_cron" {
-  count = var.enable_billing_telemetry ? 1 : 0
 
   function_name = local.billing_cron_function_name
   s3_bucket     = local.lambda_s3_bucket
@@ -23,11 +21,10 @@ resource "aws_lambda_function" "billing_cron" {
       PG_URL                        = local.postgres_url
       REDIS_HOST                    = var.redis_host
       REDIS_PORT                    = var.redis_port
-      TELEMETRY_ENABLED             = var.enable_billing_telemetry
+      TELEMETRY_URL                 = var.billing_telemetry_url
       TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
       TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
-      SERVICE_TOKEN_SECRET_KEY      = random_password.service_token_secret_key[0].result
-      TELEMETRY_URL                 = var.enable_billing_telemetry ? local.production_billing_telemetry_endpoint : ""
+      SERVICE_TOKEN_SECRET_KEY      = random_password.service_token_secret_key.result
     }, var.extra_env_vars.BillingCron)
   }
 
@@ -49,7 +46,6 @@ resource "aws_lambda_function" "billing_cron" {
 }
 
 resource "aws_cloudwatch_event_rule" "billing_cron_schedule" {
-  count = var.enable_billing_telemetry ? 1 : 0
 
   name                = "${var.deployment_name}-billing-cron-schedule"
   description         = "Trigger billing cron Lambda function."
@@ -58,28 +54,22 @@ resource "aws_cloudwatch_event_rule" "billing_cron_schedule" {
 }
 
 resource "aws_cloudwatch_event_target" "billing_cron_target" {
-  count = var.enable_billing_telemetry ? 1 : 0
-
-  rule      = aws_cloudwatch_event_rule.billing_cron_schedule[0].name
+  rule      = aws_cloudwatch_event_rule.billing_cron_schedule.name
   target_id = "BillingCronLambdaTarget"
-  arn       = aws_lambda_function.billing_cron[0].arn
+  arn       = aws_lambda_function.billing_cron.arn
 }
 
 resource "aws_lambda_permission" "allow_billing_cron_eventbridge" {
-  count = var.enable_billing_telemetry ? 1 : 0
-
   statement_id  = "AllowEventBridgeInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.billing_cron[0].function_name
+  function_name = aws_lambda_function.billing_cron.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.billing_cron_schedule[0].arn
+  source_arn    = aws_cloudwatch_event_rule.billing_cron_schedule.arn
 }
 
 
 # TODO: automation cron / service token keys will replace this
 resource "random_password" "service_token_secret_key" {
-  count = var.enable_billing_telemetry ? 1 : 0
-
   length  = 32
   special = false
 }

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -262,15 +262,27 @@ variable "extra_env_vars" {
 }
 
 variable "enable_billing_telemetry" {
-  description = "Enable billing telemetry. Do not enable this unless instructed by support."
+  description = "DEPRECATED. Use the monitoring_telemetry variable with or without `usage` instead to enable or disable billing telemetry."
+  type        = bool
+  default     = true
+}
+
+variable "disable_billing_telemetry_aggregation" {
+  description = "Disable billing telemetry aggregation. Do not set as true unless instructed by support."
   type        = bool
   default     = false
 }
 
-variable "disable_billing_telemetry_aggregation" {
-  description = "Disable billing telemetry aggregation. Do not disable this unless instructed by support."
-  type        = bool
-  default     = false
+variable "monitoring_telemetry" {
+  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  type        = string
+  default     = "status,metrics"
+}
+
+variable "billing_telemetry_url" {
+  description = "The URL endpoint for sending telemetry data. Do not change this unless instructed by support."
+  type        = string
+  default     = "https://www.braintrust.dev/api/billing/telemetry/v1/events"
 }
 
 variable "billing_telemetry_log_level" {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -283,7 +283,7 @@ variable "monitoring_telemetry" {
   default     = "status,metrics"
 
   validation {
-    condition = alltrue([
+    condition = var.monitoring_telemetry == "" || alltrue([
       for item in split(",", var.monitoring_telemetry) :
       contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
     ])

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -281,12 +281,6 @@ variable "monitoring_telemetry" {
   default     = "status,metrics"
 }
 
-variable "billing_telemetry_url" {
-  description = "The URL endpoint for sending telemetry data. Do not change this unless instructed by support."
-  type        = string
-  default     = "https://www.braintrust.dev/api/billing/telemetry/v1/events"
-}
-
 variable "billing_telemetry_log_level" {
   description = "Log level for billing telemetry. Defaults to 'error' if empty, or unspecified."
   type        = string

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -261,6 +261,8 @@ variable "extra_env_vars" {
   }
 }
 
+
+# tflint-ignore: terraform_unused_declarations
 variable "enable_billing_telemetry" {
   description = "DEPRECATED. Use the monitoring_telemetry variable with or without `usage` instead to enable or disable billing telemetry."
   type        = bool

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -268,9 +268,27 @@ variable "disable_billing_telemetry_aggregation" {
 }
 
 variable "monitoring_telemetry" {
-  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  description = <<-EOT
+    The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values.
+
+    Available options:
+    - status: Health check information (default)
+    - metrics: System metrics (CPU/memory) and Braintrust-specific metrics like indexing lag (default)
+    - usage: Billing usage telemetry for aggregate usage metrics
+    - memprof: Memory profiling statistics and heap usage patterns
+    - logs: Application logs
+    - traces: Distributed tracing data
+  EOT
   type        = string
   default     = "status,metrics"
+
+  validation {
+    condition = alltrue([
+      for item in split(",", var.monitoring_telemetry) :
+      contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
+    ])
+    error_message = "The monitoring_telemetry value must be a comma-separated list containing only: metrics, logs, traces, status, memprof, usage."
+  }
 }
 
 variable "billing_telemetry_log_level" {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -261,14 +261,6 @@ variable "extra_env_vars" {
   }
 }
 
-
-# tflint-ignore: terraform_unused_declarations
-variable "enable_billing_telemetry" {
-  description = "DEPRECATED. Use the monitoring_telemetry variable with or without `usage` instead to enable or disable billing telemetry."
-  type        = bool
-  default     = true
-}
-
 variable "disable_billing_telemetry_aggregation" {
   description = "Disable billing telemetry aggregation. Do not set as true unless instructed by support."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -389,9 +389,27 @@ variable "brainstore_vacuum_all_objects" {
 }
 
 variable "monitoring_telemetry" {
-  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  description = <<-EOT
+    The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values.
+
+    Available options:
+    - status: Health check information (default)
+    - metrics: System metrics (CPU/memory) and Braintrust-specific metrics like indexing lag (default)
+    - usage: Billing usage telemetry for aggregate usage metrics
+    - memprof: Memory profiling statistics and heap usage patterns
+    - logs: Application logs
+    - traces: Distributed tracing data
+  EOT
   type        = string
   default     = "status,metrics"
+
+  validation {
+    condition = alltrue([
+      for item in split(",", var.monitoring_telemetry) :
+      contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
+    ])
+    error_message = "The monitoring_telemetry value must be a comma-separated list containing only: metrics, logs, traces, status, memprof, usage."
+  }
 }
 variable "brainstore_extra_env_vars" {
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -203,13 +203,6 @@ variable "ai_proxy_reserved_concurrent_executions" {
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
 }
 
-# tflint-ignore: terraform_unused_declarations
-variable "enable_billing_telemetry" {
-  description = "DEPRECATED: Billing telemetry is now always enabled. This parameter is ignored."
-  type        = bool
-  default     = true
-}
-
 variable "disable_billing_telemetry_aggregation" {
   description = "Disable billing telemetry aggregation. Do not disable this unless instructed by support."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -203,6 +203,7 @@ variable "ai_proxy_reserved_concurrent_executions" {
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "enable_billing_telemetry" {
   description = "DEPRECATED: Billing telemetry is now always enabled. This parameter is ignored."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -227,12 +227,6 @@ variable "billing_telemetry_log_level" {
   }
 }
 
-variable "billing_telemetry_url" {
-  description = "The URL endpoint for sending telemetry data. Do not change this unless instructed by support."
-  type        = string
-  default     = "https://www.braintrust.dev/api/billing/telemetry/v1/events"
-}
-
 variable "whitelisted_origins" {
   description = "List of origins to whitelist for CORS"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,11 @@ variable "brainstore_vacuum_all_objects" {
   default     = false
 }
 
+variable "monitoring_telemetry" {
+  description = "The telemetry to send to Braintrust's control plane to monitor your deployment. Should be in the form of comma-separated values. Available options are metrics, logs, traces, status, memprof, and usage."
+  type        = string
+  default     = "status,metrics"
+}
 variable "brainstore_extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to set for Brainstore reader or dual use nodes"

--- a/variables.tf
+++ b/variables.tf
@@ -404,13 +404,14 @@ variable "monitoring_telemetry" {
   default     = "status,metrics"
 
   validation {
-    condition = alltrue([
+    condition = var.monitoring_telemetry == "" || alltrue([
       for item in split(",", var.monitoring_telemetry) :
       contains(["metrics", "logs", "traces", "status", "memprof", "usage"], trimspace(item))
     ])
     error_message = "The monitoring_telemetry value must be a comma-separated list containing only: metrics, logs, traces, status, memprof, usage."
   }
 }
+
 variable "brainstore_extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to set for Brainstore reader or dual use nodes"

--- a/variables.tf
+++ b/variables.tf
@@ -204,9 +204,9 @@ variable "ai_proxy_reserved_concurrent_executions" {
 }
 
 variable "enable_billing_telemetry" {
-  description = "Enable billing telemetry. Do not enable this unless instructed by support."
+  description = "DEPRECATED: Billing telemetry is now always enabled. This parameter is ignored."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "disable_billing_telemetry_aggregation" {
@@ -224,6 +224,18 @@ variable "billing_telemetry_log_level" {
     condition     = var.billing_telemetry_log_level == "" || contains(["info", "warn", "error", "debug"], var.billing_telemetry_log_level)
     error_message = "billing_telemetry_log_level must be empty or one of: info, warn, error, debug"
   }
+}
+
+variable "monitoring_telemetry" {
+  description = "Support for internal monitoring telemetry. Do not set this unless instructed by support."
+  type        = string
+  default     = ""
+}
+
+variable "billing_telemetry_url" {
+  description = "The URL endpoint for sending telemetry data. Do not change this unless instructed by support."
+  type        = string
+  default     = "https://www.braintrust.dev/api/billing/telemetry/v1/events"
 }
 
 variable "whitelisted_origins" {

--- a/variables.tf
+++ b/variables.tf
@@ -227,12 +227,6 @@ variable "billing_telemetry_log_level" {
   }
 }
 
-variable "monitoring_telemetry" {
-  description = "Support for internal monitoring telemetry. Do not set this unless instructed by support."
-  type        = string
-  default     = ""
-}
-
 variable "billing_telemetry_url" {
   description = "The URL endpoint for sending telemetry data. Do not change this unless instructed by support."
   type        = string


### PR DESCRIPTION
Adds a new `monitoring_telemetry` variable which allows for controlling what telemetry is passed back to the Braintrust Control Plane.

- By default it is `status,metrics` which sends basic health telemetry to Braintrust. This telemetry contains no PII or sensitive information. It is highly recommended to leave these enabled as it enables Braintrust to support your self-hosted data plane much more effectively.
- To enable billing telemetry, add `usage` to the `monitoring_telemetry` comma delimited list (`usage,status,metrics`)

Deprecates the previous `enable_billing_telemetry` variable in favor of `monitoring_telemetry`.