### PR TITLE
Enable fast readers by default

### DIFF
--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -57,6 +57,9 @@ module "braintrust-data-plane" {
   brainstore_writer_instance_count = 1
   brainstore_writer_instance_type  = "c8gd.xlarge"
 
+  # Disable fast readers to reduce costs in sandbox. Production deployments enable by default.
+  brainstore_fast_reader_instance_count = 0
+
   ### WARNING: skip_pg_for_brainstore_objects is safe for fresh sandbox deployments
   ### but can cause data loss or downtime if applied incorrectly to existing
   ### production environments. It is a ONE-WAY operation that cannot be rolled

--- a/variables.tf
+++ b/variables.tf
@@ -899,7 +899,7 @@ variable "brainstore_extra_env_vars_writer" {
 variable "brainstore_fast_reader_instance_count" {
   type        = number
   description = "The number of dedicated fast reader nodes to create"
-  default     = 0
+  default     = 2
 }
 
 variable "brainstore_fast_reader_instance_type" {


### PR DESCRIPTION
## Summary

This PR changes the default value of `brainstore_fast_reader_instance_count` from `0` to `2`, enabling fast readers by default in the Terraform AWS module. This aligns with the Helm chart's default behavior and matches the production example configuration.

## Context

Fast readers are considered required now for production deployments. Fast readers handle known good queries that are used for interactive features in the braintrust UI. This isolates slower and expensive adhoc queries to the standard reader hardware and helps prevent UI slowness issues.
