### PR TITLE
Increase health check grace period on brainstore instances

### DIFF
--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -145,7 +145,7 @@ resource "aws_autoscaling_group" "brainstore_writer" {
   desired_capacity          = var.writer_instance_count
   vpc_zone_identifier       = var.private_subnet_ids
   health_check_type         = "EBS,ELB"
-  health_check_grace_period = 60
+  health_check_grace_period = 180
   target_group_arns         = [aws_lb_target_group.brainstore_writer[0].arn]
   wait_for_elb_capacity     = var.writer_instance_count
   launch_template {

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -154,7 +154,7 @@ resource "aws_autoscaling_group" "brainstore" {
   health_check_type   = "EBS,ELB"
   # This is essentially the expected boot and setup time of the instance.
   # If too low, the ASG may terminate the instance before it has a chance to boot.
-  health_check_grace_period = 60
+  health_check_grace_period = 180
   target_group_arns         = [aws_lb_target_group.brainstore.arn]
   wait_for_elb_capacity     = var.instance_count
   launch_template {


### PR DESCRIPTION
Give more time for the brainstore containers to start before starting health checks on the load balancer.