### PR TITLE
Allow user to optionally pass in database subnet ids

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       language: system
       pass_filenames: false
 - repo: https://github.com/terraform-docs/terraform-docs
-  rev: v0.12.0
+  rev: v0.20.0
   hooks:
     - id: terraform-docs-go
       args: ["."]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,11 @@ repos:
       args: ["run", "lint"]
       language: system
       pass_filenames: false
-- repo: https://github.com/terraform-docs/terraform-docs
-  rev: v0.20.0
+- repo: local
   hooks:
-    - id: terraform-docs-go
-      args: ["."]
+    - id: terraform-docs
+      name: mise terraform docs
+      entry: mise
+      args: ["run", "docs"]
+      language: system
+      pass_filenames: false

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,13 @@ locals {
   main_vpc_private_subnet_2_id = var.create_vpc ? module.main_vpc[0].private_subnet_2_id : var.existing_private_subnet_2_id
   main_vpc_private_subnet_3_id = var.create_vpc ? module.main_vpc[0].private_subnet_3_id : var.existing_private_subnet_3_id
   main_vpc_public_subnet_1_id  = var.create_vpc ? module.main_vpc[0].public_subnet_1_id : var.existing_public_subnet_1_id
+
+  # Database subnet configuration - use custom subnets if provided, otherwise use main VPC private subnets
+  database_subnet_ids = var.database_subnet_ids != null ? var.database_subnet_ids : [
+    local.main_vpc_private_subnet_1_id,
+    local.main_vpc_private_subnet_2_id,
+    local.main_vpc_private_subnet_3_id
+  ]
 }
 
 module "main_vpc" {
@@ -65,12 +72,8 @@ module "database" {
   postgres_max_storage_size = var.postgres_max_storage_size
   postgres_storage_type     = var.postgres_storage_type
   postgres_version          = var.postgres_version
-  database_subnet_ids = [
-    local.main_vpc_private_subnet_1_id,
-    local.main_vpc_private_subnet_2_id,
-    local.main_vpc_private_subnet_3_id
-  ]
-  vpc_id = local.main_vpc_id
+  database_subnet_ids       = local.database_subnet_ids
+  vpc_id                    = local.main_vpc_id
   authorized_security_groups = merge(
     {
       "Lambda Services" = module.services.lambda_security_group_id

--- a/module-docs.md
+++ b/module-docs.md
@@ -213,6 +213,14 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_database_subnet_ids"></a> [database\_subnet\_ids](#input\_database\_subnet\_ids)
+
+Description: Optional list of subnet IDs for the database. If not provided, uses the main VPC's private subnets.
+
+Type: `list(string)`
+
+Default: `null`
+
 ### <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name)
 
 Description: Name of this Braintrust deployment. Will be included in tags and prefixes in resources names. Lowercase letter, numbers, and hyphens only. If you want multiple deployments in your same AWS account, use a unique name for each deployment.

--- a/variables.tf
+++ b/variables.tf
@@ -497,6 +497,12 @@ variable "internal_observability_region" {
   default     = "us5"
 }
 
+variable "database_subnet_ids" {
+  type        = list(string)
+  description = "Optional list of subnet IDs for the database. If not provided, uses the main VPC's private subnets."
+  default     = null
+}
+
 variable "DANGER_disable_database_deletion_protection" {
   type        = bool
   description = "Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database."

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,18 @@ variable "postgres_auto_minor_version_upgrade" {
   default     = true
 }
 
+variable "database_subnet_ids" {
+  type        = list(string)
+  description = "Optional list of subnet IDs for the database. If not provided, uses the main VPC's private subnets."
+  default     = null
+}
+
+variable "DANGER_disable_database_deletion_protection" {
+  type        = bool
+  description = "Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database."
+  default     = false
+}
+
 ## Redis
 variable "redis_instance_type" {
   description = "Instance type for the Redis cluster"
@@ -495,16 +507,4 @@ variable "internal_observability_region" {
   type        = string
   description = "Support for internal observability agent. Do not set this unless instructed by support."
   default     = "us5"
-}
-
-variable "database_subnet_ids" {
-  type        = list(string)
-  description = "Optional list of subnet IDs for the database. If not provided, uses the main VPC's private subnets."
-  default     = null
-}
-
-variable "DANGER_disable_database_deletion_protection" {
-  type        = bool
-  description = "Disable deletion protection for the database. Do not disable this unless you fully intend to destroy the database."
-  default     = false
 }


### PR DESCRIPTION
Normally the RDS instance uses the private subnets from the VPC, but some customers want to be able to specify a custom VPC with custom subnets for the DB. The new variable `database_subnet_ids` allows them to do that. By default it will just use the private subnets from the main VPC exactly as it always has.

```
module "braintrust-data-plane" {
  source = "github.com/braintrustdata/terraform-braintrust-data-plane"
  # ... your existing configuration ...
  # Use existing VPC
  create_vpc = false
  existing_vpc_id                        = "vpc-xxxxxxxxx"
  existing_private_subnet_1_id           = "subnet-xxxxxxxxx"
  existing_private_subnet_2_id           = "subnet-yyyyyyyyy"
  existing_private_subnet_3_id           = "subnet-zzzzzzzzz"
  existing_public_subnet_1_id            = "subnet-aaaaaaaaa"

  database_subnet_ids = ["subnet-ddddddddd", "subnet-eeeeeeeee"]
}
```