### PR TITLE
Add separate bucket additional allowed origins

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -107,4 +107,13 @@ module "braintrust-data-plane" {
   # custom_tags = {
   #   CustomTagKey = "SomeValue"
   # }
+
+  ### S3 CORS configuration
+  # Additional CORS origins for the code bundle and lambda responses buckets.
+  # Use s3_additional_allowed_origins to apply the same origins to both buckets,
+  # or set per-bucket vars to scope an origin to just one bucket. Values from all
+  # three are merged. Supports wildcards in the domain name.
+  # s3_additional_allowed_origins                  = ["https://app.example.com"]
+  # s3_code_bundle_additional_allowed_origins      = []
+  # s3_lambda_responses_additional_allowed_origins = []
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -86,4 +86,13 @@ module "braintrust-data-plane" {
   # peer with other VPCs and the default CIDRs conflict.
   # vpc_cidr            = "10.175.0.0/21"
   # quarantine_vpc_cidr = "10.175.8.0/21"
+
+  ### S3 CORS configuration
+  # Additional CORS origins for the code bundle and lambda responses buckets.
+  # Use s3_additional_allowed_origins to apply the same origins to both buckets,
+  # or set per-bucket vars to scope an origin to just one bucket. Values from all
+  # three are merged. Supports wildcards in the domain name.
+  # s3_additional_allowed_origins                  = ["https://app.example.com"]
+  # s3_code_bundle_additional_allowed_origins      = []
+  # s3_lambda_responses_additional_allowed_origins = []
 }

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -125,6 +125,16 @@ module "braintrust-data-plane" {
   # }
 
 
+  ### S3 CORS configuration
+  # Additional CORS origins for the code bundle and lambda responses buckets.
+  # Use s3_additional_allowed_origins to apply the same origins to both buckets,
+  # or set per-bucket vars to scope an origin to just one bucket. Values from all
+  # three are merged. Supports wildcards in the domain name.
+  # s3_additional_allowed_origins                  = ["https://app.example.com"]
+  # s3_code_bundle_additional_allowed_origins      = []
+  # s3_lambda_responses_additional_allowed_origins = []
+
+
   ### Braintrust Remote Support
 
   # Enable sharing of Cloudwatch logs with Braintrust staff

--- a/main.tf
+++ b/main.tf
@@ -150,12 +150,14 @@ module "redis" {
 module "storage" {
   source = "./modules/storage"
 
-  deployment_name                     = var.deployment_name
-  kms_key_arn                         = local.kms_key_arn
-  brainstore_s3_bucket_retention_days = var.brainstore_s3_bucket_retention_days
-  s3_additional_allowed_origins       = var.s3_additional_allowed_origins
-  enable_s3_bucket_abac               = var.enable_s3_bucket_abac
-  custom_tags                         = var.custom_tags
+  deployment_name                                = var.deployment_name
+  kms_key_arn                                    = local.kms_key_arn
+  brainstore_s3_bucket_retention_days            = var.brainstore_s3_bucket_retention_days
+  s3_additional_allowed_origins                  = var.s3_additional_allowed_origins
+  s3_code_bundle_additional_allowed_origins      = var.s3_code_bundle_additional_allowed_origins
+  s3_lambda_responses_additional_allowed_origins = var.s3_lambda_responses_additional_allowed_origins
+  enable_s3_bucket_abac                          = var.enable_s3_bucket_abac
+  custom_tags                                    = var.custom_tags
 }
 
 module "services" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -3,10 +3,20 @@ locals {
   default_origins = [
     "https://braintrust.dev",
     "https://*.braintrust.dev",
-    "https://*.preview.braintrust.dev"
+    "https://*.preview.braintrust.dev",
   ]
 
-  all_origins = concat(local.default_origins, var.s3_additional_allowed_origins)
+  code_bundle_allowed_origins = distinct(concat(
+    local.default_origins,
+    var.s3_additional_allowed_origins,
+    var.s3_code_bundle_additional_allowed_origins,
+  ))
+
+  lambda_responses_allowed_origins = distinct(concat(
+    local.default_origins,
+    var.s3_additional_allowed_origins,
+    var.s3_lambda_responses_additional_allowed_origins,
+  ))
 
   common_tags = merge({
     BraintrustDeploymentName = var.deployment_name

--- a/modules/storage/s3-code-bundle.tf
+++ b/modules/storage/s3-code-bundle.tf
@@ -47,7 +47,7 @@ resource "aws_s3_bucket_cors_configuration" "code_bundle_bucket" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT", "GET", "HEAD"]
-    allowed_origins = local.all_origins
+    allowed_origins = local.code_bundle_allowed_origins
     max_age_seconds = 3600
   }
 }

--- a/modules/storage/s3-lambda-responses.tf
+++ b/modules/storage/s3-lambda-responses.tf
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_cors_configuration" "lambda_responses_bucket" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "HEAD"]
-    allowed_origins = local.all_origins
+    allowed_origins = local.lambda_responses_allowed_origins
     max_age_seconds = 3600
   }
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -16,8 +16,20 @@ variable "brainstore_s3_bucket_retention_days" {
 }
 
 variable "s3_additional_allowed_origins" {
+  description = "Additional CORS origins applied to both the code bundle and lambda responses buckets. Merged with any bucket-specific values from s3_code_bundle_additional_allowed_origins and s3_lambda_responses_additional_allowed_origins. Supports wildcards in the domain name."
   type        = list(string)
-  description = "Additional origins to allow for S3 bucket CORS configuration. Supports a wildcard in the domain name."
+  default     = []
+}
+
+variable "s3_code_bundle_additional_allowed_origins" {
+  description = "Additional CORS origins for the code bundle bucket. Supports wildcards in the domain name."
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_lambda_responses_additional_allowed_origins" {
+  description = "Additional CORS origins for the lambda responses bucket. Supports wildcards in the domain name."
+  type        = list(string)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -663,7 +663,19 @@ variable "whitelisted_origins" {
 }
 
 variable "s3_additional_allowed_origins" {
-  description = "Additional origins to allow for S3 bucket CORS configuration. Supports a wildcard in the domain name."
+  description = "Additional CORS origins applied to both the code bundle and lambda responses buckets. Merged with any bucket-specific values from s3_code_bundle_additional_allowed_origins and s3_lambda_responses_additional_allowed_origins. Supports wildcards in the domain name."
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_code_bundle_additional_allowed_origins" {
+  description = "Additional CORS origins for the code bundle bucket only. Supports wildcards in the domain name."
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_lambda_responses_additional_allowed_origins" {
+  description = "Additional CORS origins for the lambda responses bucket only. Supports wildcards in the domain name."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Context

There is currently one `s3_additional_allowed_origins` variable that can be used to set additional allowed origins on the CORS policies for both the lambda_responses_bucket and code_bundles bucket. There are cases where it may be desired to set additional origins on one of these buckets but not the other, but this isn't currently supported by the module.

## Description

This change leaves `s3_additional_allowed_origins` unchanged and introduces two new optional variables—`s3_code_bundle_additional_allowed_origins` and `s3_code_bundle_additional_allowed_origins`—that can be used to set additional allowed origins on the respective S3 bucket CORS policies. The new behavior is as follows...

- (EXISTING) origins set in the `s3_additional_allowed_origins` list will be applied to both the code_bundle_bucket and lambda_responses_bucket

- (NEW) origins set in the (NEW) `s3_code_bundle_additional_allowed_origins` list will be applied to the code_bundle_bucket only

- (NEW) origins set in the `s3_lambda_responses_additional_allowed_origins`list will be applied to the lambda_responses_bucket only

All three variables are optional and are typed as lists of strings. 