### PR TITLE
Add fully Terraform-managed EKS deployment mode

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,0 +1,103 @@
+# Terraform ↔ Helm Contract
+
+This Terraform module is paired with the Braintrust Helm chart in
+[`braintrustdata/helm`](https://github.com/braintrustdata/helm). When
+`create_eks_cluster = true` (EKS deployment mode), the module provisions
+AWS infrastructure that the Helm chart expects to consume, and the Helm
+release in turn must match a set of names, ports, and keys this module
+hardcodes into IAM trust policies and security groups.
+
+The coupling surface is small, but **several items fail silently at pod
+runtime, not at `terraform apply`**. This document enumerates them so
+that a PR to either side can check it hasn't broken the other.
+
+## Pinned chart compatibility
+
+| Field | Value |
+|---|---|
+| Braintrust Helm chart | `oci://public.ecr.aws/braintrust/helm` |
+| Tested chart version | `5.0.1` |
+| Supported range | `5.x` (no hard validation today — revisit when 6.x ships) |
+
+The `helm_chart_version` variable in `examples/braintrust-data-plane-eks/`
+has no default — consumers must pin.
+
+## Coupling surfaces
+
+Anything the module *writes into the chart values* OR *trusts the chart
+to name* is listed here. If you change either side, audit this list.
+
+### Names and identifiers
+
+| Thing | TF location | Chart location | Failure mode |
+|---|---|---|---|
+| API service account name `braintrust-api` | IRSA `sub` claim in API handler role trust policy (computed in `modules/eks-cluster/iam.tf` `locals.api_iam_trust_policy`, with SA name from `var.api_service_account_name`) | `api.serviceAccount.name` default in chart `values.yaml` | **Silent runtime**: pod starts, `AssumeRoleWithWebIdentity` is rejected, every AWS SDK call returns 403 |
+| Brainstore service account name `brainstore` | IRSA `sub` claim in Brainstore role trust policy (computed in `modules/eks-cluster/iam.tf` `locals.brainstore_iam_trust_policy`, with SA name from `var.brainstore_service_account_name`) | `brainstore.serviceAccount.name` default | Silent runtime (same as above) |
+| LB Controller service account `kube-system:aws-load-balancer-controller` | `aws_iam_role.lb_controller` trust policy in `modules/eks-cluster/iam.tf` | AWS LB Controller helm chart (upstream, not ours) | LB Controller fails to create NLB targets; API service stays unreachable |
+| K8s Secret name `braintrust-secrets` | `kubernetes_secret.braintrust` in `modules/eks-deploy/main.tf` | `api-deployment.yaml` and `brainstore-*-deployment.yaml` hardcode `secretKeyRef.name: braintrust-secrets` | Pod fails to start: `CreateContainerConfigError` |
+| Secret keys `PG_URL`, `REDIS_URL`, `FUNCTION_SECRET_KEY`, `BRAINSTORE_LICENSE_KEY` | `data = { ... }` in `kubernetes_secret.braintrust` (`modules/eks-deploy/main.tf`) | Referenced in chart deployment templates | Pod fails to start (missing env var key) |
+| Namespace | `var.eks_namespace` → `kubernetes_namespace.braintrust` in `modules/eks-deploy/main.tf` + passed as template `namespace` var | `global.namespace` (used in configmap to build `BRAINSTORE_*_URL`); runtime namespace resolved via `braintrust.namespace` helper to `.Release.Namespace` when `createNamespace: false` | Pods run in wrong namespace; intra-cluster DNS fails |
+
+### Network / ports
+
+| Thing | TF location | Chart location | Failure mode |
+|---|---|---|---|
+| API service port `8000` | `aws_cloudfront_vpc_origin.api.http_port` in `modules/eks-cluster/cloudfront.tf`, NLB target port implicit via LB Controller | `api.service.port` default `8000`; `api-deployment.yaml` containerPort | **Silent at deploy**: CloudFront → NLB → node NodePort path dead |
+| NodePort range `30000-32767` | `aws_vpc_security_group_ingress_rule.eks_nodes_from_nlb` in `modules/eks-cluster/networking.tf` | Kubernetes kube-apiserver default (outside our control) | Would require K8s project default change — very low risk |
+| Pre-created NLB adopted by chart via `service.beta.kubernetes.io/aws-load-balancer-name` | `aws_lb.api.name` in `modules/eks-cluster/networking.tf` (exposed as the root's `eks_nlb_name` output) | `api.annotations.service.*` — controller reads this annotation | If chart renames the annotation or consumer unsets it, the controller creates a parallel NLB; CloudFront VPC Origin points at the orphan |
+| NLB security group | `aws_security_group.nlb_cloudfront` in `modules/eks-cluster/networking.tf` (NLBs only accept SGs at creation; cannot be added later) | `service.beta.kubernetes.io/aws-load-balancer-security-groups` in `api.annotations.service` | Adopted NLB gets wrong SG; CloudFront can't reach it |
+
+### Helm values schema written by the module template
+
+The template lives at `modules/eks-deploy/assets/helm-values.yaml.tpl`.
+Any of these keys moving or renaming in the chart breaks us silently
+(the template writes a dead key, the chart uses its own default).
+
+- `global.orgName`
+- `global.createNamespace`
+- `global.namespace`
+- `cloud` (set to `"aws"`)
+- `skipPgForBrainstoreObjects`
+- `brainstoreWalFooterVersion`
+- `objectStorage.aws.brainstoreBucket`
+- `objectStorage.aws.responseBucket`
+- `objectStorage.aws.codeBundleBucket`
+- `api.service.type` (set to `LoadBalancer`)
+- `api.annotations.service.*` (the four NLB annotations)
+- `api.serviceAccount.awsRoleArn`
+- `brainstore.serviceAccount.awsRoleArn`
+
+### Feature-flag value domains
+
+- `brainstoreWalFooterVersion` — TF validation allows `""`, `"v1"`, `"v2"`, `"v3"` (see `variables.tf`). Chart must accept the same set; when the chart adds a new version, TF validation needs updating.
+- `skipPgForBrainstoreObjects` — TF allows `""`, `"all"`, `"include:…"`, `"exclude:…"`. Chart passes through unchanged.
+
+### Assumptions baked into the contract
+
+- **EKS mode assumes a fast reader is always deployed.** The chart defaults `brainstore.fastreader.replicas = 2` and unconditionally emits `BRAINSTORE_FAST_READER_URL` + `BRAINSTORE_FAST_READER_QUERY_SOURCES` from `api-configmap.yaml`, so the API always believes fast readers are available. This differs from EC2 Brainstore mode where `brainstore_fast_reader_instance_count = 0` is a supported "disabled" state (the services module conditionally omits the env vars). In EKS mode we intentionally do not support the 0-replicas case — users who scale `eks_brainstore_fastreader_helm.replicas` to 0 opt out of this contract and own the resulting query failures.
+
+## Checklist: making a change
+
+### Changing the TF module
+
+- If the change touches any row of a table above, open a matching issue/PR in `braintrustdata/helm`.
+- Regenerate `helm-values.yaml.tpl` and confirm every key still exists in the chart's `values.yaml`.
+- If you rename a service-account name or secret, update both the IRSA trust policy *and* the kubernetes_secret / chart values in the example.
+
+### Changing the Helm chart
+
+- If you rename any `.Values.*` key listed in the "Helm values schema" section, file an issue here to update `helm-values.yaml.tpl`.
+- If you rename an SA (`api.serviceAccount.name` or `brainstore.serviceAccount.name`) or change the hardcoded secret name in a deployment template, this module's IRSA trust policy breaks silently — file a coordinated PR.
+- If you change the API service port default away from 8000, ship a matching TF variable for `eks_api_service_port` or coordinate a default bump.
+- If you want to support `fastreader.replicas = 0` in EKS mode (parity with EC2's `brainstore_fast_reader_instance_count = 0`), gate the `BRAINSTORE_FAST_READER_URL` configmap entry on `replicas > 0` first, then update the assumption in this doc.
+
+### Bumping the chart version used in the example
+
+- Diff the chart's `values.yaml` between versions, scan for any key listed above.
+- Run `helm template` locally with this module's rendered values and grep for the hardcoded names/ports/keys listed in the tables.
+
+## Future: mechanical drift detection
+
+This document is a manual safety net. See `memory` notes for deferred
+ideas: CI smoke tests that render `helm template` with TF-shaped values
+and assert the contract, plus a symmetric test in the helm repo.

--- a/eks.tf
+++ b/eks.tf
@@ -1,0 +1,99 @@
+# Composition of the EKS cluster and EKS-deploy submodules.
+# All resource-level logic lives under modules/eks-cluster/ and
+# modules/eks-deploy/. This file is just wiring.
+
+locals {
+  # Kubernetes namespace the Braintrust workloads run in. Falls back to
+  # "braintrust" when var.eks_namespace is null (keeps the existing
+  # non-EKS behavior of the var while providing a sensible default here).
+  eks_namespace_resolved = coalesce(var.eks_namespace, "braintrust")
+
+  # Safe accessors for count-gated module outputs — one() returns null for empty lists.
+  eks_cluster_arn_val                 = one(module.eks_cluster[*].cluster_arn)
+  eks_cluster_name_val                = one(module.eks_cluster[*].cluster_name)
+  eks_cluster_endpoint_val            = one(module.eks_cluster[*].cluster_endpoint)
+  eks_cluster_ca_certificate_val      = one(module.eks_cluster[*].cluster_certificate_authority_data)
+  eks_oidc_provider_arn               = one(module.eks_cluster[*].oidc_provider_arn)
+  eks_node_security_group_id          = one(module.eks_cluster[*].node_security_group_id)
+  eks_api_iam_trust_policy            = one(module.eks_cluster[*].api_iam_trust_policy)
+  eks_brainstore_iam_trust_policy     = one(module.eks_cluster[*].brainstore_iam_trust_policy)
+  eks_lb_controller_role_arn          = one(module.eks_cluster[*].lb_controller_role_arn)
+  eks_nlb_arn_val                     = one(module.eks_cluster[*].nlb_arn)
+  eks_nlb_name_val                    = one(module.eks_cluster[*].nlb_name)
+  eks_nlb_security_group_id           = one(module.eks_cluster[*].nlb_security_group_id)
+  eks_cloudfront_domain_name          = one(module.eks_cluster[*].cloudfront_distribution_domain_name)
+  eks_cloudfront_arn                  = one(module.eks_cluster[*].cloudfront_distribution_arn)
+  eks_cloudfront_hosted_zone_id       = one(module.eks_cluster[*].cloudfront_distribution_hosted_zone_id)
+}
+
+module "eks_cluster" {
+  source = "./modules/eks-cluster"
+  count  = var.create_eks_cluster ? 1 : 0
+
+  deployment_name          = var.deployment_name
+  custom_tags              = var.custom_tags
+  permissions_boundary_arn = var.permissions_boundary_arn
+
+  vpc_id = local.main_vpc_id
+  private_subnet_ids = [
+    local.main_vpc_private_subnet_1_id,
+    local.main_vpc_private_subnet_2_id,
+    local.main_vpc_private_subnet_3_id,
+  ]
+
+  eks_namespace          = local.eks_namespace_resolved
+  eks_kubernetes_version = var.eks_kubernetes_version
+  eks_node_instance_type = var.eks_node_instance_type
+  eks_node_min_size      = var.eks_node_min_size
+  eks_node_max_size      = var.eks_node_max_size
+  eks_node_desired_size  = var.eks_node_desired_size
+
+  cloudfront_price_class = var.cloudfront_price_class
+  custom_domain          = var.custom_domain
+  custom_certificate_arn = var.custom_certificate_arn
+  waf_acl_id             = var.waf_acl_id
+}
+
+module "eks_deploy" {
+  source = "./modules/eks-deploy"
+  count  = var.create_eks_cluster ? 1 : 0
+
+  deployment_name     = var.deployment_name
+  custom_tags         = var.custom_tags
+  braintrust_org_name = var.braintrust_org_name
+  namespace           = local.eks_namespace_resolved
+
+  cluster_name           = module.eks_cluster[0].cluster_name
+  vpc_id                 = local.main_vpc_id
+  lb_controller_role_arn = module.eks_cluster[0].lb_controller_role_arn
+  nlb_security_group_id  = module.eks_cluster[0].nlb_security_group_id
+  nlb_name               = module.eks_cluster[0].nlb_name
+
+  # IAM role ARNs come from services_common, which in turn consumed the
+  # trust policies output by eks_cluster above. This forms a linear chain:
+  # eks_cluster -> services_common -> eks_deploy.
+  api_handler_role_arn    = module.services_common.api_handler_role_arn
+  brainstore_iam_role_arn = module.services_common.brainstore_iam_role_arn
+
+  brainstore_bucket_name  = module.storage.brainstore_bucket_id
+  response_bucket_name    = module.storage.lambda_responses_bucket_id
+  code_bundle_bucket_name = module.storage.code_bundle_bucket_id
+
+  postgres_host     = module.database.postgres_database_address
+  postgres_port     = module.database.postgres_database_port
+  postgres_username = module.database.postgres_database_username
+  postgres_password = module.database.postgres_database_password
+  redis_host        = module.redis.redis_endpoint
+  redis_port        = module.redis.redis_port
+
+  brainstore_license_key         = var.brainstore_license_key
+  brainstore_wal_footer_version  = var.brainstore_wal_footer_version
+  skip_pg_for_brainstore_objects = var.skip_pg_for_brainstore_objects
+
+  helm_chart_version         = var.helm_chart_version
+  api_helm                   = var.eks_api_helm
+  brainstore_reader_helm     = var.eks_brainstore_reader_helm
+  brainstore_fastreader_helm = var.eks_brainstore_fastreader_helm
+  brainstore_writer_helm     = var.eks_brainstore_writer_helm
+  helm_chart_extra_values    = var.eks_helm_chart_extra_values
+}

--- a/examples/braintrust-data-plane-eks/main.tf
+++ b/examples/braintrust-data-plane-eks/main.tf
@@ -1,0 +1,73 @@
+# tflint-ignore-file: terraform_module_pinned_source
+
+# Example: Fully Terraform-managed EKS-based Braintrust data plane.
+#
+# This example is a thin configuration layer — all logic (EKS cluster, OIDC,
+# addons, NLB, CloudFront, Kubernetes namespace + secret, Helm releases) lives
+# inside the module. The example just sets variables and configures providers.
+#
+# IMPORTANT — two-step apply required on first deployment:
+#
+#   Step 1: terraform apply -target=module.braintrust.module.eks[0]
+#   Step 2: terraform apply
+#
+# Step 1 creates the EKS cluster so the kubernetes/helm providers in
+# provider.tf can resolve the cluster endpoint via data.aws_eks_cluster.
+# Step 2 deploys the K8s namespace, secret, and Helm releases.
+
+module "braintrust" {
+  source = "../../"
+  # For production use, pin to a released version:
+  # source = "github.com/braintrustdata/terraform-braintrust-data-plane?ref=vX.Y.Z"
+
+  deployment_name        = var.deployment_name
+  braintrust_org_name    = var.braintrust_org_name
+  brainstore_license_key = var.brainstore_license_key
+
+  # EKS deployment mode — disables Lambda, EC2 Brainstore, and Lambda-based ingress
+  use_deployment_mode_external_eks = true
+  # Create and manage the EKS cluster with Terraform
+  create_eks_cluster = true
+
+  eks_namespace      = var.eks_namespace
+  helm_chart_version = var.helm_chart_version
+
+  brainstore_wal_footer_version  = var.brainstore_wal_footer_version
+  skip_pg_for_brainstore_objects = var.skip_pg_for_brainstore_objects
+
+  # Disable quarantine VPC (Lambda-based, not relevant for EKS mode)
+  enable_quarantine_vpc = false
+
+  ### Postgres
+  postgres_instance_type              = "db.r8g.2xlarge"
+  postgres_storage_size               = 1000
+  postgres_max_storage_size           = 10000
+  postgres_storage_type               = "gp3"
+  postgres_storage_iops               = 15000
+  postgres_storage_throughput         = 500
+  postgres_version                    = "15"
+  postgres_auto_minor_version_upgrade = true
+
+  ### Redis
+  redis_instance_type = "cache.t4g.medium"
+  redis_version       = "7.0"
+
+  ### Sandbox helm overrides (example — uncomment and adjust for smaller
+  ### deployments than the chart's production defaults assume).
+  # eks_node_instance_type = "c8gd.2xlarge"
+  # eks_node_desired_size  = 2
+  # eks_api_helm = {
+  #   replicas = 1
+  #   resources = {
+  #     requests = { cpu = "500m", memory = "1Gi" }
+  #     limits   = { cpu = "1",    memory = "2Gi" }
+  #   }
+  # }
+  # eks_brainstore_writer_helm = {
+  #   replicas = 1
+  #   resources = {
+  #     requests = { cpu = "1", memory = "2Gi" }
+  #     limits   = { cpu = "2", memory = "4Gi" }
+  #   }
+  # }
+}

--- a/examples/braintrust-data-plane-eks/outputs.tf
+++ b/examples/braintrust-data-plane-eks/outputs.tf
@@ -1,0 +1,24 @@
+output "api_url" {
+  value       = module.braintrust.api_url
+  description = "Braintrust API URL — enter this in the Braintrust dashboard under Settings > Data Plane > API URL"
+}
+
+output "eks_cluster_name" {
+  value       = module.braintrust.eks_cluster_name
+  description = "EKS cluster name"
+}
+
+output "eks_cluster_endpoint" {
+  value       = module.braintrust.eks_cluster_endpoint
+  description = "EKS cluster API server endpoint"
+}
+
+output "cloudfront_distribution_domain_name" {
+  value       = module.braintrust.cloudfront_distribution_domain_name
+  description = "CloudFront distribution domain name"
+}
+
+output "postgres_database_identifier" {
+  value       = module.braintrust.postgres_database_identifier
+  description = "RDS instance identifier"
+}

--- a/examples/braintrust-data-plane-eks/provider.tf
+++ b/examples/braintrust-data-plane-eks/provider.tf
@@ -1,0 +1,46 @@
+# provider "aws" {
+#   region = "<your AWS region>"
+#
+#   # Optional but recommended: restrict to a specific credential profile/account.
+#   # profile             = "<your AWS credential profile>"
+#   # allowed_account_ids = ["<your AWS account ID>"]
+# }
+
+# The kubernetes and helm providers need the EKS cluster endpoint, which is created
+# by the braintrust module. On a fresh deployment, use a two-step apply:
+#
+#   Step 1: terraform apply -target=module.braintrust.module.eks[0]
+#   Step 2: terraform apply
+#
+# After step 1 the cluster exists and the data sources below succeed.
+locals {
+  eks_cluster_name = "${var.deployment_name}-eks"
+}
+
+data "aws_region" "current" {}
+
+data "aws_eks_cluster" "braintrust" {
+  name = local.eks_cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.braintrust.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.braintrust.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.eks_cluster_name, "--region", data.aws_region.current.region]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.braintrust.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.braintrust.certificate_authority[0].data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", local.eks_cluster_name, "--region", data.aws_region.current.region]
+    }
+  }
+}

