### PR TITLE
Transition Brainstore WAL objects to Standard-IA

### DIFF
--- a/modules/storage/s3-brainstore.tf
+++ b/modules/storage/s3-brainstore.tf
@@ -91,7 +91,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "brainstore" {
     filter {
       and {
         # !IMPORTANT!: do not change this path
-        prefix                   = "brainstore/wal/"
+        prefix                   = "brainstore/wal/object-store-objects/"
         object_size_greater_than = 0
       }
     }

--- a/modules/storage/s3-brainstore.tf
+++ b/modules/storage/s3-brainstore.tf
@@ -85,6 +85,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "brainstore" {
   }
 
   rule {
+    id     = "transition-wal-to-standard-ia"
+    status = "Enabled"
+
+    filter {
+      and {
+        # !IMPORTANT!: do not change this path
+        prefix                   = "brainstore/wal/"
+        object_size_greater_than = 0
+      }
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  rule {
     id     = "delete-wal-deletion-logs"
     status = "Enabled"
 

--- a/modules/storage/s3-brainstore.tf
+++ b/modules/storage/s3-brainstore.tf
@@ -85,24 +85,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "brainstore" {
   }
 
   rule {
-    id     = "transition-wal-to-standard-ia"
-    status = "Enabled"
-
-    filter {
-      and {
-        # !IMPORTANT!: do not change this path
-        prefix                   = "brainstore/wal/object-store-objects/"
-        object_size_greater_than = 0
-      }
-    }
-
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-  }
-
-  rule {
     id     = "delete-wal-deletion-logs"
     status = "Enabled"
 
@@ -115,6 +97,23 @@ resource "aws_s3_bucket_lifecycle_configuration" "brainstore" {
       # We use the same var for the expiration interval and the delete interval
       # in cleanup-old-versions so the total time to deletion is 2 * var.s3_bucket_retention_days
       days = var.brainstore_s3_bucket_retention_days
+    }
+  }
+
+  rule {
+    id     = "transition-wal-to-standard-ia"
+    status = "Enabled"
+
+    filter {
+      and {
+        prefix                   = "brainstore/wal/object-store-objects/"
+        object_size_greater_than = 1
+      }
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
   }
 }


### PR DESCRIPTION
No customer action needed. Brainstore WAL files are primarily used during initial ingestion. They can be safely transitioned to S3 Infrequent Access tier to save on storage costs. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an always-enabled S3 lifecycle rule for Brainstore WAL object-store objects under `brainstore/wal/object-store-objects/`
- Transition positive-sized matching objects to `STANDARD_IA` after 30 days

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://braintrustdata.slack.com/archives/C0B8PHDQTCJ/p1781015090391289?thread_ts=1781015090.391289&cid=C0B8PHDQTCJ)

<div><a href="https://cursor.com/agents/bc-e48d03a5-75b1-50ab-a529-c46950503461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e48d03a5-75b1-50ab-a529-c46950503461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

