### PR TITLE
Add GetFunction permissions to api handler for quarantine functions

### DIFF
--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -156,7 +156,7 @@ resource "aws_iam_policy" "api_handler_quarantine" {
         Sid = "TagQuarantine"
       },
       {
-        Action   = ["lambda:DeleteFunction", "lambda:UpdateFunctionCode", "lambda:UpdateFunctionConfiguration", "lambda:GetFunctionConfiguration"]
+        Action   = ["lambda:DeleteFunction", "lambda:UpdateFunctionCode", "lambda:UpdateFunctionConfiguration", "lambda:GetFunction", "lambda:GetFunctionConfiguration"]
         Effect   = "Allow"
         Resource = "*"
         Condition = {


### PR DESCRIPTION
GetFunction has a separate 100 call per second rate limit from the rest of lambda's APIs which are capped to 15 calls per second.