### PR TITLE
Enable optional observability for gateway and add ALB config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ locals {
   create_ecs_api                             = !var.use_deployment_mode_external_eks && var.create_ecs_api
   enable_ecs_api                             = local.create_ecs_api && var.enable_ecs_api
   enable_internal_observability              = trimspace(nonsensitive(var.internal_observability_api_key)) != ""
+  create_internal_observability_secret       = local.enable_internal_observability && (local.create_ecs_api || var.enable_ai_gateway)
   ai_proxy_url_ssm_parameter_name            = "/braintrust/${var.deployment_name}/ai-proxy-url"
   api_ecs_url_ssm_parameter_name             = "/braintrust/${var.deployment_name}/ecs-api-url"
   brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
@@ -293,6 +294,12 @@ module "gateway_ecs" {
   enable_execute_command = var.ai_gateway_enable_execute_command
   braintrust_app_url     = var.ai_gateway_braintrust_app_url
   braintrust_api_url     = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
+
+  # Observability
+  internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
+  internal_observability_env_name               = var.internal_observability_env_name
+  internal_observability_region                 = var.internal_observability_region
+  internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins
 }
 
 module "api_ecs" {
@@ -304,7 +311,7 @@ module "api_ecs" {
 
   # Telemetry
   monitoring_telemetry                          = var.monitoring_telemetry
-  internal_observability_api_key_secret_arn     = local.create_ecs_api && local.enable_internal_observability ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
+  internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
   internal_observability_env_name               = var.internal_observability_env_name
   internal_observability_region                 = var.internal_observability_region
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins

--- a/main.tf
+++ b/main.tf
@@ -297,6 +297,7 @@ module "gateway_ecs" {
 
   # Observability
   internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
+  internal_observability_enabled                = local.create_internal_observability_secret
   internal_observability_env_name               = var.internal_observability_env_name
   internal_observability_region                 = var.internal_observability_region
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins

--- a/main.tf
+++ b/main.tf
@@ -278,6 +278,9 @@ module "gateway_ecs" {
   target_cpu_utilization    = var.ai_gateway_target_cpu_utilization
   target_memory_utilization = var.ai_gateway_target_memory_utilization
   log_retention_days        = var.ai_gateway_log_retention_days
+  alb_client_keep_alive     = var.ai_gateway_alb_client_keep_alive
+  alb_idle_timeout          = var.ai_gateway_alb_idle_timeout
+  alb_deregistration_delay  = var.ai_gateway_alb_deregistration_delay
   redis_host                = module.redis.redis_endpoint
   redis_port                = module.redis.redis_port
   redis_security_group_id   = module.redis.redis_security_group_id

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -3,9 +3,11 @@ locals {
     BraintrustDeploymentName = var.deployment_name
   }, var.custom_tags)
 
-  container_name = "gateway"
-  container_port = 8080
-  base_env_vars = {
+  container_name        = "gateway"
+  container_port        = 8080
+  observability_enabled = var.internal_observability_api_key_secret_arn != ""
+  gateway_version_tag   = element(reverse(split(":", var.container_image)), 0)
+  base_env_vars = merge({
     GATEWAY_ENV        = "production"
     BRAINTRUST_APP_URL = var.braintrust_app_url
     BRAINTRUST_API_URL = var.braintrust_api_url
@@ -13,12 +15,169 @@ locals {
     COMPLETIONS_CACHE_REDIS_URL = "redis://${var.redis_host}:${var.redis_port}"
     AUTH_CACHE_REDIS_URL        = "redis://${var.redis_host}:${var.redis_port}"
     GATEWAY_JSON_LOGS           = "true"
-    OTLP_HTTP_ENDPOINT          = "https://www.braintrust.dev/api/pulse/otel"
-  }
+    OTLP_HTTP_ENDPOINT          = local.observability_enabled ? "http://localhost:4318" : "https://www.braintrust.dev/api/pulse/otel"
+    },
+    local.observability_enabled && trimspace(var.internal_observability_trace_disabled_plugins) != "" ? {
+      DD_TRACE_DISABLED_PLUGINS = var.internal_observability_trace_disabled_plugins
+    } : {},
+  )
   plain_license_env_var = var.brainstore_license_key == null ? {} : {
     BRAINSTORE_LICENSE_KEY = var.brainstore_license_key
   }
   merged_env_vars = merge(local.base_env_vars, local.plain_license_env_var, var.extra_env_vars)
+
+  gateway_container_definition = {
+    name      = local.container_name
+    image     = var.container_image
+    essential = true
+    portMappings = [
+      {
+        containerPort = local.container_port
+        hostPort      = local.container_port
+        protocol      = "tcp"
+      }
+    ]
+    environment = [
+      for key in sort(keys(local.merged_env_vars)) : {
+        name  = key
+        value = local.merged_env_vars[key]
+      }
+    ]
+    dependsOn = [
+      for dep in [
+        {
+          containerName = "log-router"
+          condition     = "START"
+        },
+        {
+          containerName = "datadog-agent"
+          condition     = "START"
+        }
+      ] : dep if local.observability_enabled
+    ]
+    logConfiguration = local.gateway_log_configuration
+  }
+
+  observability_sidecars = [
+    for sidecar in [
+      {
+        name           = "log-router"
+        essential      = true
+        image          = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+        user           = "0"
+        environment    = []
+        mountPoints    = []
+        portMappings   = []
+        systemControls = []
+        volumesFrom    = []
+        firelensConfiguration = {
+          type = "fluentbit"
+          options = {
+            enable-ecs-log-metadata = "true"
+            config-file-type        = "file"
+            config-file-value       = "/fluent-bit/configs/parse-json.conf"
+          }
+        }
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.service.name
+            awslogs-region        = data.aws_region.current.region
+            awslogs-stream-prefix = "log-router"
+          }
+        }
+        memoryReservation = 50
+      },
+      {
+        name           = "datadog-agent"
+        essential      = true
+        image          = "public.ecr.aws/datadog/agent:7"
+        mountPoints    = []
+        portMappings   = []
+        systemControls = []
+        volumesFrom    = []
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.service.name
+            awslogs-region        = data.aws_region.current.region
+            awslogs-stream-prefix = "datadog-agent"
+          }
+        }
+        environment = [
+          {
+            name  = "ECS_FARGATE"
+            value = "true"
+          },
+          {
+            name  = "DD_SITE"
+            value = "${var.internal_observability_region}.datadoghq.com"
+          },
+          {
+            name  = "DD_ENV"
+            value = var.internal_observability_env_name
+          },
+          {
+            name  = "DD_SERVICE"
+            value = "braintrust-gateway"
+          },
+          {
+            name  = "DD_VERSION"
+            value = local.gateway_version_tag
+          },
+          {
+            name  = "DD_PROCESS_AGENT_ENABLED"
+            value = "true"
+          },
+          {
+            name  = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"
+            value = "0.0.0.0:4318"
+          }
+        ]
+        secrets = [
+          {
+            name      = "DD_API_KEY"
+            valueFrom = var.internal_observability_api_key_secret_arn
+          }
+        ]
+        healthCheck = {
+          command     = ["CMD-SHELL", "agent health"]
+          interval    = 30
+          retries     = 3
+          startPeriod = 15
+          timeout     = 5
+        }
+      }
+    ] : sidecar if local.observability_enabled
+  ]
+
+  gateway_log_configuration = jsondecode(local.observability_enabled ? jsonencode({
+    logDriver = "awsfirelens"
+    options = {
+      Name           = "datadog"
+      Host           = "http-intake.logs.${var.internal_observability_region}.datadoghq.com"
+      TLS            = "on"
+      provider       = "ecs"
+      dd_service     = "braintrust-gateway"
+      dd_source      = "gateway"
+      dd_message_key = "msg"
+      dd_tags        = "env:${var.internal_observability_env_name}"
+      compress       = "gzip"
+    }
+    secretOptions = [
+      {
+        name      = "apikey"
+        valueFrom = var.internal_observability_api_key_secret_arn
+      }
+    ]
+    }) : jsonencode({
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.service.name
+      awslogs-region        = data.aws_region.current.region
+      awslogs-stream-prefix = "gateway"
+    }
+  }))
 
   valid_fargate_memory_by_cpu = {
     "256"   = [512, 1024, 2048]
@@ -181,6 +340,38 @@ resource "aws_iam_role_policy_attachment" "task_execution_default" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "task_execution_observability_secrets" {
+  count = local.observability_enabled ? 1 : 0
+
+  name = "${var.deployment_name}-gateway-task-exec-observability-secrets"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ]
+        Resource = var.internal_observability_api_key_secret_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+        ]
+        Resource = var.kms_key_arn
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role" "task" {
   name               = "${var.deployment_name}-gateway-task"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