--- a/examples/braintrust-data-plane-eks/terraform.tf
+++ b/examples/braintrust-data-plane-eks/terraform.tf
@@ -1,0 +1,9 @@
+# Configure remote state backend here (e.g. S3):
+#
+# terraform {
+#   backend "s3" {
+#     bucket = "<your-state-bucket>"
+#     key    = "braintrust-eks/terraform.tfstate"
+#     region = "<your-region>"
+#   }
+# }

--- a/examples/braintrust-data-plane-eks/variables.tf
+++ b/examples/braintrust-data-plane-eks/variables.tf
@@ -1,0 +1,43 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this Braintrust deployment. Used for resource naming and tagging. Max 18 characters, lowercase letters, numbers, and hyphens only. Do not change after initial deployment."
+  default     = "braintrust"
+}
+
+variable "braintrust_org_name" {
+  type        = string
+  description = "Your organization name in Braintrust (e.g. acme.com)."
+}
+
+variable "brainstore_license_key" {
+  type        = string
+  description = "Brainstore license key from the Braintrust UI under Settings > Data Plane."
+  sensitive   = true
+  validation {
+    condition     = var.brainstore_license_key != null && var.brainstore_license_key != ""
+    error_message = "brainstore_license_key must be set."
+  }
+}
+
+variable "helm_chart_version" {
+  type        = string
+  description = "Version of the Braintrust Helm chart to deploy. Pin to a specific version for reproducible deployments."
+}
+
+variable "eks_namespace" {
+  type        = string
+  description = "Kubernetes namespace for Braintrust workloads."
+  default     = "braintrust"
+}
+
+variable "brainstore_wal_footer_version" {
+  type        = string
+  description = "WAL footer version for Brainstore. Only change when instructed by Braintrust."
+  default     = "v3"
+}
+
+variable "skip_pg_for_brainstore_objects" {
+  type        = string
+  description = "Controls which object types bypass PostgreSQL. WARNING: one-way operation."
+  default     = "all"
+}

