### PR TITLE
Revert change to transition WAL to IA tier

### DIFF
--- a/modules/storage/s3-brainstore.tf
+++ b/modules/storage/s3-brainstore.tf
@@ -99,23 +99,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "brainstore" {
       days = var.brainstore_s3_bucket_retention_days
     }
   }
-
-  rule {
-    id     = "transition-wal-to-standard-ia"
-    status = "Enabled"
-
-    filter {
-      and {
-        prefix                   = "brainstore/wal/object-store-objects/"
-        object_size_greater_than = 1
-      }
-    }
-
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "brainstore" {


### PR DESCRIPTION
## Description 
<!-- Help the reviewer understand what you changed and what the expected behavior is now -->
<!-- Include exact details of what customers need to do, or what they should expect, if anything -->
Revert the change to transition WAL files to Infrequent Access tier in S3. There are so many small WAL files that the cost to transition them exceeds the storage cost savings.

## Context 
<!-- Help the reviewer understand the background on why you are doing this -->
WAL files are primarily only needed during initial ingestion. We recently shipped a change to transition them to cheaper storage. Unfortunately that change did not end up saving money because of the large number of WAL files being written. AWS charges per 1000 objects transitioned.

## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
