### PR TITLE
Replace hardcoded memory_limit values on API and AI Proxy lambdas

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,9 @@ module "services" {
   primary_org_name                           = var.primary_org_name
   api_handler_provisioned_concurrency        = var.api_handler_provisioned_concurrency
   api_handler_reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
+  api_handler_memory_limit                   = var.api_handler_memory_limit
   ai_proxy_reserved_concurrent_executions    = var.ai_proxy_reserved_concurrent_executions
+  ai_proxy_memory_limit                      = var.ai_proxy_memory_limit
   whitelisted_origins                        = var.whitelisted_origins
   outbound_rate_limit_window_minutes         = var.outbound_rate_limit_window_minutes
   outbound_rate_limit_max_requests           = var.outbound_rate_limit_max_requests
@@ -382,5 +384,3 @@ module "brainstore" {
   cache_file_size_writer     = var.brainstore_cache_file_size_writer
   locks_s3_path              = var.brainstore_locks_s3_path
 }
-
-

--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "ai_proxy" {
   handler                        = local.observability_enabled ? local.nodejs_datadog_handler : local.ai_proxy_original_handler
   runtime                        = "nodejs22.x"
   architectures                  = ["arm64"]
-  memory_size                    = 10240 # Max that lambda supports
+  memory_size                    = var.ai_proxy_memory_limit
   reserved_concurrent_executions = var.ai_proxy_reserved_concurrent_executions
   timeout                        = 900
   publish                        = true

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "api_handler" {
   role                           = var.api_handler_role_arn
   handler                        = local.observability_enabled ? local.nodejs_datadog_handler : local.api_handler_original_handler
   runtime                        = "nodejs22.x"
-  memory_size                    = 10240 # Max that lambda supports
+  memory_size                    = var.api_handler_memory_limit
   reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
   timeout                        = 600
   publish                        = true

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -159,10 +159,32 @@ variable "api_handler_reserved_concurrent_executions" {
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
 }
 
+variable "api_handler_memory_limit" {
+  type        = number
+  description = "The maximum memory in MB for the API Handler."
+  default     = 10240
+
+  validation {
+    condition     = var.api_handler_memory_limit <= 10240
+    error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
+  }
+}
+
 variable "ai_proxy_reserved_concurrent_executions" {
   type        = number
   description = "The number of concurrent executions to reserve for the AI Proxy. Setting this will prevent the AI Proxy from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
+variable "ai_proxy_memory_limit" {
+  type        = number
+  description = "The maximum memory in MB for the AI Proxy."
+  default     = 10240
+
+  validation {
+    condition     = var.ai_proxy_memory_limit <= 10240
+    error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
+  }
 }
 
 variable "run_draft_migrations" {

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -165,7 +165,7 @@ variable "api_handler_memory_limit" {
   default     = 10240
 
   validation {
-    condition     = var.api_handler_memory_limit <= 10240
+    condition     = var.api_handler_memory_limit > 0 && var.api_handler_memory_limit <= 10240
     error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
   }
 }
@@ -182,7 +182,7 @@ variable "ai_proxy_memory_limit" {
   default     = 10240
 
   validation {
-    condition     = var.ai_proxy_memory_limit <= 10240
+    condition     = var.ai_proxy_memory_limit > 0 && var.ai_proxy_memory_limit <= 10240
     error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -485,7 +485,7 @@ variable "api_handler_memory_limit" {
   default     = 10240
 
   validation {
-    condition     = var.api_handler_memory_limit <= 10240
+    condition     = var.api_handler_memory_limit > 0 && var.api_handler_memory_limit <= 10240
     error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
   }
 }
@@ -502,7 +502,7 @@ variable "ai_proxy_memory_limit" {
   default     = 10240
 
   validation {
-    condition     = var.ai_proxy_memory_limit <= 10240
+    condition     = var.ai_proxy_memory_limit > 0 && var.ai_proxy_memory_limit <= 10240
     error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -479,10 +479,32 @@ variable "api_handler_reserved_concurrent_executions" {
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
 }
 
+variable "api_handler_memory_limit" {
+  type        = number
+  description = "The maximum memory in MB for the API Handler."
+  default     = 10240
+
+  validation {
+    condition     = var.api_handler_memory_limit <= 10240
+    error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
+  }
+}
+
 variable "ai_proxy_reserved_concurrent_executions" {
   description = "The number of concurrent executions to reserve for the AI Proxy. Setting this will prevent the AI Proxy from throttling other lambdas in your account. Note this will take away from your global concurrency limit in your AWS account."
   type        = number
   default     = -1 # -1 means no reserved concurrency. Use up to the max concurrency limit in your AWS account.
+}
+
+variable "ai_proxy_memory_limit" {
+  type        = number
+  description = "The maximum memory in MB for the AI Proxy."
+  default     = 10240
+
+  validation {
+    condition     = var.ai_proxy_memory_limit <= 10240
+    error_message = "The maximum supported value by AWS Lambda is 10240 MB (10 GB)."
+  }
 }
 
 variable "disable_billing_telemetry_aggregation" {


### PR DESCRIPTION
New variables default to the prior hardcoded values. This is needed for BYOC deployments that do not have the Lambda max memory limit (10GB)