### PR TITLE
Allow for optionally passing in a pre-existing VPC + Remove Clickhouse refs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,42 @@ Required for new AWS accounts to ensure IAM service-linked roles are created.
 ./scripts/create-service-linked-roles.sh
 ```
 
-## Customized Deployments
+### VPCs
 
-It is highly recommended to use our root module to deploy Braintrust. It will make support and upgrades far easier. However, if you need to customize the deployment, you can pick and choose from our submodules since they are easily composable.
+This module creates two VPCs by default:
+- `main` VPC: This is the main VPC that contains the Braintrust services.
+- `quarantine` VPC: This is a "quarantine" VPC where user defined functions run in an isolated environment. The Braintrust API server spawns lambda functions in this VPC.
 
-Look at our `main.tf` as a reference for how to configure the submodules. For example, if you wanted to re-use an existing VPC, you could remove the `module.main_vpc` block and pass in the existing VPC's ID, subnets, and security group IDs to the `services`, `database`, and `redis` modules.
+## Advanced: Customized Deployments
 
+### Using an Existing VPC
+
+The module supports using an existing VPC instead of creating a new dedicated one for the Braintrust services. This is useful when you want to integrate Braintrust into your existing network infrastructure.
+
+The passed in VPC must have the following resources:
+- At least 3 private subnets in different availability zones
+- At least 1 public subnet
+- Internet gateway and NAT gateway with proper route tables configured for private subnets
+
+Important note: The module will still create and manage security groups for the services.
+
+To use an existing VPC, set `create_vpc = false` and provide the required VPC details:
+
+```hcl
+module "braintrust-data-plane" {
+  source = "github.com/braintrustdata/terraform-braintrust-data-plane"
+
+  # ... your existing configuration ...
+
+  # Use existing VPC
+  create_vpc = false
+  existing_vpc_id                        = "vpc-xxxxxxxxx"
+  existing_private_subnet_1_id           = "subnet-xxxxxxxxx"
+  existing_private_subnet_2_id           = "subnet-yyyyyyyyy"
+  existing_private_subnet_3_id           = "subnet-zzzzzzzzz"
+  existing_public_subnet_1_id            = "subnet-aaaaaaaaa"
+}
+```
 
 ## Development Setup
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "main_vpc_id" {
-  value       = module.main_vpc.vpc_id
+  value       = local.main_vpc_id
   description = "ID of the main VPC that contains the Braintrust resources"
 }
 
@@ -9,38 +9,38 @@ output "quarantine_vpc_id" {
 }
 
 output "main_vpc_cidr" {
-  value       = module.main_vpc.vpc_cidr
+  value       = local.main_vpc_cidr
   description = "CIDR block of the main VPC"
 }
 
 output "main_vpc_public_subnet_1_id" {
-  value       = module.main_vpc.public_subnet_1_id
+  value       = local.main_vpc_public_subnet_1_id
   description = "ID of the public subnet in the main VPC"
 }
 
 output "main_vpc_private_subnet_1_id" {
-  value       = module.main_vpc.private_subnet_1_id
+  value       = local.main_vpc_private_subnet_1_id
   description = "ID of the first private subnet in the main VPC"
 }
 
 output "main_vpc_private_subnet_2_id" {
-  value       = module.main_vpc.private_subnet_2_id
+  value       = local.main_vpc_private_subnet_2_id
   description = "ID of the second private subnet in the main VPC"
 }
 
 output "main_vpc_private_subnet_3_id" {
-  value       = module.main_vpc.private_subnet_3_id
+  value       = local.main_vpc_private_subnet_3_id
   description = "ID of the third private subnet in the main VPC"
 }
 
 output "main_vpc_public_route_table_id" {
-  value       = module.main_vpc.public_route_table_id
-  description = "ID of the public route table in the main VPC"
+  value       = var.create_vpc ? module.main_vpc[0].public_route_table_id : null
+  description = "ID of the public route table in the main VPC (null when using existing VPC)"
 }
 
 output "main_vpc_private_route_table_id" {
-  value       = module.main_vpc.private_route_table_id
-  description = "ID of the private route table in the main VPC"
+  value       = var.create_vpc ? module.main_vpc[0].private_route_table_id : null
+  description = "ID of the private route table in the main VPC (null when using existing VPC)"
 }
 
 output "brainstore_security_group_id" {
@@ -81,19 +81,4 @@ output "redis_arn" {
 output "api_url" {
   value       = module.services.api_url
   description = "The primary endpoint for the dataplane API. This is the value that should be entered into the braintrust dashboard under API URL."
-}
-
-output "clickhouse_secret_id" {
-  value       = try(module.clickhouse[0].clickhouse_secret_id, null)
-  description = "ID of the Clickhouse secret. Note this is the Terraform ID attribute which is a pipe delimited combination of secret ID and version ID"
-}
-
-output "clickhouse_s3_bucket_name" {
-  value       = try(module.clickhouse[0].clickhouse_s3_bucket_name, null)
-  description = "Name of the Clickhouse S3 bucket"
-}
-
-output "clickhouse_host" {
-  value       = try(module.clickhouse[0].clickhouse_instance_private_ip, null)
-  description = "Host of the Clickhouse instance"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "quarantine_vpc_id" {
 }
 
 output "main_vpc_cidr" {
-  value       = local.main_vpc_cidr
+  value       = var.create_vpc ? module.main_vpc[0].vpc_cidr : null
   description = "CIDR block of the main VPC"
 }
 

--- a/remote_support.tf
+++ b/remote_support.tf
@@ -15,8 +15,8 @@ module "remote_support" {
   database_secret_arn   = module.database.postgres_database_secret_arn
   redis_host            = module.redis.redis_endpoint
   redis_port            = module.redis.redis_port
-  clickhouse_host       = local.clickhouse_address
-  clickhouse_secret_arn = var.enable_clickhouse ? module.clickhouse[0].clickhouse_secret : null
+  clickhouse_host       = null
+  clickhouse_secret_arn = null
   kms_key_arn           = local.kms_key_arn
   lambda_function_arns = [
     module.services.api_handler_arn,
@@ -27,9 +27,9 @@ module "remote_support" {
   ]
   enable_braintrust_support_logs_access  = var.enable_braintrust_support_logs_access
   enable_braintrust_support_shell_access = var.enable_braintrust_support_shell_access
-  vpc_id                                 = module.main_vpc.vpc_id
-  private_subnet_ids                     = [module.main_vpc.private_subnet_1_id]
-  public_subnet_ids                      = [module.main_vpc.public_subnet_1_id]
+  vpc_id                                 = module.main_vpc[0].vpc_id
+  private_subnet_ids                     = [module.main_vpc[0].private_subnet_1_id]
+  public_subnet_ids                      = [module.main_vpc[0].public_subnet_1_id]
 }
 
 variable "enable_braintrust_support_logs_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,10 +48,67 @@ variable "additional_kms_key_policies" {
 }
 
 ## NETWORKING
+variable "create_vpc" {
+  type        = bool
+  default     = true
+  description = "Whether to create a new VPC. If false, existing VPC details must be provided."
+}
+
 variable "vpc_cidr" {
   type        = string
   default     = "10.175.0.0/21"
-  description = "CIDR block for the VPC"
+  description = "CIDR block for the VPC (only used when create_vpc is true)"
+}
+
+# Existing VPC variables (only used when create_vpc is false)
+variable "existing_vpc_id" {
+  type        = string
+  default     = null
+  description = "ID of existing VPC to use (required when create_vpc is false)"
+  validation {
+    condition     = var.create_vpc || var.existing_vpc_id != null
+    error_message = "existing_vpc_id is required when create_vpc is false."
+  }
+}
+
+variable "existing_private_subnet_1_id" {
+  type        = string
+  default     = null
+  description = "ID of existing private subnet 1 (required when create_vpc is false)"
+  validation {
+    condition     = var.create_vpc || var.existing_private_subnet_1_id != null
+    error_message = "existing_private_subnet_1_id is required when create_vpc is false."
+  }
+}
+
+variable "existing_private_subnet_2_id" {
+  type        = string
+  default     = null
+  description = "ID of existing private subnet 2 (required when create_vpc is false)"
+  validation {
+    condition     = var.create_vpc || var.existing_private_subnet_2_id != null
+    error_message = "existing_private_subnet_2_id is required when create_vpc is false."
+  }
+}
+
+variable "existing_private_subnet_3_id" {
+  type        = string
+  default     = null
+  description = "ID of existing private subnet 3 (required when create_vpc is false)"
+  validation {
+    condition     = var.create_vpc || var.existing_private_subnet_3_id != null
+    error_message = "existing_private_subnet_3_id is required when create_vpc is false."
+  }
+}
+
+variable "existing_public_subnet_1_id" {
+  type        = string
+  default     = null
+  description = "ID of existing public subnet 1 (required when create_vpc is false)"
+  validation {
+    condition     = var.create_vpc || var.existing_public_subnet_1_id != null
+    error_message = "existing_public_subnet_1_id is required when create_vpc is false."
+  }
 }
 
 variable "private_subnet_1_az" {
@@ -268,31 +325,6 @@ variable "lambda_version_tag_override" {
   default     = null
 }
 
-## Clickhouse
-variable "enable_clickhouse" {
-  type        = bool
-  description = "Enable Clickhouse for faster analytics"
-  default     = false
-}
-
-variable "use_external_clickhouse_address" {
-  type        = string
-  description = "Do not change this unless instructed by Braintrust. If set, the domain name or IP of the external Clickhouse instance will be used and no internal instance will be created."
-  default     = null
-}
-
-variable "clickhouse_metadata_storage_size" {
-  type        = number
-  description = "The size of the EBS volume to use for Clickhouse metadata"
-  default     = 100
-}
-
-variable "clickhouse_instance_type" {
-  type        = string
-  description = "The instance type to use for the Clickhouse instance"
-  default     = "c5.2xlarge"
-}
-
 ## Brainstore
 variable "enable_brainstore" {
   type        = bool
@@ -302,7 +334,7 @@ variable "enable_brainstore" {
 
 variable "brainstore_default" {
   type        = string
-  description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag. Don't set this if you have a large backfill ongoing and are migrating from Clickhouse."
+  description = "Whether to set Brainstore as the default rather than requiring users to opt-in via feature flag."
   default     = "force"
   validation {
     condition     = contains(["true", "false", "force"], var.brainstore_default)


### PR DESCRIPTION
Users can now optionally disable creation of the main VPC that hosts the braintrust services and data stores. An existing VPC and subnets can be passed in instead. By default, the module will continue to create a VPC as it has always.

To disable creation of the main VPC:

```hcl
module "braintrust-data-plane" {
  source = "github.com/braintrustdata/terraform-braintrust-data-plane"
  # ... your existing configuration ...
  # Use existing VPC
  create_vpc = false
  existing_vpc_id                        = "vpc-xxxxxxxxx"
  existing_private_subnet_1_id           = "subnet-xxxxxxxxx"
  existing_private_subnet_2_id           = "subnet-yyyyyyyyy"
  existing_private_subnet_3_id           = "subnet-zzzzzzzzz"
  existing_public_subnet_1_id            = "subnet-aaaaaaaaa"
}
```

There were old references to Clickhouse that were removed. No existing TF users should be on Clickhouse. We dropped support for it earlier in the year. This change removes variables, outputs, and the references to the module that was already disabled.