### PR TITLE
Enable bucket versioning and expiration

### DIFF
--- a/modules/services/s3.tf
+++ b/modules/services/s3.tf
@@ -121,8 +121,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "lambda_responses_bucket" {
     }
 
     expiration {
-      days                         = 1
-      expired_object_delete_marker = true
+      days = 1
     }
 
     abort_incomplete_multipart_upload {


### PR DESCRIPTION
Enable versioning on all remaining buckets. This is mainly a best practice and meant to silence automated scanners that flag it. 

Enable lifecycle policies on the code bundle bucket to:
* Delete old versions of objects after a day (we have no use for them)
* Delete delete markers
* Current versions **will not** be deleted

Enable lifecycle policies on the lambda responses bucket to:
* Delete everything that is a day old (existing objects, noncurrent versions, delete markers)
* Lambda responses are temporary and aren't needed beyond a day