### PR TITLE
feat(brainstore): add memory metrics to ec2 instances

### DIFF
--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -68,6 +68,7 @@ wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/$arch/latest/amazon-
 dpkg -i amazon-cloudwatch-agent.deb
 
 # Configure CloudWatch agent
+# Configure CloudWatch agent (logs + memory)
 cat <<EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
 {
   "logs": {
@@ -80,8 +81,34 @@ cat <<EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
             "log_group_name": "/braintrust/${deployment_name}/brainstore",
             "log_stream_name": "{instance_id}/containers",
             "timezone": "UTC"
+          },
+          {
+            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+            "log_group_name": "/braintrust/${deployment_name}/brainstore",
+            "log_stream_name": "{instance_id}/cloudwatch-agent",
+            "timezone": "UTC"
           }
         ]
+      }
+    }
+  },
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "\$${aws:InstanceId}"
+    },
+    "aggregation_dimensions": [
+      ["InstanceId"],
+      []
+    ],
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          {"name":"mem_used_percent","rename":"MemoryUtilization","unit":"Percent"},
+          {"name":"mem_used","unit":"Bytes"},
+          {"name":"mem_available","unit":"Bytes"},
+          {"name":"mem_total","unit":"Bytes"}
+        ],
+        "metrics_collection_interval": 60
       }
     }
   }

--- a/modules/services-common/iam-brainstore.tf
+++ b/modules/services-common/iam-brainstore.tf
@@ -110,6 +110,30 @@ resource "aws_iam_role_policy" "brainstore_secrets_access" {
   })
 }
 
+resource "aws_iam_role_policy" "brainstore_cloudwatch_metrics" {
+  name = "cloudwatch-agent-metrics"
+  role = aws_iam_role.brainstore_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect : "Allow",
+        Action : ["cloudwatch:PutMetricData"],
+        Resource : "*",
+        Condition : {
+          StringEquals : { "cloudwatch:namespace" : "CWAgent" }
+        }
+      },
+      {
+        Effect : "Allow",
+        Action : ["ec2:DescribeTags"],
+        Resource : "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "brainstore_cloudwatch_logs_access" {
   name = "cloudwatch-logs-access"
   role = aws_iam_role.brainstore_role.id


### PR DESCRIPTION
* Adds EC2 memory cloudwatch metrics to the userdata template
* Adds EC2 IAM policy to include corresponding permissions for ^^

Optional, helpful changes I can remove:
* Adds cloudwatch logs for the cloudwatch agent itself to help with debugging

## Testing

I rebased this branch on tag `v3.0.0` and applied it. I see the following now included in the EC2 Monitoring page

<img width="1653" height="789" alt="image" src="https://github.com/user-attachments/assets/7ff8c962-47f0-4fd4-8d1d-ea98c5edd2d9" />
