### PR TITLE
Default no-PG mode to "all"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,13 @@ Python scripts in `scripts/` use `#!/usr/bin/env -S uv run --script` with inline
 
 ## Critical Safety Constraints
 
-### Upgrade Sequencing
+### Upgrade Sequencing (for customers upgrading from pre-2.0)
 
-- **Never set `skip_pg_for_brainstore_objects` on Data Plane versions before 2.0.** A known bug on 1.1.32 was fixed in the 2.0 images. The correct sequence is: 1.1.32 -> WAL v1 -> 2.0 + WAL v3 -> no-PG.
+These constraints apply to customers migrating from Data Plane 1.x to 2.0. New deployments on 2.0+ ship with WAL v3 and no-PG defaults baked in.
+
+- **Never set `skip_pg_for_brainstore_objects` on Data Plane versions before 2.0.** A known bug on 1.1.32 was fixed in the 2.0 images. The correct upgrade sequence is: 1.1.32 -> WAL v1 -> 2.0 + WAL v3 -> no-PG.
 - **`brainstore_wal_footer_version` must be set in a separate apply after all Brainstore nodes are running the target version.** Old nodes cannot read the new WAL format during rollout. Exception: bumping v1 to v3 can be done in the same apply as the 2.0 image upgrade because all 2.0 nodes understand v3.
-- **`skip_pg_for_brainstore_objects` is a one-way operation.** Once enabled for an object type, it cannot be rolled back without downtime. Do not default this to any non-empty value.
+- **`skip_pg_for_brainstore_objects` is a one-way operation.** Once enabled for an object type, it cannot be rolled back without downtime.
 
 ### WAL_USE_EFFICIENT_FORMAT Decoupling
 

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -67,18 +67,6 @@ module "braintrust-data-plane" {
   brainstore_writer_instance_count = 1
   brainstore_writer_instance_type  = "c8gd.8xlarge"
 
-  ### No-PG mode (Brainstore direct writes)
-  # Controls which object types bypass PostgreSQL and write directly to Brainstore.
-  # WARNING: This is a one-way operation. Once enabled, objects cannot be migrated back
-  # to PostgreSQL without downtime.
-  # Options:
-  #   - "" (default): disabled, PostgreSQL used as normal
-  #   - "all": skip PostgreSQL for all object types
-  #   - "include:<type>:<uuid>,...": skip for specific objects only (for testing)
-  #   - "exclude:<type>:<uuid>,...": skip for all objects except specific ones
-  # Recommended: test with "include:" on a single project first, then move to "all".
-  skip_pg_for_brainstore_objects = ""
-
   ### Redis configuration
 
   # Default is acceptable for typical production deployments.

--- a/variables.tf
+++ b/variables.tf
@@ -692,7 +692,7 @@ variable "brainstore_wal_footer_version" {
 variable "skip_pg_for_brainstore_objects" {
   type        = string
   description = "Controls which object types bypass PostgreSQL and write directly to Brainstore. WARNING: This is a one-way operation. Once migrated off Postgres, objects cannot be un-migrated without downtime. When set, also enables BRAINSTORE_ASYNC_SCORING_OBJECTS / BRAINSTORE_LOG_AUTOMATIONS_OBJECTS on Brainstore nodes."
-  default     = ""
+  default     = "all"
   validation {
     condition     = var.skip_pg_for_brainstore_objects == "" || var.skip_pg_for_brainstore_objects == "all" || startswith(var.skip_pg_for_brainstore_objects, "include:") || startswith(var.skip_pg_for_brainstore_objects, "exclude:")
     error_message = "skip_pg_for_brainstore_objects must be an empty string (disabled), \"all\", or start with \"include:\" or \"exclude:\"."


### PR DESCRIPTION
With Data Plane 2.0, Brainstore direct writes (no-PG mode) are production-ready and recommended for all deployments. This release changes the default from disabled to "all", so new deployments and upgrades automatically bypass PostgreSQL for Brainstore object writes.

- Default `skip_pg_for_brainstore_objects` to `"all"` (was `""`)
- Simplify production example to reflect new default

For details, see the [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2).