### PR TITLE
Revert "Fix reference to lambda version lookup in S3 and brainstore version (#112)"

### DIFF
--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -1,5 +1,5 @@
 locals {
-  brainstore_release_version = "v${jsondecode(file("${path.module}/VERSIONS.json"))["brainstore"]}"
+  brainstore_release_version = jsondecode(file("${path.module}/VERSIONS.json"))["brainstore"]
   common_tags = {
     BraintrustDeploymentName = var.deployment_name
   }

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -31,7 +31,7 @@ locals {
 data "http" "lambda_versions" {
   for_each = toset(local.lambda_names)
 
-  url = "https://${local.lambda_s3_bucket}.s3.${data.aws_region.current.name}.amazonaws.com/lambda/${each.value}/version-v${local.lambda_version_tag}"
+  url = "https://${local.lambda_s3_bucket}.s3.${data.aws_region.current.name}.amazonaws.com/lambda/${each.value}/version-${local.lambda_version_tag}"
 }
 
 data "aws_region" "current" {


### PR DESCRIPTION
This reverts commit 4a66ba21ddcd41c45a0da7ade16e46c481c4ec9e.

The version publishing has been updated to include the v again.