### PR TITLE
Enable connection termination deregistration on NLBs

### DIFF
--- a/modules/brainstore/main-writer.tf
+++ b/modules/brainstore/main-writer.tf
@@ -111,6 +111,7 @@ resource "aws_lb_target_group" "brainstore_writer" {
   vpc_id      = var.vpc_id
   target_type = "instance"
 
+  connection_termination = true
   health_check {
     protocol            = "TCP"
     port                = var.port

--- a/modules/brainstore/main.tf
+++ b/modules/brainstore/main.tf
@@ -118,6 +118,7 @@ resource "aws_lb_target_group" "brainstore" {
   vpc_id      = var.vpc_id
   target_type = "instance"
 
+  connection_termination = true
   health_check {
     protocol            = "TCP"
     port                = var.port


### PR DESCRIPTION
In case connections still exist at the end of the deregistration delay, this will ensure the clients are notified that they're closed.