### PR TITLE
Add CloudWatch Log Groups with Retention for Lambda Functions

### DIFF
--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -49,6 +49,27 @@ resource "aws_kms_key" "braintrust" {
           Resource = "*"
         },
         {
+          Sid    = "Allow CloudWatch Logs to use the key"
+          Effect = "Allow"
+          Principal = {
+            Service = "logs.${data.aws_region.current.id}.amazonaws.com"
+          }
+          Action = [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey",
+            "kms:CreateGrant"
+          ]
+          Resource = "*"
+          Condition = {
+            ArnLike = {
+              "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:*"
+            }
+          }
+        },
+        {
           Sid    = "Allow attachment of persistent resources"
           Effect = "Allow"
           Principal = {
@@ -83,3 +104,5 @@ resource "aws_kms_alias" "braintrust" {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -7,7 +7,6 @@ locals {
 resource "aws_cloudwatch_log_group" "ai_proxy" {
   name              = "/braintrust/${var.deployment_name}/${local.ai_proxy_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -3,6 +3,15 @@ locals {
   ai_proxy_function_name      = "${var.deployment_name}-${local.ai_proxy_base_function_name}"
   ai_proxy_original_handler   = "index.handler"
 }
+
+resource "aws_cloudwatch_log_group" "ai_proxy" {
+  name              = "/braintrust/${var.deployment_name}/${local.ai_proxy_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "ai_proxy" {
   depends_on = [aws_lambda_invocation.invoke_database_migration]
 

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -7,12 +7,16 @@ locals {
 resource "aws_cloudwatch_log_group" "ai_proxy" {
   name              = "/braintrust/${var.deployment_name}/${local.ai_proxy_function_name}"
   retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }
 
 resource "aws_lambda_function" "ai_proxy" {
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.ai_proxy
+  ]
 
   function_name                  = local.ai_proxy_function_name
   s3_bucket                      = local.lambda_s3_bucket

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -56,7 +56,6 @@ locals {
 resource "aws_cloudwatch_log_group" "api_handler" {
   name              = "/braintrust/${var.deployment_name}/${local.api_handler_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -53,6 +53,14 @@ locals {
   }
 }
 
+resource "aws_cloudwatch_log_group" "api_handler" {
+  name              = "/braintrust/${var.deployment_name}/${local.api_handler_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "api_handler" {
   # Require the DB migrations to be run before the API handler is deployed
   depends_on = [aws_lambda_invocation.invoke_database_migration]

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -56,13 +56,17 @@ locals {
 resource "aws_cloudwatch_log_group" "api_handler" {
   name              = "/braintrust/${var.deployment_name}/${local.api_handler_function_name}"
   retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }
 
 resource "aws_lambda_function" "api_handler" {
   # Require the DB migrations to be run before the API handler is deployed
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.api_handler
+  ]
 
   function_name                  = local.api_handler_function_name
   s3_bucket                      = local.lambda_s3_bucket

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -4,6 +4,14 @@ locals {
   automation_cron_original_handler   = "index.handler"
 }
 
+resource "aws_cloudwatch_log_group" "automation_cron" {
+  name              = "/braintrust/${var.deployment_name}/${local.automation_cron_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "automation_cron" {
   depends_on = [aws_lambda_invocation.invoke_database_migration]
 

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -7,7 +7,6 @@ locals {
 resource "aws_cloudwatch_log_group" "automation_cron" {
   name              = "/braintrust/${var.deployment_name}/${local.automation_cron_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -12,7 +12,10 @@ resource "aws_cloudwatch_log_group" "automation_cron" {
 }
 
 resource "aws_lambda_function" "automation_cron" {
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.automation_cron
+  ]
 
   function_name = local.automation_cron_function_name
   s3_bucket     = local.lambda_s3_bucket

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -4,6 +4,13 @@ locals {
   billing_cron_original_handler   = "lambda.handler"
 }
 
+resource "aws_cloudwatch_log_group" "billing_cron" {
+  name              = "/braintrust/${var.deployment_name}/${local.billing_cron_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
 
 resource "aws_lambda_function" "billing_cron" {
   depends_on = [aws_lambda_invocation.invoke_database_migration]

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -7,7 +7,6 @@ locals {
 resource "aws_cloudwatch_log_group" "billing_cron" {
   name              = "/braintrust/${var.deployment_name}/${local.billing_cron_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -12,7 +12,10 @@ resource "aws_cloudwatch_log_group" "billing_cron" {
 }
 
 resource "aws_lambda_function" "billing_cron" {
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.billing_cron
+  ]
 
   function_name = local.billing_cron_function_name
   s3_bucket     = local.lambda_s3_bucket

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -7,12 +7,16 @@ locals {
 resource "aws_cloudwatch_log_group" "catchup_etl" {
   name              = "/braintrust/${var.deployment_name}/${local.catchup_etl_function_name}"
   retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }
 
 resource "aws_lambda_function" "catchup_etl" {
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.catchup_etl
+  ]
 
   function_name = local.catchup_etl_function_name
   s3_bucket     = local.lambda_s3_bucket

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -4,6 +4,14 @@ locals {
   catchup_etl_original_handler   = "index.handler"
 }
 
+resource "aws_cloudwatch_log_group" "catchup_etl" {
+  name              = "/braintrust/${var.deployment_name}/${local.catchup_etl_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "catchup_etl" {
   depends_on = [aws_lambda_invocation.invoke_database_migration]
 

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -7,7 +7,6 @@ locals {
 resource "aws_cloudwatch_log_group" "catchup_etl" {
   name              = "/braintrust/${var.deployment_name}/${local.catchup_etl_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -7,7 +7,6 @@ locals {
 resource "aws_cloudwatch_log_group" "migrate_database" {
   name              = "/braintrust/${var.deployment_name}/${local.migrate_database_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -4,6 +4,14 @@ locals {
   migrate_database_original_handler   = "lambda_function.lambda_handler"
 }
 
+resource "aws_cloudwatch_log_group" "migrate_database" {
+  name              = "/braintrust/${var.deployment_name}/${local.migrate_database_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "migrate_database" {
   function_name = local.migrate_database_function_name
   s3_bucket     = local.lambda_s3_bucket

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -7,11 +7,14 @@ locals {
 resource "aws_cloudwatch_log_group" "migrate_database" {
   name              = "/braintrust/${var.deployment_name}/${local.migrate_database_function_name}"
   retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }
 
 resource "aws_lambda_function" "migrate_database" {
+  depends_on = [aws_cloudwatch_log_group.migrate_database]
+
   function_name = local.migrate_database_function_name
   s3_bucket     = local.lambda_s3_bucket
   s3_key        = local.lambda_versions[local.migrate_database_base_function_name]

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_log_group" "quarantine_warmup" {
 
   name              = "/braintrust/${var.deployment_name}/${local.quarantine_warmup_function_name}"
   retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }
@@ -16,7 +17,10 @@ resource "aws_cloudwatch_log_group" "quarantine_warmup" {
 resource "aws_lambda_function" "quarantine_warmup" {
   count = var.use_quarantine_vpc ? 1 : 0
 
-  depends_on = [aws_lambda_invocation.invoke_database_migration]
+  depends_on = [
+    aws_lambda_invocation.invoke_database_migration,
+    aws_cloudwatch_log_group.quarantine_warmup
+  ]
 
   function_name = local.quarantine_warmup_function_name
   s3_bucket     = local.lambda_s3_bucket

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -4,6 +4,16 @@ locals {
   quarantine_warmup_original_handler   = "index.handler"
 }
 
+resource "aws_cloudwatch_log_group" "quarantine_warmup" {
+  count = var.use_quarantine_vpc ? 1 : 0
+
+  name              = "/braintrust/${var.deployment_name}/${local.quarantine_warmup_function_name}"
+  retention_in_days = 90
+  kms_key_id        = var.kms_key_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_lambda_function" "quarantine_warmup" {
   count = var.use_quarantine_vpc ? 1 : 0
 

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -9,7 +9,6 @@ resource "aws_cloudwatch_log_group" "quarantine_warmup" {
 
   name              = "/braintrust/${var.deployment_name}/${local.quarantine_warmup_function_name}"
   retention_in_days = 90
-  kms_key_id        = var.kms_key_arn
 
   tags = local.common_tags
 }


### PR DESCRIPTION
Creates explicit CloudWatch log groups with 90-day retention policies for all Lambda functions to prevent indefinite log storage and reduce costs.

Problem
Lambda functions currently reference log groups in their logging_config, but these log groups aren't explicitly created with retention policies. AWS automatically creates them with indefinite retention, causing logs to accumulate forever and unnecessarily increase storage costs.

Solution
Added aws_cloudwatch_log_group resources for each Lambda function with:
- 90-day retention period - balances compliance/debugging needs with cost management
- KMS encryption - consistent with other infrastructure encryption standards
- Lifecycle management - logs automatically expire after retention period

Impact
- Cost optimization: Automated cleanup of old logs prevents unbounded storage growth
- Security: Log data encrypted with customer-managed KMS key
- Operational: 90 days provides sufficient window for troubleshooting and compliance
- No breaking changes: Log groups created before Lambda functions deploy
