### PR TITLE
add ingestion endpoint for gateway

### DIFF
--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -555,6 +555,9 @@ locals {
       "/billing/refresh" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }
+      "/billing/telemetry/ingest" = {
+        for method in ["options", "post"] : method => local.snippet_api_json_text_method
+      }
       "/brainstore/time_based_retention/status" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }


### PR DESCRIPTION
This endpoint enables pre-aggregation for telemetry events. https://github.com/braintrustdata/braintrust/commit/d2fd4d69b4f05f5a547f1fe0bcd988f8a0f52cff