### PR TITLE
Data Plane 2.0 image tags and WAL v3 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Braintrust Terraform Module
 
+For the latest guidance, always refer to the official Braintrust documentation:
+- [Self-hosting overview](https://www.braintrust.dev/docs/admin/self-hosting)
+- [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2)
+
 This module is used to create the VPC, Databases, Lambdas, and associated resources for the self-hosted Braintrust data plane.
 
 ## How to use this module

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -57,22 +57,12 @@ module "braintrust-data-plane" {
   brainstore_writer_instance_count = 1
   brainstore_writer_instance_type  = "c8gd.xlarge"
 
-  ### WARNING: The following two settings are safe for fresh sandbox/environment deployments
+  ### WARNING: skip_pg_for_brainstore_objects is safe for fresh sandbox deployments
   ### but can cause data loss or downtime if applied incorrectly to existing
-  ### production environments. Do NOT copy these values into a production
-  ### configuration without following the upgrade guide.
-  ###
-  ### - skip_pg_for_brainstore_objects is a ONE-WAY operation that cannot be
-  ###   rolled back without downtime. Production deployments should test
-  ###   incrementally (include:<project_uuid>) before setting to "all".
-  ###
-  ### - brainstore_wal_footer_version must be set in a SEPARATE apply after
-  ###   all Brainstore nodes are confirmed running the target version. Setting
-  ###   it during a version bump will cause read failures on nodes still rolling
-  ###   out. Fresh deployments have no existing nodes, so this is safe here.
+  ### production environments. It is a ONE-WAY operation that cannot be rolled
+  ### back without downtime. See the upgrade guide before enabling in production.
 
-  skip_pg_for_brainstore_objects = ""
-  brainstore_wal_footer_version  = "v1"
+  skip_pg_for_brainstore_objects = "all"
 
   # Disable the quarantine VPC to simplify the sandbox deployment.
   # This disables user-defined function execution (scorers, tools) but avoids

--- a/modules/brainstore-ec2/VERSIONS.json
+++ b/modules/brainstore-ec2/VERSIONS.json
@@ -1,3 +1,3 @@
 {
-    "brainstore": "v1.1.32"
+    "brainstore": "v2.0.0"
 }

--- a/modules/services/VERSIONS.json
+++ b/modules/services/VERSIONS.json
@@ -1,3 +1,3 @@
 {
-    "lambda_version_tag": "v1.1.32"
+    "lambda_version_tag": "v2.0.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -682,7 +682,7 @@ variable "brainstore_etl_batch_size" {
 variable "brainstore_wal_footer_version" {
   type        = string
   description = "This controls the WAL footer version that should be written. When set, also enables BRAINSTORE_WAL_USE_EFFICIENT_FORMAT on the API handler. Only adjust this to 'v3' after you have successfully deployed v2.x of the data plane."
-  default     = ""
+  default     = "v3"
   validation {
     condition     = var.brainstore_wal_footer_version == "" || contains(["v1", "v2", "v3"], var.brainstore_wal_footer_version)
     error_message = "brainstore_wal_footer_version must be v1, v2, v3, or empty string (unset)."


### PR DESCRIPTION
This release upgrades the Braintrust data plane to version 2.0. It includes updated container images for the API and Brainstore services, and sets the WAL footer version to v3 by default, enabling the efficient write-ahead log format that 2.0 requires.

- Bump API and Brainstore container images to v2.0.0
- Default `brainstore_wal_footer_version` to `"v3"` (was `""`)

For upgrade instructions, see the [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2).