### PR TITLE
Expose x-bt-span-id

### DIFF
--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -73,7 +73,8 @@ resource "aws_lambda_function_url" "ai_proxy" {
       "access-control-allow-credentials",
       "access-control-allow-origin",
       "access-control-allow-methods",
-      "x-bt-internal-trace-id"
+      "x-bt-internal-trace-id",
+      "x-bt-span-id"
     ]
     max_age = 86400
   }


### PR DESCRIPTION
Expose the x-bt-span-id header in the AI Proxy.

Related: https://github.com/braintrustdata/braintrust/pull/7874
