### PR TITLE
Bump AI Proxy to 10GB RAM

### DIFF
--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "ai_proxy" {
   handler                        = "index.handler"
   runtime                        = "nodejs22.x"
   architectures                  = ["arm64"]
-  memory_size                    = 1024
+  memory_size                    = 10240 # Max that lambda supports
   reserved_concurrent_executions = var.ai_proxy_reserved_concurrent_executions
   timeout                        = 900
   publish                        = true


### PR DESCRIPTION
This will solve some OOM issues from customers. Cost per second will increase 10x, but it is a small percentage of the overall cost to run the data plane.