### PR TITLE
Add nosemgrep ignores

### DIFF
--- a/modules/brainstore/iam.tf
+++ b/modules/brainstore/iam.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "brainstore_ec2_role" {
   name = "${var.deployment_name}-brainstore-ec2-role"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -23,7 +23,7 @@ resource "aws_iam_role_policy" "brainstore_s3_access" {
   name = "brainstore-s3-bucket"
   role = aws_iam_role.brainstore_ec2_role.id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -48,7 +48,7 @@ resource "aws_iam_role_policy" "brainstore_secrets_access" {
   name = "secrets-access"
   role = aws_iam_role.brainstore_ec2_role.id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -64,7 +64,7 @@ resource "aws_iam_role_policy" "brainstore_cloudwatch_logs_access" {
   name = "cloudwatch-logs-access"
   role = aws_iam_role.brainstore_ec2_role.id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -88,7 +88,7 @@ resource "aws_iam_role_policy" "brainstore_kms_policy" {
   name = "${var.deployment_name}-brainstore-kms-policy"
   role = aws_iam_role.brainstore_ec2_role.id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -107,7 +107,7 @@ resource "aws_db_subnet_group" "main" {
 resource "aws_iam_role" "db_monitoring" {
   name = "${var.deployment_name}-db-monitoring"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2008-10-17"
     Statement = [
       {

--- a/modules/remote-support/main.tf
+++ b/modules/remote-support/main.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "braintrust_support" {
 
   name = "${var.deployment_name}-braintrust-support"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -33,7 +33,7 @@ resource "aws_iam_role_policy" "braintrust_support_logs" {
   name = "braintrust-support-logs-access"
   role = aws_iam_role.braintrust_support[0].id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {

--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -1,7 +1,7 @@
 # The role used by the API handler to invoke the used-defined quarantined function
 resource "aws_iam_role" "quarantine_invoke_role" {
   name = "${var.deployment_name}-QuarantineInvokeRole"
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Action = "sts:AssumeRole"
@@ -22,7 +22,7 @@ resource "aws_iam_role" "quarantine_invoke_role" {
 resource "aws_iam_role_policy" "quarantine_invoke_policy" {
   name = "${var.deployment_name}-QuarantineInvokeRolePolicy"
   role = aws_iam_role.quarantine_invoke_role.id
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Action   = "lambda:InvokeFunction"
@@ -48,7 +48,7 @@ resource "aws_iam_role_policies_exclusive" "quarantine_invoke_role" {
 resource "aws_iam_role" "quarantine_function_role" {
   name = "${var.deployment_name}-QuarantineFunctionRole"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy_attachment" "quarantine_function_role" {
 # The role used by the API handler and AI proxy
 resource "aws_iam_role" "api_handler_role" {
   name = "${var.deployment_name}-APIHandlerRole"
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Action = "sts:AssumeRole"
@@ -117,7 +117,7 @@ resource "aws_iam_role_policy_attachment" "api_handler_quarantine" {
 resource "aws_iam_policy" "api_handler_quarantine" {
   count = var.use_quarantine_vpc ? 1 : 0
   name  = "${var.deployment_name}-APIHandlerQuarantinePolicy"
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -175,7 +175,7 @@ resource "aws_iam_policy" "api_handler_quarantine" {
 
 resource "aws_iam_policy" "api_handler_policy" {
   name = "${var.deployment_name}-APIHandlerRolePolicy"
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Sid      = "ElasticacheAccess"
@@ -265,7 +265,7 @@ resource "aws_iam_policy" "api_handler_policy" {
 resource "aws_iam_role" "default_role" {
   name = "${var.deployment_name}-DefaultRole"
 
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {
@@ -290,7 +290,7 @@ resource "aws_iam_role_policy" "default_role_policy" {
   name = "${var.deployment_name}-DefaultRolePolicy"
   role = aws_iam_role.default_role.id
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
     Statement = [
       {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -118,7 +118,7 @@ resource "aws_lambda_alias" "api_handler_live" {
 
 resource "aws_iam_role" "ai_proxy_invoke_role" {
   name = "${var.deployment_name}-AIProxyInvokeRole"
-  assume_role_policy = jsonencode({
+  assume_role_policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Action = "sts:AssumeRole"
@@ -136,7 +136,7 @@ resource "aws_iam_role" "ai_proxy_invoke_role" {
 resource "aws_iam_role_policy" "ai_proxy_invoke_policy" {
   name = "AIProxyInvokeRolePolicy"
   role = aws_iam_role.ai_proxy_invoke_role.id
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Statement = [
       {
         Action   = "lambda:InvokeFunction"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -155,7 +155,7 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_endpoint_type = "Gateway"
   route_table_ids   = [aws_route_table.private_route_table.id]
 
-  policy = jsonencode({
+  policy = jsonencode({ # nosemgrep
     Version = "2012-10-17",
     Statement = [
       {


### PR DESCRIPTION
These are a convenience for a customer who uses semgrep and vendors our module. Their scanner has policies where they wont allow jsonencode() in iam policies, but this is our module with our standards. Adding this allows them to easily vendor our code into their own repo without having to get approvals from security teams.