### PR TITLE
[INF-151] Grant APIHandlerRole PutMetricData for ECS autoscaling metrics.

### DIFF
--- a/modules/services-common/iam-api.tf
+++ b/modules/services-common/iam-api.tf
@@ -93,6 +93,29 @@ resource "aws_iam_role_policy_attachment" "api_handler_additional_policy" {
   policy_arn = var.service_additional_policy_arns[count.index]
 }
 
+resource "aws_iam_role_policy" "api_handler_cloudwatch_metrics" {
+  count = var.enable_ecs ? 1 : 0
+  name  = "cloudwatch-autoscaling-metrics"
+  role  = aws_iam_role.api_handler_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchAutoscalingMetrics"
+        Effect = "Allow"
+        Action = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "Braintrust/Api"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_iam_policy" "api_handler_policy" {
   name = "${var.deployment_name}-APIHandlerRolePolicy"
   policy = jsonencode({ # nosemgrep


### PR DESCRIPTION


## Description 
Adds an inline IAM role policy on `APIHandlerRole` (when ECS is enabled) so `api-ts` can publish custom CloudWatch metrics via `PutMetricData`, scoped to the `Braintrust/Api` namespace. Follow-up to https://github.com/braintrustdata/braintrust/pull/16004 which pointed at a commit from this branch.


## Context 
Part of [INF-151](https://linear.app/braintrustdata/issue/INF-151/emit-nodejs-loop-metrics-into-cloudwatch-for-autoscaling). This PR is required to allow cloudwatch to actually receive the metrics issued by these PRs:
* https://github.com/braintrustdata/braintrust/pull/15939
* https://github.com/braintrustdata/braintrust/pull/16081 


## Testing 
Deployed in sandbox and observed metrics flow.
Also deployed in EU prod and observed metrics flow.