--- a/examples/braintrust-data-plane-eks/versions.tf
+++ b/examples/braintrust-data-plane-eks/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,8 @@ module "database" {
       },
       var.database_authorized_security_groups,
       # This is a deprecated security group that will be removed in the future
-      !var.use_deployment_mode_external_eks ? { "Lambda Services" = module.services[0].lambda_security_group_id } : {}
+      !var.use_deployment_mode_external_eks ? { "Lambda Services" = module.services[0].lambda_security_group_id } : {},
+      var.create_eks_cluster ? { "EKS Nodes" = local.eks_node_security_group_id } : {},
     ),
     local.bastion_security_group,
   )
@@ -130,7 +131,8 @@ module "redis" {
       },
       var.redis_authorized_security_groups,
       # This is a deprecated security group that will be removed in the future
-      !var.use_deployment_mode_external_eks ? { "Lambda Services" = module.services[0].lambda_security_group_id } : {}
+      !var.use_deployment_mode_external_eks ? { "Lambda Services" = module.services[0].lambda_security_group_id } : {},
+      var.create_eks_cluster ? { "EKS Nodes" = local.eks_node_security_group_id } : {},
     ),
     local.bastion_security_group,
   )
@@ -310,14 +312,16 @@ module "services_common" {
   service_additional_policy_arns            = var.service_additional_policy_arns
   brainstore_additional_policy_arns         = var.brainstore_additional_policy_arns
   permissions_boundary_arn                  = var.permissions_boundary_arn
-  eks_cluster_arn                           = var.existing_eks_cluster_arn
+  eks_cluster_arn                           = var.create_eks_cluster ? local.eks_cluster_arn_val : var.existing_eks_cluster_arn
   eks_namespace                             = var.eks_namespace
   enable_eks_pod_identity                   = var.enable_eks_pod_identity
   enable_eks_irsa                           = var.enable_eks_irsa
   enable_brainstore_ec2_ssm                 = var.enable_brainstore_ec2_ssm
   custom_tags                               = var.custom_tags
-  override_api_iam_role_trust_policy        = var.override_api_iam_role_trust_policy
-  override_brainstore_iam_role_trust_policy = var.override_brainstore_iam_role_trust_policy
+  # When Terraform manages the EKS cluster, replace trust policies with OIDC-only
+  # (no lambda.amazonaws.com or ec2.amazonaws.com principals needed)
+  override_api_iam_role_trust_policy        = var.create_eks_cluster ? local.eks_api_iam_trust_policy : var.override_api_iam_role_trust_policy
+  override_brainstore_iam_role_trust_policy = var.create_eks_cluster ? local.eks_brainstore_iam_trust_policy : var.override_brainstore_iam_role_trust_policy
   enable_quarantine_vpc                     = var.enable_quarantine_vpc
   quarantine_vpc_id                         = local.quarantine_vpc_id
 }