@@ -203,34 +394,7 @@ resource "aws_ecs_task_definition" "gateway" {
     cpu_architecture        = var.cpu_architecture
   }
 
-  container_definitions = jsonencode([
-    {
-      name      = local.container_name
-      image     = var.container_image
-      essential = true
-      portMappings = [
-        {
-          containerPort = local.container_port
-          hostPort      = local.container_port
-          protocol      = "tcp"
-        }
-      ]
-      environment = [
-        for key, value in local.merged_env_vars : {
-          name  = key
-          value = value
-        }
-      ]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.service.name
-          awslogs-region        = data.aws_region.current.region
-          awslogs-stream-prefix = "gateway"
-        }
-      }
-    }
-  ])
+  container_definitions = jsonencode(concat([local.gateway_container_definition], local.observability_sidecars))
 
   tags = merge({
     Name = "${var.deployment_name}-gateway"

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -5,7 +5,7 @@ locals {
 
   container_name        = "gateway"
   container_port        = 8080
-  observability_enabled = var.internal_observability_api_key_secret_arn != ""
+  observability_enabled = var.internal_observability_enabled
   gateway_version_tag   = element(reverse(split(":", var.container_image)), 0)
   base_env_vars = merge({
     GATEWAY_ENV        = "production"

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -47,10 +47,6 @@ locals {
     dependsOn = [
       for dep in [
         {
-          containerName = "log-router"
-          condition     = "START"
-        },
-        {
           containerName = "datadog-agent"
           condition     = "START"
         }
@@ -61,34 +57,6 @@ locals {
 
   observability_sidecars = [
     for sidecar in [
-      {
-        name           = "log-router"
-        essential      = true
-        image          = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
-        user           = "0"
-        environment    = []
-        mountPoints    = []
-        portMappings   = []
-        systemControls = []
-        volumesFrom    = []
-        firelensConfiguration = {
-          type = "fluentbit"
-          options = {
-            enable-ecs-log-metadata = "true"
-            config-file-type        = "file"
-            config-file-value       = "/fluent-bit/configs/parse-json.conf"
-          }
-        }
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.service.name
-            awslogs-region        = data.aws_region.current.region
-            awslogs-stream-prefix = "log-router"
-          }
-        }
-        memoryReservation = 50
-      },
       {
         name           = "datadog-agent"
         essential      = true
@@ -133,6 +101,14 @@ locals {
           {
             name  = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"
             value = "0.0.0.0:4318"
+          },
+          {
+            name  = "DD_LOGS_ENABLED"
+            value = "true"
+          },
+          {
+            name  = "DD_OTLP_CONFIG_LOGS_ENABLED"
+            value = "true"
           }
         ]
         secrets = [
@@ -152,33 +128,14 @@ locals {
     ] : sidecar if local.observability_enabled
   ]
 
-  gateway_log_configuration = jsondecode(local.observability_enabled ? jsonencode({
-    logDriver = "awsfirelens"
-    options = {
-      Name           = "datadog"
-      Host           = "http-intake.logs.${var.internal_observability_region}.datadoghq.com"
-      TLS            = "on"
-      provider       = "ecs"
-      dd_service     = "braintrust-gateway"
-      dd_source      = "gateway"
-      dd_message_key = "msg"
-      dd_tags        = "env:${var.internal_observability_env_name}"
-      compress       = "gzip"
-    }
-    secretOptions = [
-      {
-        name      = "apikey"
-        valueFrom = var.internal_observability_api_key_secret_arn
-      }
-    ]
-    }) : jsonencode({
+  gateway_log_configuration = {
     logDriver = "awslogs"
     options = {
       awslogs-group         = aws_cloudwatch_log_group.service.name
       awslogs-region        = data.aws_region.current.region
       awslogs-stream-prefix = "gateway"
     }
-  }))
+  }
 
   valid_fargate_memory_by_cpu = {
     "256"   = [512, 1024, 2048]

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -9,6 +9,7 @@ locals {
   gateway_version_tag   = element(reverse(split(":", var.container_image)), 0)
   base_env_vars = merge({
     GATEWAY_ENV        = "production"
+    GATEWAY_REGION     = data.aws_region.current.region
     BRAINTRUST_APP_URL = var.braintrust_app_url
     BRAINTRUST_API_URL = var.braintrust_api_url
 
@@ -290,6 +291,10 @@ resource "aws_lb" "gateway" {
   load_balancer_type = "application"
   subnets            = var.private_subnet_ids
   security_groups    = [aws_security_group.alb.id]
+
+  client_keep_alive = var.alb_client_keep_alive
+  idle_timeout      = var.alb_idle_timeout
+
   tags = merge({
     Name = "${var.deployment_name}-gateway"
   }, local.common_tags)
@@ -302,8 +307,10 @@ resource "aws_lb_target_group" "gateway" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
+  deregistration_delay = var.alb_deregistration_delay
+
   health_check {
-    path                = "/"
+    path                = "/health"
     matcher             = "200"
     healthy_threshold   = 3
     unhealthy_threshold = 3

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -20,6 +20,8 @@ locals {
     },
     local.observability_enabled && trimspace(var.internal_observability_trace_disabled_plugins) != "" ? {
       DD_TRACE_DISABLED_PLUGINS = var.internal_observability_trace_disabled_plugins
+      DD_ENV                    = var.internal_observability_env_name
+      DD_VERSION                = local.gateway_version_tag
     } : {},
   )
   plain_license_env_var = var.brainstore_license_key == null ? {} : {
@@ -88,7 +90,7 @@ locals {
           },
           {
             name  = "DD_SERVICE"
-            value = "braintrust-gateway"
+            value = "gateway"
           },
           {
             name  = "DD_VERSION"

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -18,10 +18,12 @@ locals {
     GATEWAY_JSON_LOGS           = "true"
     OTLP_HTTP_ENDPOINT          = local.observability_enabled ? "http://localhost:4318" : "https://www.braintrust.dev/api/pulse/otel"
     },
+    local.observability_enabled ? {
+      DD_ENV     = var.internal_observability_env_name
+      DD_VERSION = local.gateway_version_tag
+    } : {},
     local.observability_enabled && trimspace(var.internal_observability_trace_disabled_plugins) != "" ? {
       DD_TRACE_DISABLED_PLUGINS = var.internal_observability_trace_disabled_plugins
-      DD_ENV                    = var.internal_observability_env_name
-      DD_VERSION                = local.gateway_version_tag
     } : {},
   )
   plain_license_env_var = var.brainstore_license_key == null ? {} : {

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -114,6 +114,12 @@ variable "internal_observability_api_key_secret_arn" {
   default     = ""
 }
 
+variable "internal_observability_enabled" {
+  type        = bool
+  description = "Whether to enable internal Datadog observability for gateway ECS."
+  default     = false
+}
+
 variable "internal_observability_region" {
   type        = string
   description = "Datadog region suffix (e.g. us5) used to build DD_SITE."

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -108,6 +108,39 @@ variable "log_retention_days" {
   }
 }
 
+variable "alb_client_keep_alive" {
+  type        = number
+  description = "Client keep-alive duration in seconds for the gateway ALB."
+  default     = 4000
+
+  validation {
+    condition     = var.alb_client_keep_alive >= 60 && var.alb_client_keep_alive <= 604800
+    error_message = "alb_client_keep_alive must be between 60 and 604800 seconds."
+  }
+}
+
+variable "alb_idle_timeout" {
+  type        = number
+  description = "Idle timeout in seconds for the gateway ALB."
+  default     = 3600
+
+  validation {
+    condition     = var.alb_idle_timeout >= 1 && var.alb_idle_timeout <= 4000
+    error_message = "alb_idle_timeout must be between 1 and 4000 seconds."
+  }
+}
+
+variable "alb_deregistration_delay" {
+  type        = number
+  description = "Seconds for the gateway target group to wait before deregistering draining targets."
+  default     = 600
+
+  validation {
+    condition     = var.alb_deregistration_delay >= 0 && var.alb_deregistration_delay <= 3600
+    error_message = "alb_deregistration_delay must be between 0 and 3600 seconds."
+  }
+}
+
 variable "internal_observability_api_key_secret_arn" {
   type        = string
   description = "Secrets Manager secret ARN containing the internal observability API key."

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -108,6 +108,30 @@ variable "log_retention_days" {
   }
 }
 
+variable "internal_observability_api_key_secret_arn" {
+  type        = string
+  description = "Secrets Manager secret ARN containing the internal observability API key."
+  default     = ""
+}
+
+variable "internal_observability_region" {
+  type        = string
+  description = "Datadog region suffix (e.g. us5) used to build DD_SITE."
+  default     = "us5"
+}
+
+variable "internal_observability_env_name" {
+  type        = string
+  description = "Datadog environment name used for DD_ENV."
+  default     = ""
+}
+
+variable "internal_observability_trace_disabled_plugins" {
+  type        = string
+  description = "Datadog trace plugins to disable for internal observability."
+  default     = ""
+}
+
 variable "extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to inject into the gateway container."

--- a/modules/services/versions.tf
+++ b/modules/services/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 6.23.0, < 7.0.0"
     }
     http = {
-      source  = "hashicorp/http"
+      source = "hashicorp/http"
       # 3.3.0 is the first release with the data source's retry block and
       # request_timeout_ms (used in modules/services/main.tf).
       version = "~> 3.3"

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,18 +1,18 @@
 resource "aws_secretsmanager_secret" "internal_observability_api_key" {
-  count = local.create_ecs_api && local.enable_internal_observability ? 1 : 0
+  count = local.create_internal_observability_secret ? 1 : 0
 
   name                    = "${var.deployment_name}/internal-observability/api-key"
   recovery_window_in_days = 0
   kms_key_id              = local.kms_key_arn
 
   tags = merge({
-    Name                     = "${var.deployment_name}-api-ecs-internal-observability-api-key"
+    Name                     = "${var.deployment_name}-internal-observability-api-key"
     BraintrustDeploymentName = var.deployment_name
   }, var.custom_tags)
 }
 
 resource "aws_secretsmanager_secret_version" "internal_observability_api_key" {
-  count = local.create_ecs_api && local.enable_internal_observability ? 1 : 0
+  count = local.create_internal_observability_secret ? 1 : 0
 
   secret_id     = aws_secretsmanager_secret.internal_observability_api_key[0].id
   secret_string = var.internal_observability_api_key

--- a/variables.tf
+++ b/variables.tf
@@ -416,6 +416,39 @@ variable "ai_gateway_log_retention_days" {
   }
 }
 
+variable "ai_gateway_alb_client_keep_alive" {
+  description = "Client keep-alive duration in seconds for the gateway ALB."
+  type        = number
+  default     = 4000
+
+  validation {
+    condition     = var.ai_gateway_alb_client_keep_alive >= 60 && var.ai_gateway_alb_client_keep_alive <= 604800
+    error_message = "ai_gateway_alb_client_keep_alive must be between 60 and 604800 seconds."
+  }
+}
+
+variable "ai_gateway_alb_idle_timeout" {
+  description = "Idle timeout in seconds for the gateway ALB."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.ai_gateway_alb_idle_timeout >= 1 && var.ai_gateway_alb_idle_timeout <= 4000
+    error_message = "ai_gateway_alb_idle_timeout must be between 1 and 4000 seconds."
+  }
+}
+
+variable "ai_gateway_alb_deregistration_delay" {
+  description = "Seconds for the gateway target group to wait before deregistering draining targets."
+  type        = number
+  default     = 600
+
+  validation {
+    condition     = var.ai_gateway_alb_deregistration_delay >= 0 && var.ai_gateway_alb_deregistration_delay <= 3600
+    error_message = "ai_gateway_alb_deregistration_delay must be between 0 and 3600 seconds."
+  }
+}
+
 variable "ai_gateway_extra_env_vars" {
   description = "Extra environment variables for the gateway ECS container"
   type        = map(string)


### PR DESCRIPTION
Adds optional observability capabilities for the optional AI Gateway as well as new defaults for ALB configuration. For most customers, we don't recommend changing these settings and leaving the default.