### PR TITLE
fix(outputs): use one() for conditional resource outputs

### DIFF
--- a/modules/brainstore-ec2/outputs.tf
+++ b/modules/brainstore-ec2/outputs.tf
@@ -10,7 +10,7 @@ output "writer_dns_name" {
 
 output "fast_reader_dns_name" {
   description = "The DNS name of the Brainstore fast reader NLB, if enabled"
-  value       = local.has_fast_reader_nodes ? aws_lb.brainstore_fast_reader[0].dns_name : null
+  value       = one(aws_lb.brainstore_fast_reader[*].dns_name)
 }
 
 output "port" {

--- a/modules/brainstore-ec2/outputs.tf
+++ b/modules/brainstore-ec2/outputs.tf
@@ -5,7 +5,7 @@ output "dns_name" {
 
 output "writer_dns_name" {
   description = "The DNS name of the Brainstore writer NLB, if enabled"
-  value       = local.has_writer_nodes ? aws_lb.brainstore_writer[0].dns_name : null
+  value       = one(aws_lb.brainstore_writer[*].dns_name)
 }
 
 output "fast_reader_dns_name" {

--- a/modules/services-common/outputs.tf
+++ b/modules/services-common/outputs.tf
@@ -41,15 +41,15 @@ output "function_tools_secret_arn" {
 
 output "quarantine_invoke_role_arn" {
   description = "The ARN of the IAM role used by the API handler to invoke quarantined functions"
-  value       = var.enable_quarantine_vpc ? aws_iam_role.quarantine_invoke_role[0].arn : null
+  value       = one(aws_iam_role.quarantine_invoke_role[*].arn)
 }
 
 output "quarantine_function_role_arn" {
   description = "The ARN of the IAM role used by quarantined Lambda functions"
-  value       = var.enable_quarantine_vpc ? aws_iam_role.quarantine_function_role[0].arn : null
+  value       = one(aws_iam_role.quarantine_function_role[*].arn)
 }
 
 output "quarantine_lambda_security_group_id" {
   description = "The ID of the security group for quarantine Lambda functions"
-  value       = var.enable_quarantine_vpc ? aws_security_group.quarantine_lambda[0].id : null
+  value       = one(aws_security_group.quarantine_lambda[*].id)
 }

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -25,7 +25,7 @@ output "catchup_etl_arn" {
 
 output "quarantine_warmup_arn" {
   description = "The ARN of the quarantine warmup lambda function. Only created when use_deployment_mode_external_eks is false."
-  value       = var.use_quarantine_vpc ? aws_lambda_function.quarantine_warmup[0].arn : null
+  value       = one(aws_lambda_function.quarantine_warmup[*].arn)
 }
 
 output "lambda_security_group_id" {


### PR DESCRIPTION
## What

Replace direct `[0]` indexing on count-gated resources with `one(...[*])` for conditional outputs across the module:

- `brainstore-ec2`: `writer_dns_name`, `fast_reader_dns_name`
- `services-common`: `quarantine_invoke_role_arn`, `quarantine_function_role_arn`, `quarantine_lambda_security_group_id`
- `services`: `quarantine_warmup_arn`

## Why

`gate ? resource[0].attr : null` requires Terraform to resolve the gate at plan time to pick a branch. Under `pulumi-terraform-module`, gate inputs can be `Output<bool>` (unknown until apply), so Terraform tries to type-check **both** branches and `resource[0]` blows up with `Invalid index` on the count-gated (empty) list.

`one(resource[*].attr)` has no branch to short-circuit — it collapses a 0-or-1 element splat to the element or `null`. Behaviorally identical under plain Terraform; safe under unknown gates. Each resource's `count` is `gate ? 1 : 0`, so the >1 error case can't occur.

## Testing

| Terraform | `enable_quarantine_vpc` | Result |
|-----------|-------------------------|--------|
| 1.10      | `false`                 | ✅ pass |
| 1.10      | `true`                  | ✅ pass |
| 1.15      | `false`                 | ✅ pass |
| 1.15      | `true`                  | ✅ pass |

## Notes

- Supersedes #240 (couldn't push to that fork branch); the `one()` conversion commit preserves @miguelslemos' authorship.
   - 🙏 Thanks to @miguelslemos for surfacing and fixing this issue.
- Adds `fast_reader_dns_name`, which #240 had missed.
- Rebased onto current `main`; #246's new outputs are preserved.