--- a/modules/eks-cluster/assets/aws-lb-controller-iam-policy.json
+++ b/modules/eks-cluster/assets/aws-lb-controller-iam-policy.json
@@ -1,0 +1,250 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/modules/eks-cluster/cloudfront.tf
+++ b/modules/eks-cluster/cloudfront.tf
@@ -1,0 +1,111 @@
+locals {
+  # CloudFront managed policy IDs (same values as in modules/ingress/cloudfront.tf)
+  cloudfront_CachingDisabled           = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+  cloudfront_AllViewerExceptHostHeader = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+}
+
+# CloudFront VPC Origin wrapping the internal NLB.
+resource "aws_cloudfront_vpc_origin" "api" {
+  vpc_origin_endpoint_config {
+    name                   = "${var.deployment_name}-eks-api"
+    arn                    = aws_lb.api.arn
+    http_port              = 8000
+    https_port             = 443
+    origin_protocol_policy = "http-only"
+
+    origin_ssl_protocols {
+      items    = ["TLSv1.2"]
+      quantity = 1
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# CloudFront distribution for the EKS-based dataplane.
+resource "aws_cloudfront_distribution" "dataplane" {
+  comment      = "Braintrust EKS Dataplane - ${var.deployment_name}"
+  enabled      = true
+  http_version = "http2and3"
+  web_acl_id   = var.waf_acl_id
+  price_class  = var.cloudfront_price_class
+  aliases      = var.custom_domain != null ? [var.custom_domain] : null
+
+  origin {
+    origin_id   = "EKSAPIOrigin"
+    domain_name = aws_lb.api.dns_name
+
+    vpc_origin_config {
+      vpc_origin_id            = aws_cloudfront_vpc_origin.api.id
+      origin_read_timeout      = 60
+      origin_keepalive_timeout = 60
+    }
+
+    dynamic "custom_header" {
+      for_each = var.custom_domain != null ? [1] : []
+      content {
+        name  = "X-CloudFront-Domain"
+        value = var.custom_domain
+      }
+    }
+  }
+
+  origin {
+    domain_name = "braintrustproxy.com"
+    origin_id   = "CloudflareProxy"
+
+    custom_origin_config {
+      origin_protocol_policy   = "https-only"
+      origin_read_timeout      = 60
+      origin_keepalive_timeout = 60
+      https_port               = 443
+      http_port                = 80
+      origin_ssl_protocols     = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = "EKSAPIOrigin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    cache_policy_id          = local.cloudfront_CachingDisabled
+    origin_request_policy_id = local.cloudfront_AllViewerExceptHostHeader
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = toset([
+      "/v1/proxy", "/v1/proxy/*",
+      "/v1/eval", "/v1/eval/*",
+      "/v1/function/*/?*",
+      "/function/*",
+    ])
+    content {
+      path_pattern           = ordered_cache_behavior.value
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD", "OPTIONS"]
+      target_origin_id       = "CloudflareProxy"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = local.cloudfront_CachingDisabled
+      origin_request_policy_id = local.cloudfront_AllViewerExceptHostHeader
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = var.custom_certificate_arn != null ? false : true
+    acm_certificate_arn            = var.custom_certificate_arn
+    minimum_protocol_version       = var.custom_certificate_arn != null ? "TLSv1.3_2025" : null
+    ssl_support_method             = var.custom_certificate_arn != null ? "sni-only" : null
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  depends_on = [aws_cloudfront_vpc_origin.api]
+  tags       = local.common_tags
+}

--- a/modules/eks-cluster/iam.tf
+++ b/modules/eks-cluster/iam.tf
@@ -1,0 +1,79 @@
+locals {
+  # oidc_provider is the issuer URL already stripped of https://
+  eks_oidc_issuer = module.eks.oidc_provider
+
+  # IRSA-only trust policies published as outputs so the parent module can
+  # feed them into services_common as override_*_trust_policy. EKS mode uses
+  # OIDC only — no lambda.amazonaws.com or ec2.amazonaws.com principals.
+  api_iam_trust_policy = jsonencode({ # nosemgrep
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = module.eks.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.eks_oidc_issuer}:sub" = "system:serviceaccount:${var.eks_namespace}:${var.api_service_account_name}"
+          "${local.eks_oidc_issuer}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  brainstore_iam_trust_policy = jsonencode({ # nosemgrep
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = module.eks.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.eks_oidc_issuer}:sub" = "system:serviceaccount:${var.eks_namespace}:${var.brainstore_service_account_name}"
+          "${local.eks_oidc_issuer}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+}
+
+# IAM for the AWS Load Balancer Controller (IRSA).
+# The actual Helm release of the controller lives in the eks-deploy submodule
+# because it uses the kubernetes/helm providers.
+resource "aws_iam_policy" "lb_controller" {
+  name   = "${var.deployment_name}-lb-controller"
+  policy = file("${path.module}/assets/aws-lb-controller-iam-policy.json")
+  tags   = local.common_tags
+}
+
+resource "aws_iam_role" "lb_controller" {
+  name = "${var.deployment_name}-lb-controller"
+
+  assume_role_policy = jsonencode({ # nosemgrep
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = module.eks.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.eks_oidc_issuer}:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          "${local.eks_oidc_issuer}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lb_controller" {
+  role       = aws_iam_role.lb_controller.name
+  policy_arn = aws_iam_policy.lb_controller.arn
+}

--- a/modules/eks-cluster/main.tf
+++ b/modules/eks-cluster/main.tf
@@ -1,0 +1,48 @@
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+}
+
+# EKS Cluster — uses terraform-aws-modules/eks v21, which handles:
+#   - Cluster IAM role
+#   - OIDC provider (enable_irsa = true by default)
+#   - Core addons (vpc-cni, coredns, kube-proxy) via the `addons` map
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.0"
+
+  name               = "${var.deployment_name}-eks"
+  kubernetes_version = var.eks_kubernetes_version
+
+  # Terraform must be able to reach the cluster API during apply.
+  endpoint_public_access = true
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
+
+  # Core addons — not auto-installed by EKS, must be explicit.
+  addons = {
+    vpc-cni    = {}
+    coredns    = {}
+    kube-proxy = {}
+  }
+
+  eks_managed_node_groups = {
+    main = {
+      # Explicit names so the node IAM role and launch template are prefixed
+      # with the deployment name (use_name_prefix = false gives exact names,
+      # matching the rest of the top-level module's naming style).
+      iam_role_name                   = "${var.deployment_name}-eks-nodes"
+      iam_role_use_name_prefix        = false
+      launch_template_name            = "${var.deployment_name}-eks-nodes"
+      launch_template_use_name_prefix = false
+      instance_types                  = [var.eks_node_instance_type]
+      min_size                        = var.eks_node_min_size
+      max_size                        = var.eks_node_max_size
+      desired_size                    = var.eks_node_desired_size
+    }
+  }
+
+  tags = local.common_tags
+}

--- a/modules/eks-cluster/networking.tf
+++ b/modules/eks-cluster/networking.tf
@@ -1,0 +1,62 @@
+# Tag private subnets so the AWS Load Balancer Controller can auto-discover
+# them when creating internal NLBs.
+resource "aws_ec2_tag" "private_subnet_internal_elb" {
+  count       = length(var.private_subnet_ids)
+  resource_id = var.private_subnet_ids[count.index]
+  key         = "kubernetes.io/role/internal-elb"
+  value       = "1"
+}
+
+# CloudFront's managed prefix list for origin-facing traffic.
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
+# NLB security group: allow CloudFront IP ranges on the API port (8000).
+resource "aws_security_group" "nlb_cloudfront" {
+  name   = "${var.deployment_name}-nlb-cloudfront"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge({ Name = "${var.deployment_name}-nlb-cloudfront" }, local.common_tags)
+}
+
+# Allow the NLB to reach the EKS nodes on the default NodePort range.
+resource "aws_vpc_security_group_ingress_rule" "eks_nodes_from_nlb" {
+  security_group_id            = module.eks.node_security_group_id
+  referenced_security_group_id = aws_security_group.nlb_cloudfront.id
+  from_port                    = 30000
+  to_port                      = 32767
+  ip_protocol                  = "tcp"
+}
+
+# Pre-create the NLB so its ARN is known before the Load Balancer Controller
+# runs — CloudFront VPC Origin requires the NLB ARN at plan time. The LB
+# Controller adopts this NLB via the `aws-load-balancer-name` annotation
+# emitted by the Braintrust Helm chart in the eks-deploy submodule.
+#
+# NLB security groups must be attached at creation time (they cannot be
+# added later), which is why this is pre-created rather than handed off
+# entirely to the Load Balancer Controller.
+resource "aws_lb" "api" {
+  name               = "${var.deployment_name}-api-nlb"
+  internal           = true
+  load_balancer_type = "network"
+  security_groups    = [aws_security_group.nlb_cloudfront.id]
+  subnets            = var.private_subnet_ids
+
+  tags = merge({ Name = "${var.deployment_name}-api-nlb" }, local.common_tags)
+}

--- a/modules/eks-cluster/outputs.tf
+++ b/modules/eks-cluster/outputs.tf
@@ -1,0 +1,90 @@
+## Cluster
+
+output "cluster_name" {
+  value       = module.eks.cluster_name
+  description = "Name of the EKS cluster."
+}
+
+output "cluster_arn" {
+  value       = module.eks.cluster_arn
+  description = "ARN of the EKS cluster."
+}
+
+output "cluster_endpoint" {
+  value       = module.eks.cluster_endpoint
+  description = "API server endpoint of the EKS cluster."
+}
+
+output "cluster_certificate_authority_data" {
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+  description = "Base64-encoded CA certificate data for the EKS cluster."
+}
+
+output "cluster_oidc_issuer_url" {
+  value       = module.eks.cluster_oidc_issuer_url
+  description = "OIDC issuer URL for the EKS cluster (with https:// prefix)."
+}
+
+output "oidc_provider_arn" {
+  value       = module.eks.oidc_provider_arn
+  description = "ARN of the IAM OIDC provider for the EKS cluster."
+}
+
+output "node_security_group_id" {
+  value       = module.eks.node_security_group_id
+  description = "Security group ID for the EKS worker nodes (used to authorize RDS/Redis access)."
+}
+
+## IRSA trust policies (consumed by services_common as override_*_trust_policy)
+
+output "api_iam_trust_policy" {
+  value       = local.api_iam_trust_policy
+  description = "OIDC-only trust policy for the API handler IAM role, scoped to the API service account."
+}
+
+output "brainstore_iam_trust_policy" {
+  value       = local.brainstore_iam_trust_policy
+  description = "OIDC-only trust policy for the Brainstore IAM role, scoped to the Brainstore service account."
+}
+
+## Load Balancer Controller IAM
+
+output "lb_controller_role_arn" {
+  value       = aws_iam_role.lb_controller.arn
+  description = "ARN of the IAM role for the AWS Load Balancer Controller (consumed by eks-deploy as an IRSA annotation)."
+}
+
+## NLB
+
+output "nlb_arn" {
+  value       = aws_lb.api.arn
+  description = "ARN of the pre-created internal NLB."
+}
+
+output "nlb_name" {
+  value       = aws_lb.api.name
+  description = "Name of the pre-created NLB (used by the chart's aws-load-balancer-name annotation to adopt it)."
+}
+
+output "nlb_security_group_id" {
+  value       = aws_security_group.nlb_cloudfront.id
+  description = "Security group ID attached to the NLB (passed into the chart via aws-load-balancer-security-groups)."
+}
+
+## CloudFront
+
+output "cloudfront_distribution_domain_name" {
+  value       = aws_cloudfront_distribution.dataplane.domain_name
+  description = "CloudFront distribution domain name."
+}
+
+output "cloudfront_distribution_arn" {
+  value       = aws_cloudfront_distribution.dataplane.arn
+  description = "CloudFront distribution ARN."
+}
+
+output "cloudfront_distribution_hosted_zone_id" {
+  value       = aws_cloudfront_distribution.dataplane.hosted_zone_id
+  description = "CloudFront distribution hosted zone ID (for Route 53 alias records)."
+}

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -1,0 +1,98 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Will be prefix-included in all resource names."
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Custom tags applied to all created resources."
+  default     = {}
+}
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "IAM permissions boundary ARN applied to all IAM roles created by this submodule."
+  default     = null
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where the EKS cluster and NLB will be provisioned."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "List of three private subnet IDs (must span AZs) for the EKS control plane ENIs, managed node group, and internal NLB."
+  validation {
+    condition     = length(var.private_subnet_ids) == 3
+    error_message = "Exactly three private subnet IDs are required."
+  }
+}
+
+variable "eks_namespace" {
+  type        = string
+  description = "Kubernetes namespace the Braintrust workloads run in. Used to scope IRSA trust policies to the API and Brainstore service accounts."
+}
+
+variable "api_service_account_name" {
+  type        = string
+  description = "Kubernetes service account name the API pod uses (matches the chart default)."
+  default     = "braintrust-api"
+}
+
+variable "brainstore_service_account_name" {
+  type        = string
+  description = "Kubernetes service account name the Brainstore pods use (matches the chart default)."
+  default     = "brainstore"
+}
+
+variable "eks_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the EKS cluster."
+}
+
+variable "eks_node_instance_type" {
+  type        = string
+  description = "EC2 instance type for the managed node group (must support local NVMe SSD for Brainstore cache)."
+}
+
+variable "eks_node_min_size" {
+  type        = number
+  description = "Minimum number of nodes in the managed node group."
+}
+
+variable "eks_node_max_size" {
+  type        = number
+  description = "Maximum number of nodes in the managed node group."
+}
+
+variable "eks_node_desired_size" {
+  type        = number
+  description = "Desired number of nodes in the managed node group."
+}
+
+## CloudFront
+
+variable "cloudfront_price_class" {
+  type        = string
+  description = "Price class for the CloudFront distribution."
+  default     = "PriceClass_100"
+}
+
+variable "custom_domain" {
+  type        = string
+  description = "Optional custom domain for the CloudFront distribution."
+  default     = null
+}
+
+variable "custom_certificate_arn" {
+  type        = string
+  description = "Optional ACM certificate ARN (us-east-1) for the custom domain."
+  default     = null
+}
+
+variable "waf_acl_id" {
+  type        = string
+  description = "Optional WAF Web ACL ID to associate with the CloudFront distribution."
+  default     = null
+}

--- a/modules/eks-cluster/versions.tf
+++ b/modules/eks-cluster/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/modules/eks-deploy/assets/helm-values.yaml.tpl
+++ b/modules/eks-deploy/assets/helm-values.yaml.tpl
@@ -1,0 +1,41 @@
+global:
+  orgName: "${org_name}"
+  # Namespace is pre-created by Terraform (kubernetes_namespace.braintrust).
+  # createNamespace=false makes the chart use the Helm release namespace.
+  createNamespace: false
+  namespace: "${namespace}"
+
+cloud: "aws"
+
+skipPgForBrainstoreObjects: "${skip_pg}"
+brainstoreWalFooterVersion: "${wal_footer_version}"
+
+objectStorage:
+  aws:
+    brainstoreBucket: "${brainstore_bucket}"
+    responseBucket: "${response_bucket}"
+    codeBundleBucket: "${code_bundle_bucket}"
+
+api:
+  # Expose via an internal NLB that adopts the Terraform-pre-created LB.
+  # `aws-load-balancer-name` tells the Load Balancer Controller to reconcile
+  # the existing NLB (already wired into the CloudFront VPC Origin) instead
+  # of creating a new one.
+  service:
+    type: LoadBalancer
+  annotations:
+    service:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-security-groups: "${nlb_sg_id}"
+      service.beta.kubernetes.io/aws-load-balancer-name: "${nlb_name}"
+  serviceAccount:
+    awsRoleArn: "${api_role_arn}"
+
+brainstore:
+  serviceAccount:
+    awsRoleArn: "${brainstore_role_arn}"
+
+# Replicas, resources, image tags, probes, locksBackend: all left to chart
+# defaults in values.yaml (production-sized). Override via TF variable
+# `eks_helm_chart_extra_values` to scale down for sandbox deployments.

--- a/modules/eks-deploy/main.tf
+++ b/modules/eks-deploy/main.tf
@@ -1,0 +1,94 @@
+data "aws_region" "current" {}
+
+## Shared secret for the API's signed-function-execution feature.
+## Generated once and stored in the Kubernetes Secret consumed by the chart.
+resource "random_password" "function_secret" {
+  length  = 32
+  special = false
+}
+
+## Braintrust namespace for chart workloads.
+resource "kubernetes_namespace" "braintrust" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+## Runtime credentials consumed by the chart's deployment templates.
+## Secret name and keys are hardcoded by the chart (see CONTRACT.md).
+resource "kubernetes_secret" "braintrust" {
+  metadata {
+    name      = "braintrust-secrets"
+    namespace = var.namespace
+  }
+  data = {
+    PG_URL                 = "postgresql://${var.postgres_username}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/postgres?sslmode=require"
+    REDIS_URL              = "redis://${var.redis_host}:${var.redis_port}"
+    BRAINSTORE_LICENSE_KEY = var.brainstore_license_key
+    FUNCTION_SECRET_KEY    = random_password.function_secret.result
+  }
+  depends_on = [kubernetes_namespace.braintrust]
+}
+
+## AWS Load Balancer Controller.
+## Runs in kube-system; adopts the pre-created NLB when the Braintrust chart
+## is released (via the aws-load-balancer-name annotation in helm-values.yaml.tpl).
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+
+  set {
+    name  = "clusterName"
+    value = var.cluster_name
+  }
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = var.lb_controller_role_arn
+  }
+  set {
+    name  = "region"
+    value = data.aws_region.current.region
+  }
+  set {
+    name  = "vpcId"
+    value = var.vpc_id
+  }
+}
+
+## Braintrust application Helm release.
+##
+## Values precedence (later wins): chart defaults (values.yaml) <
+## rendered template < structured overrides < raw YAML escape hatch.
+resource "helm_release" "braintrust" {
+  name             = "braintrust"
+  repository       = "oci://public.ecr.aws/braintrust/helm"
+  chart            = "braintrust"
+  version          = var.helm_chart_version
+  namespace        = var.namespace
+  create_namespace = false
+
+  values = compact([
+    templatefile("${path.module}/assets/helm-values.yaml.tpl", {
+      org_name            = var.braintrust_org_name
+      namespace           = var.namespace
+      brainstore_bucket   = var.brainstore_bucket_name
+      response_bucket     = var.response_bucket_name
+      code_bundle_bucket  = var.code_bundle_bucket_name
+      brainstore_role_arn = var.brainstore_iam_role_arn
+      api_role_arn        = var.api_handler_role_arn
+      nlb_sg_id           = var.nlb_security_group_id
+      nlb_name            = var.nlb_name
+      wal_footer_version  = var.brainstore_wal_footer_version
+      skip_pg             = var.skip_pg_for_brainstore_objects
+    }),
+    local.helm_structured_overrides_yaml,
+    var.helm_chart_extra_values,
+  ])
+
+  depends_on = [
+    helm_release.aws_load_balancer_controller,
+    kubernetes_secret.braintrust,
+  ]
+}

--- a/modules/eks-deploy/outputs.tf
+++ b/modules/eks-deploy/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  value       = kubernetes_namespace.braintrust.metadata[0].name
+  description = "Namespace the Braintrust workloads were deployed into."
+}
+
+output "braintrust_release_name" {
+  value       = helm_release.braintrust.name
+  description = "Name of the Braintrust Helm release."
+}

--- a/modules/eks-deploy/overrides.tf
+++ b/modules/eks-deploy/overrides.tf
@@ -1,0 +1,34 @@
+# Build a Helm values YAML blob from the structured override variables.
+# Only fields the caller actually set are emitted so unset overrides fall
+# back to chart defaults (null values from `optional()` get dropped).
+locals {
+  _api_override = merge(
+    var.api_helm.replicas != null ? { replicas = var.api_helm.replicas } : {},
+    var.api_helm.resources != null ? { resources = var.api_helm.resources } : {},
+  )
+  _reader_override = merge(
+    var.brainstore_reader_helm.replicas != null ? { replicas = var.brainstore_reader_helm.replicas } : {},
+    var.brainstore_reader_helm.resources != null ? { resources = var.brainstore_reader_helm.resources } : {},
+  )
+  _fastreader_override = merge(
+    var.brainstore_fastreader_helm.replicas != null ? { replicas = var.brainstore_fastreader_helm.replicas } : {},
+    var.brainstore_fastreader_helm.resources != null ? { resources = var.brainstore_fastreader_helm.resources } : {},
+  )
+  _writer_override = merge(
+    var.brainstore_writer_helm.replicas != null ? { replicas = var.brainstore_writer_helm.replicas } : {},
+    var.brainstore_writer_helm.resources != null ? { resources = var.brainstore_writer_helm.resources } : {},
+  )
+
+  _brainstore_override = merge(
+    length(local._reader_override) > 0 ? { reader = local._reader_override } : {},
+    length(local._fastreader_override) > 0 ? { fastreader = local._fastreader_override } : {},
+    length(local._writer_override) > 0 ? { writer = local._writer_override } : {},
+  )
+
+  _helm_overrides = merge(
+    length(local._api_override) > 0 ? { api = local._api_override } : {},
+    length(local._brainstore_override) > 0 ? { brainstore = local._brainstore_override } : {},
+  )
+
+  helm_structured_overrides_yaml = length(local._helm_overrides) > 0 ? yamlencode(local._helm_overrides) : ""
+}

--- a/modules/eks-deploy/variables.tf
+++ b/modules/eks-deploy/variables.tf
@@ -1,0 +1,195 @@
+## Context
+
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Used in tags and resource naming."
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Custom tags applied to created resources."
+  default     = {}
+}
+
+variable "braintrust_org_name" {
+  type        = string
+  description = "Braintrust org name (becomes global.orgName in the Helm chart)."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace for Braintrust workloads. Created by this submodule."
+}
+
+## Cluster (outputs from eks-cluster)
+
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name (used by the Load Balancer Controller Helm release)."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID (used by the Load Balancer Controller Helm release)."
+}
+
+variable "lb_controller_role_arn" {
+  type        = string
+  description = "IAM role ARN for the AWS Load Balancer Controller service account (IRSA)."
+}
+
+variable "nlb_security_group_id" {
+  type        = string
+  description = "Security group ID attached to the pre-created NLB (annotated on the API service)."
+}
+
+variable "nlb_name" {
+  type        = string
+  description = "Name of the pre-created NLB (annotated on the API service so the Load Balancer Controller adopts it)."
+}
+
+## IAM role ARNs (outputs from services_common)
+
+variable "api_handler_role_arn" {
+  type        = string
+  description = "ARN of the API handler IAM role. Consumed by the chart via api.serviceAccount.awsRoleArn for IRSA."
+}
+
+variable "brainstore_iam_role_arn" {
+  type        = string
+  description = "ARN of the Brainstore IAM role. Consumed by the chart via brainstore.serviceAccount.awsRoleArn for IRSA."
+}
+
+## Storage
+
+variable "brainstore_bucket_name" {
+  type        = string
+  description = "S3 bucket name for Brainstore data."
+}
+
+variable "response_bucket_name" {
+  type        = string
+  description = "S3 bucket name for API responses."
+}
+
+variable "code_bundle_bucket_name" {
+  type        = string
+  description = "S3 bucket name for code bundles."
+}
+
+## Database + Redis
+
+variable "postgres_host" {
+  type        = string
+  description = "Postgres host."
+}
+
+variable "postgres_port" {
+  type        = number
+  description = "Postgres port."
+}
+
+variable "postgres_username" {
+  type        = string
+  description = "Postgres username."
+}
+
+variable "postgres_password" {
+  type        = string
+  description = "Postgres password."
+  sensitive   = true
+}
+
+variable "redis_host" {
+  type        = string
+  description = "Redis host."
+}
+
+variable "redis_port" {
+  type        = number
+  description = "Redis port."
+}
+
+variable "brainstore_license_key" {
+  type        = string
+  description = "Brainstore license key."
+  sensitive   = true
+}
+
+## Feature flags passed through to the chart
+
+variable "brainstore_wal_footer_version" {
+  type        = string
+  description = "WAL footer version passed to the chart (top-level value)."
+}
+
+variable "skip_pg_for_brainstore_objects" {
+  type        = string
+  description = "Controls which object types bypass PostgreSQL (top-level chart value)."
+}
+
+## Helm chart
+
+variable "helm_chart_version" {
+  type        = string
+  description = "Version of the Braintrust Helm chart (oci://public.ecr.aws/braintrust/helm)."
+}
+
+## Structured per-component Helm overrides
+##
+## Any field left unset falls back to the chart's default. If `resources` is
+## set, both `requests` and `limits` must be provided.
+
+variable "api_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the api component."
+}
+
+variable "brainstore_reader_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore reader."
+}
+
+variable "brainstore_fastreader_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore fast reader."
+}
+
+variable "brainstore_writer_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore writer."
+}
+
+variable "helm_chart_extra_values" {
+  type        = string
+  default     = ""
+  description = "Escape-hatch YAML appended to the chart's values list; wins over template and structured overrides."
+}

