### PR TITLE
Add optional Attribute-Based Access Control (ABAC) to S3 buckets

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/versions.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/examples/braintrust-data-plane-sandbox/versions.tf
+++ b/examples/braintrust-data-plane-sandbox/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/examples/braintrust-data-plane/versions.tf
+++ b/examples/braintrust-data-plane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/examples/cloudfront-logging/versions.tf
+++ b/examples/cloudfront-logging/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,7 @@ module "storage" {
   kms_key_arn                         = local.kms_key_arn
   brainstore_s3_bucket_retention_days = var.brainstore_s3_bucket_retention_days
   s3_additional_allowed_origins       = var.s3_additional_allowed_origins
+  enable_s3_bucket_abac               = var.enable_s3_bucket_abac
   custom_tags                         = var.custom_tags
 }
 

--- a/modules/api-ecs/versions.tf
+++ b/modules/api-ecs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/brainstore-ec2/versions.tf
+++ b/modules/brainstore-ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/ecs/versions.tf
+++ b/modules/ecs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/elasticache/versions.tf
+++ b/modules/elasticache/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/gateway-ecs/versions.tf
+++ b/modules/gateway-ecs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/ingress/versions.tf
+++ b/modules/ingress/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/remote-support/versions.tf
+++ b/modules/remote-support/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/services-common/versions.tf
+++ b/modules/services-common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/services/versions.tf
+++ b/modules/services/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/modules/storage/s3-brainstore.tf
+++ b/modules/storage/s3-brainstore.tf
@@ -11,6 +11,16 @@ resource "aws_s3_bucket" "brainstore" {
   tags = local.common_tags
 }
 
+resource "aws_s3_bucket_abac" "brainstore" {
+  count = var.enable_s3_bucket_abac ? 1 : 0
+
+  bucket = aws_s3_bucket.brainstore.id
+
+  abac_status {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "brainstore" {
   bucket = aws_s3_bucket.brainstore.id
 

--- a/modules/storage/s3-code-bundle.tf
+++ b/modules/storage/s3-code-bundle.tf
@@ -11,6 +11,16 @@ resource "aws_s3_bucket" "code_bundle_bucket" {
   tags = local.common_tags
 }
 
+resource "aws_s3_bucket_abac" "code_bundle_bucket" {
+  count = var.enable_s3_bucket_abac ? 1 : 0
+
+  bucket = aws_s3_bucket.code_bundle_bucket.id
+
+  abac_status {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "code_bundle_bucket" {
   bucket = aws_s3_bucket.code_bundle_bucket.id
 

--- a/modules/storage/s3-lambda-responses.tf
+++ b/modules/storage/s3-lambda-responses.tf
@@ -11,6 +11,16 @@ resource "aws_s3_bucket" "lambda_responses_bucket" {
   tags = local.common_tags
 }
 
+resource "aws_s3_bucket_abac" "lambda_responses_bucket" {
+  count = var.enable_s3_bucket_abac ? 1 : 0
+
+  bucket = aws_s3_bucket.lambda_responses_bucket.id
+
+  abac_status {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_versioning" "lambda_responses_bucket" {
   bucket = aws_s3_bucket.lambda_responses_bucket.id
   versioning_configuration {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -21,6 +21,12 @@ variable "s3_additional_allowed_origins" {
   default     = []
 }
 
+variable "enable_s3_bucket_abac" {
+  description = "Enable attribute-based access control (ABAC) on S3 buckets managed by this module."
+  type        = bool
+  default     = false
+}
+
 variable "custom_tags" {
   description = "Custom tags to apply to all created resources"
   type        = map(string)

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/vpc-peering-accepter/versions.tf
+++ b/modules/vpc-peering-accepter/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/vpc-peering-requester/versions.tf
+++ b/modules/vpc-peering-requester/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -657,6 +657,12 @@ variable "s3_additional_allowed_origins" {
   default     = []
 }
 
+variable "enable_s3_bucket_abac" {
+  description = "Enable attribute-based access control (ABAC) on S3 buckets managed by this module. When enabled, bucket tags can be used in authorization policies and tag management requires s3:TagResource, s3:UntagResource, and s3:ListTagsForResource."
+  type        = bool
+  default     = false
+}
+
 variable "outbound_rate_limit_max_requests" {
   description = "The maximum number of requests per user allowed in the time frame specified by OutboundRateLimitMaxRequests. Setting to 0 will disable rate limits"
   type        = number

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.23.0, < 7.0.0"
     }
   }
 }


### PR DESCRIPTION
This is an optional setting to let IAM policies grant or deny access based on bucket attributes like tags, instead of only hard-coded bucket ARNs. 

This can be enabled by setting `enable_s3_bucket_abac=true` 

Please review the [AWS S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html) first before enabling this, and review your IAM policies if tag-based conditions reference any existing tags on your buckets, as these could grant unintentional authorization changes to your Amazon S3 buckets. 

S3 ABAC support was only added in the Terraform AWS provider version 6.23.0. Updated version constraints to match this.