### PR TITLE
Make the brainstore tmp directory globally writable to allow for non-root users

### DIFF
--- a/modules/brainstore/templates/user_data.sh.tpl
+++ b/modules/brainstore/templates/user_data.sh.tpl
@@ -11,7 +11,8 @@ DEVICE=$(nvme list | grep 'Instance Storage' | head -n1 | awk '{print $1}')
 if [ -n "$DEVICE" ]; then
   echo "Ephemeral device: $DEVICE"
   blkid "$DEVICE" >/dev/null || mkfs.ext4 -F "$DEVICE"
-  mount -o dir_mode=0777,file_mode=0777 "$DEVICE" "$MOUNT_DIR"
+  mount "$DEVICE" "$MOUNT_DIR"
+  chmod -R 0777 "$MOUNT_DIR"
   # Add to fstab using UUID rather than device name
   UUID=$(blkid -s UUID -o value "$DEVICE")
   echo "UUID=$UUID $MOUNT_DIR ext4 defaults 0 2" >> /etc/fstab


### PR DESCRIPTION
In order to support running brainstore as a non-root user in Docker, we need to make sure the NVMe path that's mounted into the container is writable by non-root users. Tested with a personal deployment.