--- a/modules/eks-deploy/versions.tf
+++ b/modules/eks-deploy/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -124,22 +124,30 @@ output "redis_arn" {
 }
 
 output "api_url" {
-  value       = !var.use_deployment_mode_external_eks ? module.ingress[0].api_url : null
+  value = !var.use_deployment_mode_external_eks ? module.ingress[0].api_url : (
+    var.create_eks_cluster ? "https://${local.eks_cloudfront_domain_name}" : null
+  )
   description = "The primary endpoint for the dataplane API. This is the value that should be entered into the braintrust dashboard under API URL."
 }
 
 output "cloudfront_distribution_domain_name" {
-  value       = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_domain_name : null
+  value = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_domain_name : (
+    var.create_eks_cluster ? local.eks_cloudfront_domain_name : null
+  )
   description = "The domain name of the cloudfront distribution"
 }
 
 output "cloudfront_distribution_arn" {
-  value       = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_arn : null
+  value = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_arn : (
+    var.create_eks_cluster ? local.eks_cloudfront_arn : null
+  )
   description = "The ARN of the cloudfront distribution"
 }
 
 output "cloudfront_distribution_hosted_zone_id" {
-  value       = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_hosted_zone_id : null
+  value = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_hosted_zone_id : (
+    var.create_eks_cluster ? local.eks_cloudfront_hosted_zone_id : null
+  )
   description = "The hosted zone ID of the cloudfront distribution"
 }
 
