### PR TITLE
Allow a release to be created without service version changes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,6 +50,10 @@ jobs:
           git config --global user.email "braintrust-bot[bot]@users.noreply.github.com"
           ./lock_versions ${{ inputs.services_version }}
           git add .
+          if git diff --cached --quiet; then
+            echo "Braintrust Services are already at ${{ inputs.services_version }}; skipping commit."
+            exit 0
+          fi
           git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
           git push origin main
 


### PR DESCRIPTION
We need to be able to bump only module changes without service version changes.