### PR TITLE
Update `global_gateway_origin_domain` to be configurable

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -90,6 +90,10 @@ module "braintrust-data-plane" {
   # Redis engine version
   redis_version = "7.0"
 
+  # Only use this when instructed to by the Braintrust team.
+  # use_global_gateway_origin   = false
+  # global_gateway_origin_domain = "gateway.braintrust.dev"
+
   ### Network configuration
   # WARNING: You should choose these values carefully after discussing with your networking team.
   # Changing them after the fact is not possible and will require a complete rebuild of your Braintrust deployment.

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -74,6 +74,10 @@ module "braintrust-data-plane" {
   redis_instance_type = "cache.t4g.small"
   redis_version       = "7.0"
 
+  # Only use this when instructed to by the Braintrust team.
+  # use_global_gateway_origin   = false
+  # global_gateway_origin_domain = "gateway.braintrust.dev"
+
   ### Network configuration
   # Defaults are fine for most sandbox deployments. Only change if you need to
   # peer with other VPCs and the default CIDRs conflict.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -104,6 +104,10 @@ module "braintrust-data-plane" {
   # api_handler_reserved_concurrent_executions = -1
   # ai_proxy_reserved_concurrent_executions    = -1
 
+  # Only use this when instructed to by the Braintrust team.
+  # use_global_gateway_origin   = false
+  # global_gateway_origin_domain = "gateway.braintrust.dev"
+
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.
   # brainstore_extra_env_vars = {}

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -5,6 +5,10 @@
 module "braintrust-data-plane" {
   source = "github.com/braintrustdata/terraform-braintrust-data-plane"
   # ... your eixsting configuration ...
+
+  # Only use this when instructed to by the Braintrust team.
+  # use_global_gateway_origin   = false
+  # global_gateway_origin_domain = "gateway.braintrust.dev"
 }
 
 ###############################################################################

--- a/main.tf
+++ b/main.tf
@@ -389,6 +389,7 @@ module "ingress" {
   cloudfront_origin_read_timeout = var.cloudfront_origin_read_timeout
   use_global_ai_proxy            = var.use_global_ai_proxy
   use_global_gateway_origin      = var.use_global_gateway_origin
+  global_gateway_origin_domain   = var.global_gateway_origin_domain
   ai_proxy_function_url          = module.services[0].ai_proxy_url
   api_handler_function_arn       = module.services[0].api_handler_arn
   custom_tags                    = var.custom_tags

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -72,7 +72,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
   }
 
   origin {
-    domain_name = var.global_gateway_origin_domain
+    domain_name = trimsuffix(replace(var.global_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")
     origin_id   = local.cloudfront_GatewayOrigin
 
     custom_origin_config {

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -72,7 +72,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
   }
 
   origin {
-    domain_name = "gateway.braintrust.dev"
+    domain_name = var.global_gateway_origin_domain
     origin_id   = local.cloudfront_GatewayOrigin
 
     custom_origin_config {

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -33,6 +33,12 @@ variable "use_global_gateway_origin" {
   default     = false
 }
 
+variable "global_gateway_origin_domain" {
+  description = "Gateway origin domain to use when use_global_gateway_origin is enabled"
+  type        = string
+  default     = "gateway.braintrust.dev"
+}
+
 variable "ai_proxy_function_url" {
   description = "The function URL of the AI proxy lambda function"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -978,6 +978,12 @@ variable "use_global_gateway_origin" {
   default     = false
 }
 
+variable "global_gateway_origin_domain" {
+  description = "Gateway origin domain to use when use_global_gateway_origin is enabled. Don't change this unless instructed by Braintrust."
+  type        = string
+  default     = "gateway.braintrust.dev"
+}
+
 variable "use_deployment_mode_external_eks" {
   description = "Enable EKS deployment mode. When true, disables lambdas, ec2, and ingress submodules. It assumes an EKS deployment is being done outside of terraform."
   type        = bool


### PR DESCRIPTION
This change lets you configure `global_gateway_origin_domain` so if your deployment has regional requirements and you want to use the public gateway URLs, you can set it to be `https://gateway.euw.braintrust.dev` instead of the hard-codd value of `https://gateway.braintrust.dev`