@@ -176,4 +184,117 @@ output "quarantine_private_subnet_3_id" {
 output "quarantine_lambda_security_group_id" {
   value       = module.services_common.quarantine_lambda_security_group_id
   description = "ID of the security group for quarantine Lambda functions"
+}
+
+## IAM role ARNs (useful for EKS IRSA configuration)
+
+output "brainstore_iam_role_arn" {
+  value       = module.services_common.brainstore_iam_role_arn
+  description = "ARN of the IAM role for Brainstore (used for IRSA service account annotation)"
+}
+
+output "api_handler_role_arn" {
+  value       = module.services_common.api_handler_role_arn
+  description = "ARN of the IAM role for the API handler (used for IRSA service account annotation)"
+}
+
+output "function_tools_secret_key" {
+  value       = module.services_common.function_tools_secret_key
+  sensitive   = true
+  description = "The function tools encryption key used by Brainstore as SERVICE_TOKEN_SECRET_KEY"
+}
+
+## Storage bucket names
+
+output "code_bundle_bucket_id" {
+  value       = module.storage.code_bundle_bucket_id
+  description = "Name of the code bundle S3 bucket"
+}
+
+output "lambda_responses_bucket_id" {
+  value       = module.storage.lambda_responses_bucket_id
+  description = "Name of the lambda responses S3 bucket"
+}
+
+## Database connection details (for EKS Kubernetes secret construction)
+
+output "postgres_database_address" {
+  value       = module.database.postgres_database_address
+  description = "Hostname of the main Postgres database"
+}
+
+output "postgres_database_port" {
+  value       = module.database.postgres_database_port
+  description = "Port of the main Postgres database"
+}
+
+output "postgres_database_username" {
+  value       = module.database.postgres_database_username
+  description = "Username for the main Postgres database"
+}
+
+output "postgres_database_password" {
+  value       = module.database.postgres_database_password
+  sensitive   = true
+  description = "Password for the main Postgres database"
+}
+
+## Redis connection details
+
+output "redis_endpoint" {
+  value       = module.redis.redis_endpoint
+  description = "Hostname of the Redis instance"
+}
+
+output "redis_port" {
+  value       = module.redis.redis_port
+  description = "Port of the Redis instance"
+}
+
+## EKS cluster outputs (only populated when create_eks_cluster = true)
+
+output "eks_cluster_name" {
+  value       = local.eks_cluster_name_val
+  description = "Name of the EKS cluster (null when create_eks_cluster = false)"
+}
+
+output "eks_cluster_endpoint" {
+  value       = local.eks_cluster_endpoint_val
+  description = "API server endpoint of the EKS cluster (null when create_eks_cluster = false)"
+}
+
+output "eks_cluster_ca_certificate" {
+  value       = local.eks_cluster_ca_certificate_val
+  sensitive   = true
+  description = "Base64-encoded certificate authority data for the EKS cluster"
+}
+
+output "eks_oidc_provider_arn" {
+  value       = local.eks_oidc_provider_arn
+  description = "ARN of the IAM OIDC provider for the EKS cluster"
+}
+
+output "eks_node_security_group_id" {
+  value       = local.eks_node_security_group_id
+  description = "ID of the EKS node security group"
+}
+
+output "eks_lb_controller_role_arn" {
+  value       = local.eks_lb_controller_role_arn
+  description = "ARN of the IAM role for the AWS Load Balancer Controller"
+}
+
+output "eks_nlb_arn" {
+  value       = local.eks_nlb_arn_val
+  description = "ARN of the pre-created NLB for the EKS API service"
+}
+
+output "eks_nlb_name" {
+  value       = local.eks_nlb_name_val
+  description = "Name of the pre-created NLB (used for aws-load-balancer-name annotation)"
+}
+
+output "nlb_security_group_id" {
+  value       = local.eks_nlb_security_group_id
+  description = "ID of the NLB CloudFront security group"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -876,3 +876,116 @@ variable "override_brainstore_iam_role_trust_policy" {
   description = "Advanced: If provided, this will completely replace the trust policy for the Brainstore IAM role. Must be a valid JSON string representing the IAM trust policy document."
   default     = null
 }
+
+## EKS Cluster (Terraform-managed)
+
+variable "create_eks_cluster" {
+  type        = bool
+  description = "Create and manage an EKS cluster with Terraform. Requires use_deployment_mode_external_eks = true. When enabled, Terraform provisions the cluster, node group, addons, OIDC provider, NLB, and CloudFront distribution."
+  default     = false
+  validation {
+    condition     = !var.create_eks_cluster || var.use_deployment_mode_external_eks
+    error_message = "create_eks_cluster requires use_deployment_mode_external_eks = true."
+  }
+}
+
+variable "eks_node_instance_type" {
+  type        = string
+  description = "EC2 instance type for the EKS managed node group. Must support local NVMe SSD for Brainstore cache. Default (c8gd.12xlarge) is sized to fit the Helm chart's production resource defaults: Brainstore writer requests 32 CPU / 64 GiB, which needs more than c8gd.8xlarge's ~31.5 allocatable CPU after kubelet overhead. Smaller instances (e.g. c8gd.2xlarge) work for sandbox deployments if chart resources are scaled down via eks_helm_chart_extra_values in the example."
+  default     = "c8gd.12xlarge"
+}
+
+variable "eks_node_min_size" {
+  type        = number
+  description = "Minimum number of nodes in the EKS managed node group."
+  default     = 3
+}
+
+variable "eks_node_max_size" {
+  type        = number
+  description = "Maximum number of nodes in the EKS managed node group."
+  default     = 6
+}
+
+variable "eks_node_desired_size" {
+  type        = number
+  description = "Desired number of nodes in the EKS managed node group. Default (3) fits the chart's production defaults: 1 node for the writer, 1 for the 2 readers, 1 for the 2 fast readers + API pods."
+  default     = 3
+}
+
+variable "eks_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the EKS cluster."
+  default     = "1.31"
+}
+
+## Braintrust Helm release (used when create_eks_cluster = true)
+
+variable "helm_chart_version" {
+  type        = string
+  description = "Version of the Braintrust Helm chart (oci://public.ecr.aws/braintrust/helm) to deploy. Required when create_eks_cluster = true."
+  default     = null
+  validation {
+    condition     = !var.create_eks_cluster || (var.helm_chart_version != null && var.helm_chart_version != "")
+    error_message = "helm_chart_version is required when create_eks_cluster = true."
+  }
+}
+
+variable "eks_api_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the Braintrust Helm chart's api component. Unset fields fall back to chart defaults."
+}
+
+variable "eks_brainstore_reader_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore reader component."
+}
+
+variable "eks_brainstore_fastreader_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore fast reader component."
+}
+
+variable "eks_brainstore_writer_helm" {
+  type = object({
+    replicas = optional(number)
+    resources = optional(object({
+      requests = object({ cpu = string, memory = string })
+      limits   = object({ cpu = string, memory = string })
+    }))
+  })
+  default     = {}
+  description = "Override replicas and/or resources for the brainstore writer component."
+}
+
+variable "eks_helm_chart_extra_values" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    Escape hatch for Helm overrides not covered by the structured variables.
+    Raw YAML appended to the `values` list; wins over both the rendered
+    template and the structured overrides. Use this for probe tweaks, image
+    pins, partial resource overrides, etc.
+  EOT
+}

