### PR TITLE
add option for routing `/v1/proxy` to gateway.braintrust.dev

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -381,15 +381,16 @@ module "ingress" {
   source = "./modules/ingress"
   count  = !var.use_deployment_mode_external_eks ? 1 : 0
 
-  deployment_name          = var.deployment_name
-  custom_domain            = var.custom_domain
-  custom_certificate_arn   = var.custom_certificate_arn
-  waf_acl_id               = var.waf_acl_id
-  cloudfront_price_class   = var.cloudfront_price_class
-  use_global_ai_proxy      = var.use_global_ai_proxy
-  ai_proxy_function_url    = module.services[0].ai_proxy_url
-  api_handler_function_arn = module.services[0].api_handler_arn
-  custom_tags              = var.custom_tags
+  deployment_name           = var.deployment_name
+  custom_domain             = var.custom_domain
+  custom_certificate_arn    = var.custom_certificate_arn
+  waf_acl_id                = var.waf_acl_id
+  cloudfront_price_class    = var.cloudfront_price_class
+  use_global_ai_proxy       = var.use_global_ai_proxy
+  use_global_gateway_origin = var.use_global_gateway_origin
+  ai_proxy_function_url     = module.services[0].ai_proxy_url
+  api_handler_function_arn  = module.services[0].api_handler_arn
+  custom_tags               = var.custom_tags
 }
 
 module "services_common" {

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -5,7 +5,9 @@ locals {
   cloudfront_AllViewerExceptHostHeader = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
   cloudfront_AIProxyOrigin             = "AIProxyOrigin"
   cloudfront_CloudflareProxy           = "CloudflareProxy"
+  cloudfront_GatewayOrigin             = "GatewayOrigin"
   cloudfront_APIGatewayOrigin          = "APIGatewayOrigin"
+  cloudfront_ProxyOrigin               = var.use_global_ai_proxy ? local.cloudfront_CloudflareProxy : local.cloudfront_AIProxyOrigin
 }
 
 resource "aws_cloudfront_distribution" "dataplane" {
@@ -69,6 +71,20 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
   }
 
+  origin {
+    domain_name = "gateway.braintrust.dev"
+    origin_id   = local.cloudfront_GatewayOrigin
+
+    custom_origin_config {
+      origin_protocol_policy   = "https-only"
+      origin_read_timeout      = 60
+      origin_keepalive_timeout = 60
+      https_port               = 443
+      http_port                = 80
+      origin_ssl_protocols     = ["TLSv1.2"]
+    }
+  }
+
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD", "OPTIONS"]
@@ -80,8 +96,21 @@ resource "aws_cloudfront_distribution" "dataplane" {
   }
 
   dynamic "ordered_cache_behavior" {
+    for_each = toset(["/v1/proxy", "/v1/proxy/*"])
+    content {
+      path_pattern           = ordered_cache_behavior.value
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD", "OPTIONS"]
+      target_origin_id       = var.use_global_gateway_origin ? local.cloudfront_GatewayOrigin : local.cloudfront_ProxyOrigin
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = local.cloudfront_CachingDisabled
+      origin_request_policy_id = local.cloudfront_AllViewerExceptHostHeader
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
     for_each = toset([
-      "/v1/proxy", "/v1/proxy/*",
       "/v1/eval", "/v1/eval/*",
       "/v1/function/*/?*",
       "/function/*"
@@ -90,7 +119,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
       path_pattern           = ordered_cache_behavior.value
       allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
       cached_methods         = ["GET", "HEAD", "OPTIONS"]
-      target_origin_id       = var.use_global_ai_proxy ? local.cloudfront_CloudflareProxy : local.cloudfront_AIProxyOrigin
+      target_origin_id       = local.cloudfront_ProxyOrigin
       viewer_protocol_policy = "redirect-to-https"
 
       cache_policy_id          = local.cloudfront_CachingDisabled

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -27,6 +27,12 @@ variable "use_global_ai_proxy" {
   default     = false
 }
 
+variable "use_global_gateway_origin" {
+  description = "Whether to route /v1/proxy traffic to gateway.braintrust.dev"
+  type        = bool
+  default     = false
+}
+
 variable "ai_proxy_function_url" {
   description = "The function URL of the AI proxy lambda function"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -961,6 +961,12 @@ variable "use_global_ai_proxy" {
   default     = false
 }
 
+variable "use_global_gateway_origin" {
+  description = "Whether to route /v1/proxy traffic to gateway.braintrust.dev. Don't enable this unless instructed by Braintrust."
+  type        = bool
+  default     = false
+}
+
 variable "use_deployment_mode_external_eks" {
   description = "Enable EKS deployment mode. When true, disables lambdas, ec2, and ingress submodules. It assumes an EKS deployment is being done outside of terraform."
   type        = bool


### PR DESCRIPTION
This change enables the option for routing `/v1/proxy` to use the public gateway URL for dataplane deployments