### PR TITLE
Configure bucket versioning and lifecycle policies

### DIFF
--- a/modules/clickhouse/s3.tf
+++ b/modules/clickhouse/s3.tf
@@ -22,3 +22,35 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "clickhouse_s3_buc
     bucket_key_enabled = var.kms_key_arn != null
   }
 }
+
+resource "aws_s3_bucket_versioning" "clickhouse_s3_bucket" {
+  count  = var.external_clickhouse_s3_bucket_name == null ? 1 : 0
+  bucket = aws_s3_bucket.clickhouse_s3_bucket[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "clickhouse_s3_bucket" {
+  count      = var.external_clickhouse_s3_bucket_name == null ? 1 : 0
+  depends_on = [aws_s3_bucket_versioning.clickhouse_s3_bucket]
+  bucket     = aws_s3_bucket.clickhouse_s3_bucket[0].id
+
+  rule {
+    id     = "cleanup-old-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    # Delete old versions after 14 days (longer than other buckets since this stores data)
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}


### PR DESCRIPTION
Add bucket versioning and lifecycle policies to non-brainstore S3 buckets to automatically clean up old versions.

Lifecycle policies are configured to delete noncurrent versions after 3, 7, or 14 days, depending on the bucket's purpose, ensuring old versions are not preserved unnecessarily.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc08b615-b54b-4389-a33c-49fdeda74e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc08b615-b54b-4389-a33c-49fdeda74e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

