### PR TITLE
Increase nofile limit to 65k for brainstore

### DIFF
--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -243,6 +243,7 @@ docker run -d \
   --name brainstore \
   --env-file /etc/brainstore.env \
   --restart always \
+  --ulimit nofile=65535:65535 \
   -v /mnt/tmp/brainstore:/mnt/tmp/brainstore \
   public.ecr.aws/braintrust/brainstore:$${BRAINSTORE_VERSION} \
   web


### PR DESCRIPTION
Brainstore processes may need to open more than the default of 1024 files.