--- a/versions.tf
+++ b/versions.tf
@@ -9,3 +9,13 @@ terraform {
     }
   }
 }
+
+# The kubernetes, helm, and random providers required by modules/eks-deploy
+# are declared there, not here. Terraform aggregates provider requirements
+# across all submodules in the source tree regardless of whether they're
+# instantiated (count=0), so every consumer of this module must configure
+# those providers at their root. For non-EKS deployments they can be
+# empty/no-op — `provider "kubernetes" {}` and `provider "helm" { kubernetes {} }`
+# are sufficient because count=0 means the underlying resources are never
+# evaluated. See examples/braintrust-data-plane-eks/provider.tf for a full
+# EKS-mode configuration.


### PR DESCRIPTION

Introduces `create_eks_cluster = true`, which provisions an EKS cluster, the supporting AWS infrastructure, and the Braintrust Helm release end-to-end. Previously `use_deployment_mode_external_eks` assumed the cluster was managed outside Terraform; the new mode lets the module own the full lifecycle.

## Structure

Two new submodules under `modules/`, plus a thin root-level wiring file (`eks.tf`).

### `modules/eks-cluster/` — AWS infrastructure

- EKS cluster via `terraform-aws-modules/eks` v21
- OIDC provider and IRSA trust policies, OIDC-only, scoped to the `braintrust-api` and `brainstore` service accounts
- Core addons: `vpc-cni`, `coredns`, `kube-proxy`
- Private-subnet tagging (`kubernetes.io/role/internal-elb`) for Load Balancer Controller discovery
- Pre-created internal NLB with a CloudFront-restricted security group. NLB security groups cannot be attached after creation, so the module creates the NLB itself and lets the LB Controller adopt it via the `service.beta.kubernetes.io/aws-load-balancer-name` annotation
- CloudFront VPC Origin and distribution: default behavior routes to the EKS API; AI-proxy paths route to `braintrustproxy.com`
- IAM role for the AWS Load Balancer Controller (IRSA)

