### PR TITLE
Update default redis instance type to r7g.large instead of t4g.medium

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -85,7 +85,7 @@ module "braintrust-data-plane" {
 
   ### Redis configuration
   # Default is acceptable for typical production deployments.
-  redis_instance_type = "cache.t4g.medium"
+  redis_instance_type = "cache.r7g.large"
 
   # Redis engine version
   redis_version = "7.0"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -70,7 +70,7 @@ module "braintrust-data-plane" {
   ### Redis configuration
 
   # Default is acceptable for typical production deployments.
-  redis_instance_type = "cache.t4g.medium"
+  redis_instance_type = "cache.r7g.large"
 
   # Redis engine version
   redis_version = "7.0"

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -33,7 +33,7 @@ variable "custom_security_group_ids" {
 variable "redis_instance_type" {
   type        = string
   description = "Instance type for the Redis cluster"
-  default     = "cache.t4g.medium"
+  default     = "cache.r7g.large"
 }
 
 variable "redis_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -308,7 +308,7 @@ variable "DANGER_disable_database_deletion_protection" {
 variable "redis_instance_type" {
   description = "Instance type for the Redis cluster"
   type        = string
-  default     = "cache.t4g.medium"
+  default     = "cache.r7g.large"
 }
 
 variable "redis_version" {


### PR DESCRIPTION
In our guidance we explicitly call out no longer using burstable t variant instance types, updating our defaults to reflect this. 

https://www.braintrust.dev/docs/admin/self-hosting/deploy#redis-instance-sizing