### PR TITLE
Add KMS encryption for RDS Performance Insights data

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -42,6 +42,7 @@ resource "aws_db_instance" "main" {
 
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
+  performance_insights_kms_key_id       = var.kms_key_arn
 
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   deletion_protection        = !var.DANGER_disable_deletion_protection


### PR DESCRIPTION
Configures RDS Performance Insights to use customer-managed KMS key encryption, ensuring consistent encryption standards across all database components.

Problem

Performance Insights is currently enabled for the RDS instance but does not specify a KMS key for encryption. Without the performance_insights_kms_key_id parameter, Performance Insights data is encrypted using AWS-managed keys instead of the customer-managed KMS key that encrypts the database itself.

Solution

Added performance_insights_kms_key_id = var.kms_key_arn to the RDS instance configuration in modules/database/main.tf. This ensures Performance Insights metrics and data use the same customer-managed KMS key as the database storage (already configured via kms_key_id).

Impact

- Security: Performance Insights data now uses customer-managed encryption, providing consistent key management
- Compliance: Aligns with security best practices requiring all data encrypted with organization-controlled keys
- No breaking changes: This is a configuration enhancement that applies encryption to existing Performance Insights data
