### PR TITLE
AI gateway variable naming

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -91,8 +91,8 @@ module "braintrust-data-plane" {
   redis_version = "7.0"
 
   # Only use this when instructed to by the Braintrust team.
-  # use_global_gateway_origin   = false
-  # global_gateway_origin_domain = "gateway.braintrust.dev"
+  # use_global_ai_gateway_origin   = false
+  # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
   ### Network configuration
   # WARNING: You should choose these values carefully after discussing with your networking team.

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -78,8 +78,8 @@ module "braintrust-data-plane" {
   redis_version       = "7.0"
 
   # Only use this when instructed to by the Braintrust team.
-  # use_global_gateway_origin   = false
-  # global_gateway_origin_domain = "gateway.braintrust.dev"
+  # use_global_ai_gateway_origin   = false
+  # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
   ### Network configuration
   # Defaults are fine for most sandbox deployments. Only change if you need to

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -105,8 +105,8 @@ module "braintrust-data-plane" {
   # ai_proxy_reserved_concurrent_executions    = -1
 
   # Only use this when instructed to by the Braintrust team.
-  # use_global_gateway_origin   = false
-  # global_gateway_origin_domain = "gateway.braintrust.dev"
+  # use_global_ai_gateway_origin   = false
+  # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -7,8 +7,8 @@ module "braintrust-data-plane" {
   # ... your eixsting configuration ...
 
   # Only use this when instructed to by the Braintrust team.
-  # use_global_gateway_origin   = false
-  # global_gateway_origin_domain = "gateway.braintrust.dev"
+  # use_global_ai_gateway_origin   = false
+  # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 }
 
 ###############################################################################

--- a/main.tf
+++ b/main.tf
@@ -244,7 +244,7 @@ module "services" {
 
 module "ecs" {
   source = "./modules/ecs"
-  count  = var.enable_llm_gateway || local.create_ecs_api ? 1 : 0
+  count  = var.enable_ai_gateway || local.create_ecs_api ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -254,7 +254,7 @@ module "ecs" {
 
 module "gateway_ecs" {
   source = "./modules/gateway-ecs"
-  count  = var.enable_llm_gateway ? 1 : 0
+  count  = var.enable_ai_gateway ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -264,16 +264,16 @@ module "gateway_ecs" {
   ecs_cluster_name   = module.ecs[0].cluster_name
   container_image = format(
     "public.ecr.aws/braintrust/gateway:%s",
-    var.gateway_version_override == null ? "prerelease" : var.gateway_version_override
+    var.ai_gateway_version_override == null ? "prerelease" : var.ai_gateway_version_override
   )
-  cpu                       = var.gateway_cpu
-  memory                    = var.gateway_memory
-  cpu_architecture          = var.gateway_cpu_architecture
-  min_capacity              = var.gateway_min_capacity
-  max_capacity              = var.gateway_max_capacity
-  target_cpu_utilization    = var.gateway_target_cpu_utilization
-  target_memory_utilization = var.gateway_target_memory_utilization
-  log_retention_days        = var.gateway_log_retention_days
+  cpu                       = var.ai_gateway_cpu
+  memory                    = var.ai_gateway_memory
+  cpu_architecture          = var.ai_gateway_cpu_architecture
+  min_capacity              = var.ai_gateway_min_capacity
+  max_capacity              = var.ai_gateway_max_capacity
+  target_cpu_utilization    = var.ai_gateway_target_cpu_utilization
+  target_memory_utilization = var.ai_gateway_target_memory_utilization
+  log_retention_days        = var.ai_gateway_log_retention_days
   redis_host                = module.redis.redis_endpoint
   redis_port                = module.redis.redis_port
   redis_security_group_id   = module.redis.redis_security_group_id
@@ -282,13 +282,13 @@ module "gateway_ecs" {
       "API"        = module.services_common.api_security_group_id
       "Brainstore" = module.services_common.brainstore_instance_security_group_id
     },
-    var.gateway_authorized_security_groups,
+    var.ai_gateway_authorized_security_groups,
   )
-  extra_env_vars         = var.gateway_extra_env_vars
+  extra_env_vars         = var.ai_gateway_extra_env_vars
   custom_tags            = var.custom_tags
   brainstore_license_key = var.brainstore_license_key
-  enable_execute_command = var.gateway_enable_execute_command
-  braintrust_app_url     = var.gateway_braintrust_app_url
+  enable_execute_command = var.ai_gateway_enable_execute_command
+  braintrust_app_url     = var.ai_gateway_braintrust_app_url
   braintrust_api_url     = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
 }
 
@@ -381,18 +381,18 @@ module "ingress" {
   source = "./modules/ingress"
   count  = !var.use_deployment_mode_external_eks ? 1 : 0
 
-  deployment_name                = var.deployment_name
-  custom_domain                  = var.custom_domain
-  custom_certificate_arn         = var.custom_certificate_arn
-  waf_acl_id                     = var.waf_acl_id
-  cloudfront_price_class         = var.cloudfront_price_class
-  cloudfront_origin_read_timeout = var.cloudfront_origin_read_timeout
-  use_global_ai_proxy            = var.use_global_ai_proxy
-  use_global_gateway_origin      = var.use_global_gateway_origin
-  global_gateway_origin_domain   = var.global_gateway_origin_domain
-  ai_proxy_function_url          = module.services[0].ai_proxy_url
-  api_handler_function_arn       = module.services[0].api_handler_arn
-  custom_tags                    = var.custom_tags
+  deployment_name                 = var.deployment_name
+  custom_domain                   = var.custom_domain
+  custom_certificate_arn          = var.custom_certificate_arn
+  waf_acl_id                      = var.waf_acl_id
+  cloudfront_price_class          = var.cloudfront_price_class
+  cloudfront_origin_read_timeout  = var.cloudfront_origin_read_timeout
+  use_global_ai_proxy             = var.use_global_ai_proxy
+  use_global_ai_gateway_origin    = var.use_global_ai_gateway_origin
+  global_ai_gateway_origin_domain = var.global_ai_gateway_origin_domain
+  ai_proxy_function_url           = module.services[0].ai_proxy_url
+  api_handler_function_arn        = module.services[0].api_handler_arn
+  custom_tags                     = var.custom_tags
 }
 
 module "services_common" {

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -72,7 +72,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
   }
 
   origin {
-    domain_name = trimsuffix(replace(var.global_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")
+    domain_name = trimsuffix(replace(var.global_ai_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")
     origin_id   = local.cloudfront_GatewayOrigin
 
     custom_origin_config {
@@ -101,7 +101,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
       path_pattern           = ordered_cache_behavior.value
       allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
       cached_methods         = ["GET", "HEAD", "OPTIONS"]
-      target_origin_id       = var.use_global_gateway_origin ? local.cloudfront_GatewayOrigin : local.cloudfront_ProxyOrigin
+      target_origin_id       = var.use_global_ai_gateway_origin ? local.cloudfront_GatewayOrigin : local.cloudfront_ProxyOrigin
       viewer_protocol_policy = "redirect-to-https"
 
       cache_policy_id          = local.cloudfront_CachingDisabled

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -27,14 +27,14 @@ variable "use_global_ai_proxy" {
   default     = false
 }
 
-variable "use_global_gateway_origin" {
+variable "use_global_ai_gateway_origin" {
   description = "Whether to route /v1/proxy traffic to gateway.braintrust.dev"
   type        = bool
   default     = false
 }
 
-variable "global_gateway_origin_domain" {
-  description = "Gateway origin domain to use when use_global_gateway_origin is enabled"
+variable "global_ai_gateway_origin_domain" {
+  description = "Gateway origin domain to use when use_global_ai_gateway_origin is enabled"
   type        = string
   default     = "gateway.braintrust.dev"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,32 +74,32 @@ output "api_security_group_id" {
 }
 
 output "ecs_cluster_arn" {
-  value       = var.enable_llm_gateway || local.create_ecs_api ? module.ecs[0].cluster_arn : null
+  value       = var.enable_ai_gateway || local.create_ecs_api ? module.ecs[0].cluster_arn : null
   description = "ARN of the ECS cluster used for ECS services"
 }
 
 output "gateway_service_name" {
-  value       = var.enable_llm_gateway ? module.gateway_ecs[0].service_name : null
+  value       = var.enable_ai_gateway ? module.gateway_ecs[0].service_name : null
   description = "Name of the ECS gateway service"
 }
 
 output "gateway_alb_dns_name" {
-  value       = var.enable_llm_gateway ? module.gateway_ecs[0].alb_dns_name : null
+  value       = var.enable_ai_gateway ? module.gateway_ecs[0].alb_dns_name : null
   description = "Internal DNS name of the private gateway ALB"
 }
 
 output "gateway_alb_arn" {
-  value       = var.enable_llm_gateway ? module.gateway_ecs[0].alb_arn : null
+  value       = var.enable_ai_gateway ? module.gateway_ecs[0].alb_arn : null
   description = "ARN of the private gateway ALB"
 }
 
 output "gateway_target_group_arn" {
-  value       = var.enable_llm_gateway ? module.gateway_ecs[0].target_group_arn : null
+  value       = var.enable_ai_gateway ? module.gateway_ecs[0].target_group_arn : null
   description = "ARN of the gateway ALB target group"
 }
 
 output "gateway_task_security_group_id" {
-  value       = var.enable_llm_gateway ? module.gateway_ecs[0].task_security_group_id : null
+  value       = var.enable_ai_gateway ? module.gateway_ecs[0].task_security_group_id : null
   description = "ID of the security group for ECS gateway tasks"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -325,7 +325,7 @@ variable "redis_authorized_security_groups" {
 
 ## Services
 
-variable "enable_llm_gateway" {
+variable "enable_ai_gateway" {
   description = "Enable ECS gateway service deployment (Fargate with private ALB)"
   type        = bool
   default     = false
@@ -342,115 +342,115 @@ variable "container_insights" {
   }
 }
 
-variable "gateway_version_override" {
+variable "ai_gateway_version_override" {
   type        = string
   description = "Lock Gateway on a specific version. Don't set this unless instructed by Braintrust."
   default     = null
 
   validation {
-    condition     = var.gateway_version_override == null || var.gateway_version_override != ""
-    error_message = "gateway_version_override must be null or a non-empty string."
+    condition     = var.ai_gateway_version_override == null || var.ai_gateway_version_override != ""
+    error_message = "ai_gateway_version_override must be null or a non-empty string."
   }
 }
 
-variable "gateway_cpu" {
+variable "ai_gateway_cpu" {
   description = "CPU units for the gateway ECS task definition"
   type        = number
   default     = 2048
 }
 
-variable "gateway_memory" {
+variable "ai_gateway_memory" {
   description = "Memory in MiB for the gateway ECS task definition"
   type        = number
   default     = 4096
 }
 
-variable "gateway_min_capacity" {
+variable "ai_gateway_min_capacity" {
   description = "Minimum task count for the gateway ECS service"
   type        = number
   default     = 2
 }
 
-variable "gateway_max_capacity" {
+variable "ai_gateway_max_capacity" {
   description = "Maximum task count for the gateway ECS service"
   type        = number
   default     = 6
 
   validation {
-    condition     = var.gateway_max_capacity >= var.gateway_min_capacity
-    error_message = "gateway_max_capacity must be greater than or equal to gateway_min_capacity."
+    condition     = var.ai_gateway_max_capacity >= var.ai_gateway_min_capacity
+    error_message = "ai_gateway_max_capacity must be greater than or equal to ai_gateway_min_capacity."
   }
 }
 
-variable "gateway_target_cpu_utilization" {
+variable "ai_gateway_target_cpu_utilization" {
   description = "Target average CPU utilization percentage for gateway ECS autoscaling"
   type        = number
   default     = 70
 
   validation {
-    condition     = var.gateway_target_cpu_utilization > 0 && var.gateway_target_cpu_utilization <= 100
-    error_message = "gateway_target_cpu_utilization must be between 1 and 100."
+    condition     = var.ai_gateway_target_cpu_utilization > 0 && var.ai_gateway_target_cpu_utilization <= 100
+    error_message = "ai_gateway_target_cpu_utilization must be between 1 and 100."
   }
 }
 
-variable "gateway_target_memory_utilization" {
+variable "ai_gateway_target_memory_utilization" {
   description = "Target average memory utilization percentage for gateway ECS autoscaling"
   type        = number
   default     = 75
 
   validation {
-    condition     = var.gateway_target_memory_utilization > 0 && var.gateway_target_memory_utilization <= 100
-    error_message = "gateway_target_memory_utilization must be between 1 and 100."
+    condition     = var.ai_gateway_target_memory_utilization > 0 && var.ai_gateway_target_memory_utilization <= 100
+    error_message = "ai_gateway_target_memory_utilization must be between 1 and 100."
   }
 }
 
-variable "gateway_log_retention_days" {
+variable "ai_gateway_log_retention_days" {
   description = "CloudWatch log retention period (days) for gateway ECS logs"
   type        = number
   default     = 14
 
   validation {
     condition = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
-    ], var.gateway_log_retention_days)
-    error_message = "gateway_log_retention_days must be a valid CloudWatch Logs retention value."
+    ], var.ai_gateway_log_retention_days)
+    error_message = "ai_gateway_log_retention_days must be a valid CloudWatch Logs retention value."
   }
 }
 
-variable "gateway_extra_env_vars" {
+variable "ai_gateway_extra_env_vars" {
   description = "Extra environment variables for the gateway ECS container"
   type        = map(string)
   default     = {}
 
   validation {
-    condition     = !contains(keys(var.gateway_extra_env_vars), "BRAINSTORE_LICENSE_KEY")
-    error_message = "Do not set BRAINSTORE_LICENSE_KEY in gateway_extra_env_vars; use brainstore_license_key."
+    condition     = !contains(keys(var.ai_gateway_extra_env_vars), "BRAINSTORE_LICENSE_KEY")
+    error_message = "Do not set BRAINSTORE_LICENSE_KEY in ai_gateway_extra_env_vars; use brainstore_license_key."
   }
 }
 
-variable "gateway_cpu_architecture" {
+variable "ai_gateway_cpu_architecture" {
   description = "CPU architecture for the gateway ECS task definition."
   type        = string
   default     = "ARM64"
 
   validation {
-    condition     = contains(["ARM64", "X86_64"], var.gateway_cpu_architecture)
-    error_message = "gateway_cpu_architecture must be either ARM64 or X86_64."
+    condition     = contains(["ARM64", "X86_64"], var.ai_gateway_cpu_architecture)
+    error_message = "ai_gateway_cpu_architecture must be either ARM64 or X86_64."
   }
 }
 
-variable "gateway_authorized_security_groups" {
+variable "ai_gateway_authorized_security_groups" {
   description = "Map of security group names to their IDs that are authorized to access the internal gateway ALB. Format: { name = <security_group_id> }"
   type        = map(string)
   default     = {}
 }
 
-variable "gateway_enable_execute_command" {
+variable "ai_gateway_enable_execute_command" {
   description = "Enable ECS Exec for gateway tasks."
   type        = bool
   default     = false
 }
 
-variable "gateway_braintrust_app_url" {
+variable "ai_gateway_braintrust_app_url" {
   description = "Braintrust app URL used by the gateway service."
   type        = string
   default     = "https://www.braintrust.dev"
@@ -594,8 +594,8 @@ variable "braintrust_api_url" {
   default     = null
 
   validation {
-    condition     = !(var.use_deployment_mode_external_eks && var.enable_llm_gateway) || var.braintrust_api_url != null
-    error_message = "braintrust_api_url is required when use_deployment_mode_external_eks and enable_llm_gateway are both true."
+    condition     = !(var.use_deployment_mode_external_eks && var.enable_ai_gateway) || var.braintrust_api_url != null
+    error_message = "braintrust_api_url is required when use_deployment_mode_external_eks and enable_ai_gateway are both true."
   }
 }
 
@@ -972,14 +972,14 @@ variable "use_global_ai_proxy" {
   default     = false
 }
 
-variable "use_global_gateway_origin" {
+variable "use_global_ai_gateway_origin" {
   description = "Whether to route /v1/proxy traffic to gateway.braintrust.dev. Don't enable this unless instructed by Braintrust."
   type        = bool
   default     = false
 }
 
-variable "global_gateway_origin_domain" {
-  description = "Gateway origin domain to use when use_global_gateway_origin is enabled. Don't change this unless instructed by Braintrust."
+variable "global_ai_gateway_origin_domain" {
+  description = "Gateway origin domain to use when use_global_ai_gateway_origin is enabled. Don't change this unless instructed by Braintrust."
   type        = string
   default     = "gateway.braintrust.dev"
 }


### PR DESCRIPTION
This update renames variables and outputs related to the gateway to reflect current naming of Braintrust's gateway service. Changes include updating variable names and output values to use `enable_ai_gateway` instead of `enable_llm_gateway`, ensuring consistency across the module.

Since these variables should be unused unless used without documentation, I'm doing a full replacement without deprecation marking on the old variables. 