### PR TITLE
Add sa-east-1 to services region allowlist

### DIFF
--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -2,7 +2,7 @@ locals {
   # Lambdas can only be deployed from s3 buckets in the same region. These are
   # the regions where we currently host our lambda code.
   # Contact support if you need a new region to be supported.
-  supported_regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1", "ca-central-1", "ap-southeast-2"]
+  supported_regions = ["us-east-1", "us-east-2", "us-west-2", "eu-west-1", "ca-central-1", "ap-southeast-2", "sa-east-1"]
   lambda_s3_bucket  = "braintrust-assets-${data.aws_region.current.region}"
   lambda_names      = ["AIProxy", "APIHandler", "MigrateDatabaseFunction", "QuarantineWarmupFunction", "CatchupETL", "BillingCron", "AutomationCron"]
 
@@ -76,7 +76,7 @@ data "aws_region" "current" {
   lifecycle {
     postcondition {
       condition     = contains(local.supported_regions, self.region)
-      error_message = "Region must be one of: us-east-1, us-east-2, us-west-2, eu-west-1, ca-central-1, ap-southeast-2. Contact support if you need a new region to be supported."
+      error_message = "Region must be one of: us-east-1, us-east-2, us-west-2, eu-west-1, ca-central-1, ap-southeast-2, sa-east-1. Contact support if you need a new region to be supported."
     }
   }
 }


### PR DESCRIPTION
Add sa-east-1 to supported regions. Only v2.1.1 of the data plane and higher are supported in this region.