### PR TITLE
Retry external lambda-version HTTP lookups

### DIFF
--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -64,6 +64,15 @@ data "http" "lambda_versions" {
 
   url = "https://${local.lambda_s3_bucket}.s3.${data.aws_region.current.region}.amazonaws.com/lambda/${each.value}/version-${local.lambda_version_tag}"
 
+  # External S3 lookups are otherwise a single attempt with no backoff, so a
+  # transient network blip (connection reset) fails the whole plan. Retry.
+  retry {
+    attempts     = 5
+    min_delay_ms = 500
+    max_delay_ms = 5000
+  }
+  request_timeout_ms = 10000
+
   lifecycle {
     postcondition {
       condition     = self.status_code < 400

--- a/modules/services/versions.tf
+++ b/modules/services/versions.tf
@@ -7,7 +7,9 @@ terraform {
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.0"
+      # 3.3.0 is the first release with the data source's retry block and
+      # request_timeout_ms (used in modules/services/main.tf).
+      version = "~> 3.3"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## What
`data.http.lambda_versions` (in `modules/services`) does single-attempt S3 GETs with no backoff — the `http` provider defaults to 1 attempt. A transient network blip (e.g. `connection reset by peer`) on any one of the per-Lambda lookups fails the entire `plan`/`apply`.

## Change
Add a `retry` block (5 attempts, 0.5–5s backoff) and a 10s `request_timeout_ms` to the lookup.

## Why
These are external network calls during refresh; they should ride through transient resets (common on VPN'd/corporate networks) instead of aborting the whole run. No behavior change on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)