### PR TITLE
Add support for passing in a permissions boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ This module creates two VPCs by default:
 - `main` VPC: This is the main VPC that contains the Braintrust services.
 - `quarantine` VPC: This is a "quarantine" VPC where user defined functions run in an isolated environment. The Braintrust API server spawns lambda functions in this VPC.
 
+### Tagging and Naming
+
+If you have requirements to add custom tags to resources created by the module, you can do so by setting the `default_tags` variable on the AWS provider. The example directory [`examples/braintrust-data-plane`](examples/braintrust-data-plane) shows how to do this.
+
+Example:
+```hcl
+provider "aws" {
+  default_tags {
+    tags = {
+      YourCustomTag = "<your-custom-value>"
+    }
+  }
+}
+```
+
+The `deployment_name` variable is also used to prefix the names of the resources created by the module wherever possible. It will also be applied as a tag named `BraintrustDeploymentName` to all resources created by the module.
+
 ## Advanced: Customized Deployments
 
 ### Using an Existing VPC

--- a/examples/braintrust-data-plane/provider.tf
+++ b/examples/braintrust-data-plane/provider.tf
@@ -6,4 +6,11 @@ provider "aws" {
   # Optional, but recommended. Only allow running in a specific AWS account.
   # This is helpful for preventing accidental changes in the wrong account.
   allowed_account_ids = ["<your AWS account ID>"]
+
+  # Optionally, you can add default tags to all resources created by this module.
+  # default_tags {
+  #   tags = {
+  #     YourCustomTag = "<your-custom-value>"
+  #   }
+  # }
 }

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,8 @@ module "database" {
   auto_minor_version_upgrade         = var.postgres_auto_minor_version_upgrade
   DANGER_disable_deletion_protection = var.DANGER_disable_database_deletion_protection
 
-  kms_key_arn = local.kms_key_arn
+  kms_key_arn              = local.kms_key_arn
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "redis" {
@@ -175,7 +176,8 @@ module "services" {
     module.quarantine_vpc[0].private_subnet_3_id
   ] : []
 
-  kms_key_arn = local.kms_key_arn
+  kms_key_arn              = local.kms_key_arn
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 
@@ -223,7 +225,8 @@ module "brainstore" {
     local.main_vpc_private_subnet_3_id
   ]
 
-  kms_key_arn = local.kms_key_arn
+  kms_key_arn              = local.kms_key_arn
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 # Handle state migration since the VPC module became conditional

--- a/module-docs.md
+++ b/module-docs.md
@@ -381,6 +381,14 @@ Type: `number`
 
 Default: `1`
 
+### <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn)
+
+Description: ARN of the IAM permissions boundary to apply to all IAM roles created by this module
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_postgres_auto_minor_version_upgrade"></a> [postgres\_auto\_minor\_version\_upgrade](#input\_postgres\_auto\_minor\_version\_upgrade)
 
 Description: Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. When true you will have to set your postgres\_version to only the major number or you will see drift. e.g. '15' instead of '15.7'

--- a/modules/brainstore/iam.tf
+++ b/modules/brainstore/iam.tf
@@ -14,6 +14,8 @@ resource "aws_iam_role" "brainstore_ec2_role" {
     ]
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = merge({
     Name = "${var.deployment_name}-brainstore-ec2-role"
   }, local.common_tags)

--- a/modules/brainstore/variables.tf
+++ b/modules/brainstore/variables.tf
@@ -178,3 +178,9 @@ variable "service_token_secret_key" {
   description = "The secret encryption key for SERVICE_TOKEN_SECRET_KEY. Typically this re-uses the function tools secret key."
   sensitive   = true
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
+  default     = null
+}

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -120,6 +120,8 @@ resource "aws_iam_role" "db_monitoring" {
     ]
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = local.common_tags
 }
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -85,3 +85,9 @@ variable "DANGER_disable_deletion_protection" {
   type        = bool
   default     = false
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
+  default     = null
+}

--- a/modules/remote-support/main-bastion.tf
+++ b/modules/remote-support/main-bastion.tf
@@ -122,6 +122,8 @@ resource "aws_iam_role" "bastion" {
     ]
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = local.common_tags
 }
 

--- a/modules/remote-support/main.tf
+++ b/modules/remote-support/main.tf
@@ -24,6 +24,8 @@ resource "aws_iam_role" "braintrust_support" {
     ]
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = local.common_tags
 }
 

--- a/modules/remote-support/variables.tf
+++ b/modules/remote-support/variables.tf
@@ -84,3 +84,9 @@ variable "lambda_function_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
+  default     = null
+}

--- a/modules/services/iam.tf
+++ b/modules/services/iam.tf
@@ -14,6 +14,8 @@ resource "aws_iam_role" "quarantine_invoke_role" {
     Version = "2012-10-17"
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = {
     BraintrustDeploymentName = var.deployment_name
   }
@@ -61,6 +63,8 @@ resource "aws_iam_role" "quarantine_function_role" {
     ]
   })
 
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = {
     BraintrustDeploymentName = var.deployment_name
   }
@@ -86,6 +90,8 @@ resource "aws_iam_role" "api_handler_role" {
     ]
     Version = "2012-10-17"
   })
+
+  permissions_boundary = var.permissions_boundary_arn
 
   tags = {
     BraintrustDeploymentName = var.deployment_name
@@ -277,6 +283,8 @@ resource "aws_iam_role" "default_role" {
       }
     ]
   })
+
+  permissions_boundary = var.permissions_boundary_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -130,6 +130,9 @@ resource "aws_iam_role" "ai_proxy_invoke_role" {
     ]
     Version = "2012-10-17"
   })
+
+  permissions_boundary = var.permissions_boundary_arn
+
   tags = local.common_tags
 }
 

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -301,3 +301,9 @@ variable "billing_telemetry_log_level" {
     error_message = "billing_telemetry_log_level must be empty or one of: info, warn, error, debug"
   }
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
+  default     = null
+}

--- a/remote_support.tf
+++ b/remote_support.tf
@@ -30,6 +30,7 @@ module "remote_support" {
   vpc_id                                 = local.main_vpc_id
   private_subnet_ids                     = [local.main_vpc_private_subnet_1_id]
   public_subnet_ids                      = [local.main_vpc_public_subnet_1_id]
+  permissions_boundary_arn               = var.permissions_boundary_arn
 }
 
 variable "enable_braintrust_support_logs_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -508,3 +508,9 @@ variable "internal_observability_region" {
   description = "Support for internal observability agent. Do not set this unless instructed by support."
   default     = "us5"
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
+  default     = null
+}


### PR DESCRIPTION
You can now optionally pass in an ARN for a permissions boundary to apply to all roles created by this module. This is only needed if your organization or security team requires it. By default no boundary is used.

`permissions_boundary_arn = <arn>`

Note: There currently isn't a way to apply a different boundary to different roles. 

Tested and verified locally on our shared sandbox stack.