### PR TITLE
Validate RDS min iops/throughput limits

### DIFF
--- a/module-docs.md
+++ b/module-docs.md
@@ -427,7 +427,7 @@ Description: Storage IOPS for the RDS instance. Only applicable if storage\_type
 
 Type: `number`
 
-Default: `10000`
+Default: `12000`
 
 ### <a name="input_postgres_storage_size"></a> [postgres\_storage\_size](#input\_postgres\_storage\_size)
 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -31,13 +31,29 @@ variable "postgres_storage_type" {
 variable "postgres_storage_iops" {
   description = "Storage IOPS for the RDS instance. Only applicable if storage_type is io1, io2, or gp3."
   type        = number
-  default     = 10000
+  default     = 12000
+  validation {
+    condition = (
+      var.postgres_storage_type != "gp3" ||
+      var.postgres_storage_size < 400 ||
+      var.postgres_storage_iops >= 12000
+    )
+    error_message = "For gp3 storage with size >= 400GB: IOPS must be greater than or equal to 12000."
+  }
 }
 
 variable "postgres_storage_throughput" {
   description = "Storage throughput for the RDS instance. Only applicable if storage_type is gp3."
   type        = number
   default     = 500
+  validation {
+    condition = (
+      var.postgres_storage_type != "gp3" ||
+      var.postgres_storage_size < 400 ||
+      var.postgres_storage_throughput >= 500
+    )
+    error_message = "For gp3 storage with size >= 400GB: throughput must be at least 500."
+  }
 }
 
 variable "postgres_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -200,13 +200,29 @@ variable "postgres_storage_type" {
 variable "postgres_storage_iops" {
   description = "Storage IOPS for the RDS instance. Only applicable if storage_type is io1, io2, or gp3."
   type        = number
-  default     = 10000
+  default     = 12000
+  validation {
+    condition = (
+      var.postgres_storage_type != "gp3" ||
+      var.postgres_storage_size < 400 ||
+      var.postgres_storage_iops >= 12000
+    )
+    error_message = "For gp3 storage with size >= 400GB: IOPS must be greater than or equal to 12000."
+  }
 }
 
 variable "postgres_storage_throughput" {
   description = "Throughput for the RDS instance. Only applicable if storage_type is gp3."
   type        = number
   default     = 500
+  validation {
+    condition = (
+      var.postgres_storage_type != "gp3" ||
+      var.postgres_storage_size < 400 ||
+      var.postgres_storage_throughput >= 500
+    )
+    error_message = "For gp3 storage with size >= 400GB: throughput must be at least 500."
+  }
 }
 
 variable "postgres_version" {


### PR DESCRIPTION
When creating a gp3 volume >= 400GB there are minimum IOPS and Throughput limits that are different than standard gp3 disks. It must be a minimum of 12000 IOPS and 500 Mbps throughput. Our module defaults were causing apply errors because of this. 

The default IOPS was changed to 12000 and variable validation blocks were added so this can be discovered in the plan phase.

Limits documented here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html