### PR TITLE
Allow disabling of db deletion protection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,10 @@ module "database" {
     },
     local.bastion_security_group,
   )
-  postgres_storage_iops       = var.postgres_storage_iops
-  postgres_storage_throughput = var.postgres_storage_throughput
-  auto_minor_version_upgrade  = var.postgres_auto_minor_version_upgrade
+  postgres_storage_iops              = var.postgres_storage_iops
+  postgres_storage_throughput        = var.postgres_storage_throughput
+  auto_minor_version_upgrade         = var.postgres_auto_minor_version_upgrade
+  DANGER_disable_deletion_protection = var.DANGER_disable_database_deletion_protection
 
   kms_key_arn = local.kms_key_arn
 }

--- a/module-docs.md
+++ b/module-docs.md
@@ -15,7 +15,7 @@ The following input variables are optional (have default values):
 
 ### <a name="input_DANGER_disable_database_deletion_protection"></a> [DANGER\_disable\_database\_deletion\_protection](#input\_DANGER\_disable\_database\_deletion\_protection)
 
-Description: Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database.
+Description: Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database.
 
 Type: `bool`
 

--- a/module-docs.md
+++ b/module-docs.md
@@ -13,6 +13,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_DANGER_disable_database_deletion_protection"></a> [DANGER\_disable\_database\_deletion\_protection](#input\_DANGER\_disable\_database\_deletion\_protection)
+
+Description: Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database.
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_additional_kms_key_policies"></a> [additional\_kms\_key\_policies](#input\_additional\_kms\_key\_policies)
 
 Description: Additional IAM policy statements to append to the generated KMS key.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "main" {
   performance_insights_retention_period = 7
 
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
-  deletion_protection        = var.deletion_protection
+  deletion_protection        = !var.DANGER_disable_deletion_protection
 
   kms_key_id = var.kms_key_arn
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -80,8 +80,8 @@ variable "auto_minor_version_upgrade" {
   default     = true
 }
 
-variable "deletion_protection" {
-  description = "Indicates that the DB instance should be protected against deletion. The database can't be deleted when this value is set to true."
+variable "DANGER_disable_deletion_protection" {
+  description = "Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database."
   type        = bool
-  default     = true
+  default     = false
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -81,7 +81,7 @@ variable "auto_minor_version_upgrade" {
 }
 
 variable "DANGER_disable_deletion_protection" {
-  description = "Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database."
+  description = "Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -496,3 +496,9 @@ variable "internal_observability_region" {
   description = "Support for internal observability agent. Do not set this unless instructed by support."
   default     = "us5"
 }
+
+variable "DANGER_disable_database_deletion_protection" {
+  type        = bool
+  description = "Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -499,6 +499,6 @@ variable "internal_observability_region" {
 
 variable "DANGER_disable_database_deletion_protection" {
   type        = bool
-  description = "Disable deletion protection for the database. Do not disable this this when you fully intend to destroy the database."
+  description = "Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database."
   default     = false
 }


### PR DESCRIPTION
This is primarily for development purposes so a test stack can be spun up and spun down more easily. It is specifically prefixed with `DANGER_` to make it painfully obvious what you're doing and to hopefully not accidentally slip by in a PR review.