### PR TITLE
Allow Cloudfront origin read timeout to be increased from 60s

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -381,16 +381,17 @@ module "ingress" {
   source = "./modules/ingress"
   count  = !var.use_deployment_mode_external_eks ? 1 : 0
 
-  deployment_name           = var.deployment_name
-  custom_domain             = var.custom_domain
-  custom_certificate_arn    = var.custom_certificate_arn
-  waf_acl_id                = var.waf_acl_id
-  cloudfront_price_class    = var.cloudfront_price_class
-  use_global_ai_proxy       = var.use_global_ai_proxy
-  use_global_gateway_origin = var.use_global_gateway_origin
-  ai_proxy_function_url     = module.services[0].ai_proxy_url
-  api_handler_function_arn  = module.services[0].api_handler_arn
-  custom_tags               = var.custom_tags
+  deployment_name                = var.deployment_name
+  custom_domain                  = var.custom_domain
+  custom_certificate_arn         = var.custom_certificate_arn
+  waf_acl_id                     = var.waf_acl_id
+  cloudfront_price_class         = var.cloudfront_price_class
+  cloudfront_origin_read_timeout = var.cloudfront_origin_read_timeout
+  use_global_ai_proxy            = var.use_global_ai_proxy
+  use_global_gateway_origin      = var.use_global_gateway_origin
+  ai_proxy_function_url          = module.services[0].ai_proxy_url
+  api_handler_function_arn       = module.services[0].api_handler_arn
+  custom_tags                    = var.custom_tags
 }
 
 module "services_common" {

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
     custom_origin_config {
       origin_protocol_policy   = "https-only"
-      origin_read_timeout      = 60
+      origin_read_timeout      = var.cloudfront_origin_read_timeout
       origin_keepalive_timeout = 60
       https_port               = 443
       http_port                = 80
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
     custom_origin_config {
       origin_protocol_policy   = "https-only"
-      origin_read_timeout      = 60
+      origin_read_timeout      = var.cloudfront_origin_read_timeout
       origin_keepalive_timeout = 60
       https_port               = 443
       http_port                = 80
@@ -62,7 +62,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
     custom_origin_config {
       origin_protocol_policy   = "https-only"
-      origin_read_timeout      = 60
+      origin_read_timeout      = var.cloudfront_origin_read_timeout
       origin_keepalive_timeout = 60
       https_port               = 443
       http_port                = 80

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
     custom_origin_config {
       origin_protocol_policy   = "https-only"
-      origin_read_timeout      = 60
+      origin_read_timeout      = var.cloudfront_origin_read_timeout
       origin_keepalive_timeout = 60
       https_port               = 443
       http_port                = 80

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -49,6 +49,17 @@ variable "cloudfront_price_class" {
   default     = "PriceClass_100"
 }
 
+variable "cloudfront_origin_read_timeout" {
+  description = "The read timeout (in seconds) for CloudFront origins. AWS CloudFront supports up to 180s; values above 60s may require an AWS Support ticket to raise the quota."
+  type        = number
+  default     = 60
+
+  validation {
+    condition     = var.cloudfront_origin_read_timeout >= 1 && var.cloudfront_origin_read_timeout <= 180
+    error_message = "cloudfront_origin_read_timeout must be between 1 and 180 seconds."
+  }
+}
+
 variable "custom_tags" {
   description = "Custom tags to apply to all created resources"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -710,6 +710,17 @@ variable "cloudfront_price_class" {
   default     = "PriceClass_100"
 }
 
+variable "cloudfront_origin_read_timeout" {
+  description = "The read timeout (in seconds) for CloudFront origins. Increase this if long-running scorers or tools hit 504 Gateway Timeout errors on /function/invoke. AWS CloudFront supports up to 180s; values above 60s may require an AWS Support ticket to raise the quota."
+  type        = number
+  default     = 60
+
+  validation {
+    condition     = var.cloudfront_origin_read_timeout >= 1 && var.cloudfront_origin_read_timeout <= 180
+    error_message = "cloudfront_origin_read_timeout must be between 1 and 180 seconds."
+  }
+}
+
 variable "service_additional_policy_arns" {
   type        = list(string)
   description = "Additional policy ARNs to attach to the main braintrust API service"


### PR DESCRIPTION
The origin_read_timeout was hardcoded to 60s across all CloudFront origins. A longer read timeout can help resolve timeouts for long LLM completions through the AI proxy.