### `modules/eks-deploy/` — Kubernetes + Helm

- Kubernetes namespace
- Runtime `Secret` with keys `PG_URL`, `REDIS_URL`, `FUNCTION_SECRET_KEY`, `BRAINSTORE_LICENSE_KEY`. The name (`braintrust-secrets`) and keys are hardcoded by the chart.
- Helm release: AWS Load Balancer Controller
- Helm release: Braintrust chart, with a thin values template that sets only what the module owns (org name, namespace, `cloud`, S3 buckets, IRSA role ARNs, NLB adoption annotations, WAL / no-PG flags). Chart defaults handle everything else.
- Structured per-component overrides — `api_helm`, `brainstore_reader_helm`, `brainstore_fastreader_helm`, `brainstore_writer_helm` — each accepting optional `replicas` and `resources`. Raw-YAML `helm_chart_extra_values` as an escape hatch for anything the structured variables do not cover.

### Why two submodules (and a root-level wiring file)

`services_common` creates IAM roles shared with the non-EKS (Lambda / EC2) path, so it must sit at the root between `eks_cluster` (produces trust policies) and `eks_deploy` (consumes role ARNs). Wrapping both EKS submodules in a single parent would create a module-level dependency cycle through `services_common`: `eks_deploy` would need role ARNs from `services_common`, while `services_common` would need trust policies from `eks_cluster`, and Terraform treats module I/O atomically for cycle detection.

## Changes to existing root files

- `main.tf`: `services_common` uses `eks_cluster`'s trust policies as `override_*_trust_policy` when `create_eks_cluster = true`; the `database` and `redis` `authorized_security_groups` include the EKS node security group in EKS mode.
- `outputs.tf`: `api_url` and `cloudfront_*` outputs resolve to the EKS CloudFront distribution in EKS mode. Adds EKS-specific outputs plus database, Redis, storage, and IAM outputs consumed by downstream integrations.
- `variables.tf`: new EKS knobs — `create_eks_cluster`, `eks_node_instance_type`, `eks_node_min_size`, `eks_node_max_size`, `eks_node_desired_size`, `eks_kubernetes_version`, `helm_chart_version`, and the four structured helm-override variables plus the raw-YAML escape hatch.
- `versions.tf`: notes that `kubernetes`, `helm`, and `random` are declared in `modules/eks-deploy`. Non-EKS consumers still need empty provider blocks at the root because Terraform aggregates provider requirements across all submodules regardless of `count`, but the underlying resources are never evaluated when `create_eks_cluster = false`.

## Example

`examples/braintrust-data-plane-eks/` is a thin consumer — provider configuration plus a single module call — demonstrating the two-step apply workflow required on a fresh deployment:

    terraform apply -target=module.braintrust.module.eks_cluster[0]
    terraform apply

Step 1 creates the cluster so the `kubernetes` and `helm` providers in `provider.tf` can resolve its endpoint via `data.aws_eks_cluster` looked up by the known name `${deployment_name}-eks`. Step 2 deploys the Kubernetes namespace, `Secret`, and Helm releases.

## Contract

`CONTRACT.md` documents the coupling surface between this module and `braintrustdata/helm`: service account names, `Secret` name and keys, API port `8000`, the helm-values schema this module writes, and the assumption that `brainstore.fastreader.replicas >= 1` — the chart's `api-configmap.yaml` unconditionally emits `BRAINSTORE_FAST_READER_URL`, so `replicas = 0` would leave the API pointing at an empty service. A mirror of `CONTRACT.md` lives in the helm repo.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>