### PR TITLE
fix(outputs): use one() for conditional resource outputs

### DIFF
--- a/modules/brainstore-ec2/outputs.tf
+++ b/modules/brainstore-ec2/outputs.tf
@@ -5,7 +5,7 @@ output "dns_name" {
 
 output "writer_dns_name" {
   description = "The DNS name of the Brainstore writer NLB, if enabled"
-  value       = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
+  value       = one(aws_lb.brainstore_writer[*].dns_name)
 }
 
 output "fast_reader_dns_name" {

--- a/modules/services-common/outputs.tf
+++ b/modules/services-common/outputs.tf
@@ -36,15 +36,15 @@ output "function_tools_secret_key" {
 
 output "quarantine_invoke_role_arn" {
   description = "The ARN of the IAM role used by the API handler to invoke quarantined functions"
-  value       = var.enable_quarantine_vpc ? aws_iam_role.quarantine_invoke_role[0].arn : null
+  value       = one(aws_iam_role.quarantine_invoke_role[*].arn)
 }
 
 output "quarantine_function_role_arn" {
   description = "The ARN of the IAM role used by quarantined Lambda functions"
-  value       = var.enable_quarantine_vpc ? aws_iam_role.quarantine_function_role[0].arn : null
+  value       = one(aws_iam_role.quarantine_function_role[*].arn)
 }
 
 output "quarantine_lambda_security_group_id" {
   description = "The ID of the security group for quarantine Lambda functions"
-  value       = var.enable_quarantine_vpc ? aws_security_group.quarantine_lambda[0].id : null
+  value       = one(aws_security_group.quarantine_lambda[*].id)
 }

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -25,7 +25,7 @@ output "catchup_etl_arn" {
 
 output "quarantine_warmup_arn" {
   description = "The ARN of the quarantine warmup lambda function. Only created when use_deployment_mode_external_eks is false."
-  value       = var.use_quarantine_vpc ? aws_lambda_function.quarantine_warmup[0].arn : null
+  value       = one(aws_lambda_function.quarantine_warmup[*].arn)
 }
 
 output "lambda_security_group_id" {


### PR DESCRIPTION
## Summary

Replace direct `[0]` indexing on `count`-gated resources with the `one()` function in two module outputs:

- `modules/services/outputs.tf` — `quarantine_warmup_arn`
- `modules/brainstore-ec2/outputs.tf` — `writer_dns_name`

## Problem

Both outputs use the standard Terraform idiom of pairing a `count` gate with a ternary that indexes `[0]`:

```hcl
# Resource
count = local.has_writer_nodes ? 1 : 0

# Output
value = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
```

This works fine under plain `terraform plan`/`apply` because the gate is a concrete `bool` and the ternary short-circuits — `[0]` is never evaluated when the gate is `false`.

It **fails at plan time** when the module is consumed by [pulumi/pulumi-terraform-module](https://github.com/pulumi/pulumi-terraform-module). Pulumi inputs cross into OpenTofu as values that may be unknown until apply during `pulumi preview`. When the gate is unknown, OpenTofu evaluates *both* branches of the ternary and indexes into a `count = 0` tuple, producing:

```
Error: Invalid index
  on .terraform/modules/braintrust-data-plane/modules/services/outputs.tf line 28:
  28:   value = var.use_quarantine_vpc ? aws_lambda_function.quarantine_warmup[0].arn : null
    │ aws_lambda_function.quarantine_warmup is empty tuple
The given key does not identify an element in this collection value: the
collection has no elements.

Error: Invalid index
  on .terraform/modules/braintrust-data-plane/modules/brainstore-ec2/outputs.tf line 8:
   8:   value = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
    │ aws_lb.brainstore_writer is empty tuple
```

This is a known rough edge with conditional `count` resources whose outputs use `[0]` (see [hashicorp/terraform#23222](https://github.com/hashicorp/terraform/issues/23222) and the [HashiCorp support note](https://support.hashicorp.com/hc/en-us/articles/9471971461651-ERROR-Invalid-index-on-empty-tuple)).

## Fix

`one(resource[*].attr)` is the idiomatic Terraform helper for "0-or-1 resource": it returns `null` when the splat is empty and the value when there's exactly one. It's safe to evaluate eagerly, so it doesn't blow up when the count tuple is empty.

```hcl
value = one(aws_lb.brainstore_writer[*].dns_name)
value = one(aws_lambda_function.quarantine_warmup[*].arn)
```

Behavior is unchanged for all existing terraform consumers (still `null` when the resource isn't created, the attribute when it is) and the module now plans cleanly under pulumi-terraform-module preview as well.
