### PR TITLE
fix(outputs): use one() for conditional resource outputs

### DIFF
--- a/modules/brainstore-ec2/outputs.tf
+++ b/modules/brainstore-ec2/outputs.tf
@@ -5,7 +5,7 @@ output "dns_name" {
 
 output "writer_dns_name" {
   description = "The DNS name of the Brainstore writer NLB, if enabled"
-  value       = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
+  value       = one(aws_lb.brainstore_writer[*].dns_name)
 }
 
 output "fast_reader_dns_name" {

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -25,7 +25,7 @@ output "catchup_etl_arn" {
 
 output "quarantine_warmup_arn" {
   description = "The ARN of the quarantine warmup lambda function. Only created when use_deployment_mode_external_eks is false."
-  value       = var.use_quarantine_vpc ? aws_lambda_function.quarantine_warmup[0].arn : null
+  value       = one(aws_lambda_function.quarantine_warmup[*].arn)
 }
 
 output "lambda_security_group_id" {


### PR DESCRIPTION
Replace direct [0] indexing on count-gated resources with the one() function in modules/services and modules/brainstore-ec2 outputs.