### PR TITLE
Add URL-security controls for outbound URL checks

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -121,13 +121,6 @@ module "braintrust-data-plane" {
   # custom_tags = {
   #   CustomTagKey = "SomeValue"
   # }
-
-  ### Optional URL-security controls for Braintrust services created by this module.
-  ### External EKS workloads must also receive matching env vars in their own deployment manifests.
-  # unsafe_url_request_mode  = "reject"
-  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
-  # url_security_allow_cidrs = "10.0.0.0/8"
-
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.
   # Use s3_additional_allowed_origins to apply the same origins to both buckets,

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -122,6 +122,12 @@ module "braintrust-data-plane" {
   #   CustomTagKey = "SomeValue"
   # }
 
+  ### Optional URL-security controls for Braintrust services created by this module.
+  ### External EKS workloads must also receive matching env vars in their own deployment manifests.
+  # unsafe_url_request_mode  = "reject"
+  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
+  # url_security_allow_cidrs = "10.0.0.0/8"
+
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.
   # Use s3_additional_allowed_origins to apply the same origins to both buckets,

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -99,13 +99,6 @@ module "braintrust-data-plane" {
   # peer with other VPCs and the default CIDRs conflict.
   # vpc_cidr            = "10.175.0.0/21"
   # quarantine_vpc_cidr = "10.175.8.0/21"
-
-  ### Optional URL-security controls for externally supplied outbound HTTP URLs.
-  ### Leave unset to use the application default mode of "warn".
-  # unsafe_url_request_mode  = "reject"
-  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
-  # url_security_allow_cidrs = "10.0.0.0/8"
-
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.
   # Use s3_additional_allowed_origins to apply the same origins to both buckets,

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -100,6 +100,12 @@ module "braintrust-data-plane" {
   # vpc_cidr            = "10.175.0.0/21"
   # quarantine_vpc_cidr = "10.175.8.0/21"
 
+  ### Optional URL-security controls for externally supplied outbound HTTP URLs.
+  ### Leave unset to use the application default mode of "warn".
+  # unsafe_url_request_mode  = "reject"
+  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
+  # url_security_allow_cidrs = "10.0.0.0/8"
+
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.
   # Use s3_additional_allowed_origins to apply the same origins to both buckets,

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -117,9 +117,11 @@ module "braintrust-data-plane" {
   # use_global_ai_gateway_origin   = false
   # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
-  # How to handle URL-security validation failures for externally supplied outbound HTTP URLs.
-  # Allowed values: "off", "proxy", "warn", "reject". Defaults to "warn".
-  # unsafe_url_request_mode = "warn"
+  # Optional URL-security controls for externally supplied outbound HTTP URLs.
+  # Leave unset to use the application default mode of "warn".
+  # unsafe_url_request_mode  = "reject"
+  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
+  # url_security_allow_cidrs = "10.0.0.0/8"
 
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -9,6 +9,8 @@ module "braintrust-data-plane" {
   # Only use this when instructed to by the Braintrust team.
   # use_global_ai_gateway_origin   = false
   # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
+
+  # Optional URL-security inputs are shown in examples/braintrust-data-plane/main.tf.
 }
 
 ###############################################################################

--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,8 @@ module "services" {
   outbound_rate_limit_window_minutes         = var.outbound_rate_limit_window_minutes
   outbound_rate_limit_max_requests           = var.outbound_rate_limit_max_requests
   unsafe_url_request_mode                    = var.unsafe_url_request_mode
+  url_security_dns_servers                   = var.url_security_dns_servers
+  url_security_allow_cidrs                   = var.url_security_allow_cidrs
   extra_env_vars                             = var.service_extra_env_vars
 
   # Billing usage telemetry
@@ -293,12 +295,15 @@ module "gateway_ecs" {
     },
     var.ai_gateway_authorized_security_groups,
   )
-  extra_env_vars         = var.ai_gateway_extra_env_vars
-  custom_tags            = var.custom_tags
-  brainstore_license_key = var.brainstore_license_key
-  enable_execute_command = var.ai_gateway_enable_execute_command
-  braintrust_app_url     = var.ai_gateway_braintrust_app_url
-  braintrust_api_url     = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
+  extra_env_vars           = var.ai_gateway_extra_env_vars
+  custom_tags              = var.custom_tags
+  brainstore_license_key   = var.brainstore_license_key
+  enable_execute_command   = var.ai_gateway_enable_execute_command
+  braintrust_app_url       = var.ai_gateway_braintrust_app_url
+  braintrust_api_url       = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
+  unsafe_url_request_mode  = var.unsafe_url_request_mode
+  url_security_dns_servers = var.url_security_dns_servers
+  url_security_allow_cidrs = var.url_security_allow_cidrs
 
   # Observability
   internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
@@ -355,9 +360,11 @@ module "api_ecs" {
   whitelisted_origins                   = var.whitelisted_origins
   outbound_rate_limit_window_minutes    = var.outbound_rate_limit_window_minutes
   outbound_rate_limit_max_requests      = var.outbound_rate_limit_max_requests
-  unsafe_url_request_mode               = var.unsafe_url_request_mode
   disable_billing_telemetry_aggregation = var.disable_billing_telemetry_aggregation
   billing_telemetry_log_level           = var.billing_telemetry_log_level
+  unsafe_url_request_mode               = var.unsafe_url_request_mode
+  url_security_dns_servers              = var.url_security_dns_servers
+  url_security_allow_cidrs              = var.url_security_allow_cidrs
   extra_env_vars                        = var.api_ecs_extra_env_vars
 
   # Quarantine VPC

--- a/modules/api-ecs/main.tf
+++ b/modules/api-ecs/main.tf
@@ -9,6 +9,20 @@ locals {
   using_brainstore_writer      = var.brainstore_writer_hostname != null && var.brainstore_writer_hostname != ""
   using_brainstore_fast_reader = var.brainstore_fast_reader_hostname != null && var.brainstore_fast_reader_hostname != ""
   api_ecs_url                  = "http://${aws_lb.api_ecs.dns_name}"
+  unsafe_url_request_mode      = var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode)
+  url_security_dns_servers     = var.url_security_dns_servers == null ? "" : trimspace(var.url_security_dns_servers)
+  url_security_allow_cidrs     = var.url_security_allow_cidrs == null ? "" : trimspace(var.url_security_allow_cidrs)
+  url_security_env_vars = merge(
+    local.unsafe_url_request_mode != "" ? {
+      BRAINTRUST_UNSAFE_URL_REQUEST_MODE = local.unsafe_url_request_mode
+    } : {},
+    local.url_security_dns_servers != "" ? {
+      BRAINTRUST_URL_SECURITY_DNS_SERVERS = local.url_security_dns_servers
+    } : {},
+    local.url_security_allow_cidrs != "" ? {
+      BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = local.url_security_allow_cidrs
+    } : {}
+  )
 
   base_env_vars = merge({
     ORG_NAME                                          = var.braintrust_org_name
@@ -51,10 +65,8 @@ locals {
     TS_API_PORT                                       = "8000"
     PROXY_URL                                         = "http://127.0.0.1:8000/v1/proxy"
     TS_API_ASYNC_SCORING_PROXY_URL                    = "http://127.0.0.1:8000"
-    BRAINTRUST_UNSAFE_URL_REQUEST_MODE                = var.unsafe_url_request_mode
-    BRAINTRUST_URL_SECURITY_DNS_SERVERS               = var.url_security_dns_servers
-    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS               = var.url_security_allow_cidrs
     },
+    local.url_security_env_vars,
     local.using_brainstore_fast_reader ? {
       BRAINSTORE_FAST_READER_URL           = "http://${var.brainstore_fast_reader_hostname}:${var.brainstore_port}"
       BRAINSTORE_FAST_READER_QUERY_SOURCES = "summaryPaginatedObjectViewer [realtime],summaryPaginatedObjectViewer,a602c972-1843-4ee1-b6bc-d3c1075cd7e7,traceQueryFn-id,traceQueryFn-rootSpanId,fullSpanQueryFn-root_span_id,fullSpanQueryFn-id"

--- a/modules/api-ecs/main.tf
+++ b/modules/api-ecs/main.tf
@@ -20,7 +20,6 @@ locals {
     WHITELISTED_ORIGINS                               = join(",", var.whitelisted_origins)
     OUTBOUND_RATE_LIMIT_WINDOW_MINUTES                = tostring(var.outbound_rate_limit_window_minutes)
     OUTBOUND_RATE_LIMIT_MAX_REQUESTS                  = tostring(var.outbound_rate_limit_max_requests)
-    BRAINTRUST_UNSAFE_URL_REQUEST_MODE                = var.unsafe_url_request_mode
     QUARANTINE_INVOKE_ROLE                            = var.use_quarantine_vpc && var.quarantine_invoke_role_arn != null ? var.quarantine_invoke_role_arn : ""
     QUARANTINE_FUNCTION_ROLE                          = var.use_quarantine_vpc && var.quarantine_function_role_arn != null ? var.quarantine_function_role_arn : ""
     QUARANTINE_PROXY_URL                              = var.quarantine_proxy_url
@@ -52,6 +51,9 @@ locals {
     TS_API_PORT                                       = "8000"
     PROXY_URL                                         = "http://127.0.0.1:8000/v1/proxy"
     TS_API_ASYNC_SCORING_PROXY_URL                    = "http://127.0.0.1:8000"
+    BRAINTRUST_UNSAFE_URL_REQUEST_MODE                = var.unsafe_url_request_mode
+    BRAINTRUST_URL_SECURITY_DNS_SERVERS               = var.url_security_dns_servers
+    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS               = var.url_security_allow_cidrs
     },
     local.using_brainstore_fast_reader ? {
       BRAINSTORE_FAST_READER_URL           = "http://${var.brainstore_fast_reader_hostname}:${var.brainstore_port}"

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -336,6 +336,20 @@ variable "quarantine_proxy_url" {
   description = "URL for the AI proxy function used by quarantine execution."
 }
 
+variable "url_security_dns_servers" {
+  description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "url_security_allow_cidrs" {
+  description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
 variable "extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to inject into the API ECS container."

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -246,13 +246,13 @@ variable "outbound_rate_limit_max_requests" {
 }
 
 variable "unsafe_url_request_mode" {
-  description = "How to handle URL-security validation failures for externally supplied outbound HTTP URLs."
+  description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, proxy to proxy, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
   type        = string
-  default     = "warn"
+  default     = ""
 
   validation {
-    condition     = contains(["off", "proxy", "warn", "reject"], var.unsafe_url_request_mode)
-    error_message = "unsafe_url_request_mode must be one of: off, proxy, warn, reject."
+    condition     = contains(["", "off", "proxy", "warn", "reject"], var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode))
+    error_message = "unsafe_url_request_mode must be empty or one of: off, proxy, warn, reject."
   }
 }
 
@@ -336,18 +336,17 @@ variable "quarantine_proxy_url" {
   description = "URL for the AI proxy function used by quarantine execution."
 }
 
+
 variable "url_security_dns_servers" {
   description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "url_security_allow_cidrs" {
   description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "extra_env_vars" {

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -17,6 +17,10 @@ locals {
     AUTH_CACHE_REDIS_URL        = "redis://${var.redis_host}:${var.redis_port}"
     GATEWAY_JSON_LOGS           = "true"
     OTLP_HTTP_ENDPOINT          = local.observability_enabled ? "http://localhost:4318" : "https://www.braintrust.dev/api/pulse/otel"
+
+    BRAINTRUST_UNSAFE_URL_REQUEST_MODE  = var.unsafe_url_request_mode
+    BRAINTRUST_URL_SECURITY_DNS_SERVERS = var.url_security_dns_servers
+    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = var.url_security_allow_cidrs
     },
     local.observability_enabled ? {
       DD_ENV     = var.internal_observability_env_name

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -3,10 +3,24 @@ locals {
     BraintrustDeploymentName = var.deployment_name
   }, var.custom_tags)
 
-  container_name        = "gateway"
-  container_port        = 8080
-  observability_enabled = var.internal_observability_enabled
-  gateway_version_tag   = element(reverse(split(":", var.container_image)), 0)
+  container_name           = "gateway"
+  container_port           = 8080
+  observability_enabled    = var.internal_observability_enabled
+  gateway_version_tag      = element(reverse(split(":", var.container_image)), 0)
+  unsafe_url_request_mode  = var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode)
+  url_security_dns_servers = var.url_security_dns_servers == null ? "" : trimspace(var.url_security_dns_servers)
+  url_security_allow_cidrs = var.url_security_allow_cidrs == null ? "" : trimspace(var.url_security_allow_cidrs)
+  url_security_env_vars = merge(
+    local.unsafe_url_request_mode != "" ? {
+      BRAINTRUST_UNSAFE_URL_REQUEST_MODE = local.unsafe_url_request_mode
+    } : {},
+    local.url_security_dns_servers != "" ? {
+      BRAINTRUST_URL_SECURITY_DNS_SERVERS = local.url_security_dns_servers
+    } : {},
+    local.url_security_allow_cidrs != "" ? {
+      BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = local.url_security_allow_cidrs
+    } : {}
+  )
   base_env_vars = merge({
     GATEWAY_ENV        = "production"
     GATEWAY_REGION     = data.aws_region.current.region
@@ -17,11 +31,8 @@ locals {
     AUTH_CACHE_REDIS_URL        = "redis://${var.redis_host}:${var.redis_port}"
     GATEWAY_JSON_LOGS           = "true"
     OTLP_HTTP_ENDPOINT          = local.observability_enabled ? "http://localhost:4318" : "https://www.braintrust.dev/api/pulse/otel"
-
-    BRAINTRUST_UNSAFE_URL_REQUEST_MODE  = var.unsafe_url_request_mode
-    BRAINTRUST_URL_SECURITY_DNS_SERVERS = var.url_security_dns_servers
-    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = var.url_security_allow_cidrs
     },
+    local.url_security_env_vars,
     local.observability_enabled ? {
       DD_ENV     = var.internal_observability_env_name
       DD_VERSION = local.gateway_version_tag

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -182,6 +182,32 @@ variable "extra_env_vars" {
   }
 }
 
+variable "unsafe_url_request_mode" {
+  description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, proxy to proxy, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition     = contains(["", "off", "proxy", "warn", "reject"], trimspace(var.unsafe_url_request_mode))
+    error_message = "unsafe_url_request_mode must be empty or one of: off, proxy, warn, reject."
+  }
+}
+
+variable "url_security_dns_servers" {
+  description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "url_security_allow_cidrs" {
+  description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
 variable "braintrust_app_url" {
   type        = string
   description = "Braintrust application URL used by the gateway."
@@ -248,4 +274,3 @@ variable "enable_execute_command" {
   description = "Enable ECS Exec on the gateway service."
   default     = false
 }
-

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -186,10 +186,9 @@ variable "unsafe_url_request_mode" {
   description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, proxy to proxy, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
   type        = string
   default     = ""
-  nullable    = false
 
   validation {
-    condition     = contains(["", "off", "proxy", "warn", "reject"], trimspace(var.unsafe_url_request_mode))
+    condition     = contains(["", "off", "proxy", "warn", "reject"], var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode))
     error_message = "unsafe_url_request_mode must be empty or one of: off, proxy, warn, reject."
   }
 }
@@ -198,14 +197,12 @@ variable "url_security_dns_servers" {
   description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "url_security_allow_cidrs" {
   description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "braintrust_app_url" {

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -2,8 +2,23 @@ locals {
   api_handler_base_function_name = "APIHandler"
   api_handler_function_name      = "${var.deployment_name}-${local.api_handler_base_function_name}"
   api_handler_original_handler   = "index.handler"
+  unsafe_url_request_mode        = var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode)
+  url_security_dns_servers       = var.url_security_dns_servers == null ? "" : trimspace(var.url_security_dns_servers)
+  url_security_allow_cidrs       = var.url_security_allow_cidrs == null ? "" : trimspace(var.url_security_allow_cidrs)
+  url_security_env_vars = merge(
+    local.unsafe_url_request_mode != "" ? {
+      BRAINTRUST_UNSAFE_URL_REQUEST_MODE = local.unsafe_url_request_mode
+    } : {},
+    local.url_security_dns_servers != "" ? {
+      BRAINTRUST_URL_SECURITY_DNS_SERVERS = local.url_security_dns_servers
+    } : {},
+    local.url_security_allow_cidrs != "" ? {
+      BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = local.url_security_allow_cidrs
+    } : {}
+  )
+
   # Shared between the AI Proxy and API Handler
-  api_common_env_vars = {
+  api_common_env_vars = merge({
     ORG_NAME                   = var.braintrust_org_name
     PRIMARY_ORG_NAME           = var.primary_org_name
     ALLOWED_ORG_IDS            = var.allowed_org_ids
@@ -40,13 +55,9 @@ locals {
     TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
     TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
 
-    BRAINTRUST_UNSAFE_URL_REQUEST_MODE  = var.unsafe_url_request_mode
-    BRAINTRUST_URL_SECURITY_DNS_SERVERS = var.url_security_dns_servers
-    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = var.url_security_allow_cidrs
-
     SERVICE_TOKEN_SECRET_KEY = var.function_tools_secret_key
     CRON_OVERRIDE_SECRET_KEY = random_password.service_token_secret_key.result
-  }
+  }, local.url_security_env_vars)
   api_fast_reader_env_vars = local.using_brainstore_fast_reader ? {
     BRAINSTORE_FAST_READER_URL           = local.brainstore_fast_reader_url
     BRAINSTORE_FAST_READER_QUERY_SOURCES = join(",", local.default_fast_reader_query_sources)

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -40,6 +40,10 @@ locals {
     TELEMETRY_DISABLE_AGGREGATION = var.disable_billing_telemetry_aggregation
     TELEMETRY_LOG_LEVEL           = var.billing_telemetry_log_level
 
+    BRAINTRUST_UNSAFE_URL_REQUEST_MODE  = var.unsafe_url_request_mode
+    BRAINTRUST_URL_SECURITY_DNS_SERVERS = var.url_security_dns_servers
+    BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = var.url_security_allow_cidrs
+
     SERVICE_TOKEN_SECRET_KEY = var.function_tools_secret_key
     CRON_OVERRIDE_SECRET_KEY = random_password.service_token_secret_key.result
   }
@@ -55,8 +59,6 @@ locals {
       AI_PROXY_INVOKE_ROLE = aws_iam_role.ai_proxy_invoke_role.arn
       CATCHUP_ETL_ARN      = aws_lambda_function.catchup_etl.arn
       INSERT_LOGS2         = "true"
-
-      BRAINTRUST_UNSAFE_URL_REQUEST_MODE = var.unsafe_url_request_mode
     },
     var.brainstore_wal_footer_version != "" ? {
       BRAINSTORE_WAL_FOOTER_VERSION = var.brainstore_wal_footer_version

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -262,6 +262,20 @@ variable "skip_pg_for_brainstore_objects" {
   }
 }
 
+variable "url_security_dns_servers" {
+  description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "url_security_allow_cidrs" {
+  description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
 variable "brainstore_enable_export" {
   type        = bool
   description = "If true, sets BRAINSTORE_EXPORT_MIGRATION_ENABLED=true on the API Handler Lambda."

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -163,13 +163,13 @@ variable "outbound_rate_limit_window_minutes" {
 }
 
 variable "unsafe_url_request_mode" {
-  description = "How to handle URL-security validation failures for externally supplied outbound HTTP URLs."
+  description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, proxy to proxy, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
   type        = string
-  default     = "warn"
+  default     = ""
 
   validation {
-    condition     = contains(["off", "proxy", "warn", "reject"], var.unsafe_url_request_mode)
-    error_message = "unsafe_url_request_mode must be one of: off, proxy, warn, reject."
+    condition     = contains(["", "off", "proxy", "warn", "reject"], var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode))
+    error_message = "unsafe_url_request_mode must be empty or one of: off, proxy, warn, reject."
   }
 }
 
@@ -262,18 +262,17 @@ variable "skip_pg_for_brainstore_objects" {
   }
 }
 
+
 variable "url_security_dns_servers" {
   description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "url_security_allow_cidrs" {
   description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "brainstore_enable_export" {

--- a/variables.tf
+++ b/variables.tf
@@ -499,6 +499,20 @@ variable "ai_gateway_braintrust_app_url" {
   default     = "https://www.braintrust.dev"
 }
 
+variable "url_security_dns_servers" {
+  description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "url_security_allow_cidrs" {
+  description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
 variable "api_ecs_version_override" {
   type        = string
   description = "Optional API ECS image tag override. If unset, uses modules/api-ecs/VERSIONS.json."

--- a/variables.tf
+++ b/variables.tf
@@ -499,18 +499,17 @@ variable "ai_gateway_braintrust_app_url" {
   default     = "https://www.braintrust.dev"
 }
 
+
 variable "url_security_dns_servers" {
   description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VPC or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "url_security_allow_cidrs" {
   description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
   type        = string
   default     = ""
-  nullable    = false
 }
 
 variable "api_ecs_version_override" {
@@ -756,13 +755,13 @@ variable "outbound_rate_limit_window_minutes" {
 }
 
 variable "unsafe_url_request_mode" {
-  description = "How to handle URL-security validation failures for externally supplied outbound HTTP URLs."
+  description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, proxy to proxy, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
   type        = string
-  default     = "warn"
+  default     = ""
 
   validation {
-    condition     = contains(["off", "proxy", "warn", "reject"], var.unsafe_url_request_mode)
-    error_message = "unsafe_url_request_mode must be one of: off, proxy, warn, reject."
+    condition     = contains(["", "off", "proxy", "warn", "reject"], var.unsafe_url_request_mode == null ? "" : trimspace(var.unsafe_url_request_mode))
+    error_message = "unsafe_url_request_mode must be empty or one of: off, proxy, warn, reject."
   }
 }
 


### PR DESCRIPTION
### Context

Braintrust backends perform URL-security checks for outbound requests to user-supplied URLs. Operators need Terraform-level controls to tune how unsafe URLs are handled and which trusted DNS resolvers or CIDR exceptions should be used in their AWS data plane.

### Description

- Add root Terraform inputs for unsafe URL request mode, URL-security DNS resolvers, and URL-security allow CIDRs.
- Pass those values through to API Handler/AI Proxy Lambdas, API ECS, and gateway ECS so the backends receive consistent URL-security configuration.
- Keep defaults empty/non-null so existing deployments retain the application defaults: warn mode, default resolver behavior, and no additional allow CIDRs.
- Update examples with commented URL-security configuration guidance, including a note that external EKS workloads need matching env vars in their own manifests.
