### PR TITLE
Enable ASG metrics collection

### DIFF
--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -155,8 +155,8 @@ resource "aws_autoscaling_group" "brainstore_fast_reader" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_fast_reader[0].arn]
   wait_for_elb_capacity     = var.fast_reader_instance_count
-  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
-  metrics_granularity = "1Minute"
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore_fast_reader[0].id

--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -155,6 +155,9 @@ resource "aws_autoscaling_group" "brainstore_fast_reader" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_fast_reader[0].arn]
   wait_for_elb_capacity     = var.fast_reader_instance_count
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
+
   launch_template {
     id      = aws_launch_template.brainstore_fast_reader[0].id
     version = aws_launch_template.brainstore_fast_reader[0].latest_version

--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -155,8 +155,8 @@ resource "aws_autoscaling_group" "brainstore_fast_reader" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_fast_reader[0].arn]
   wait_for_elb_capacity     = var.fast_reader_instance_count
-  enabled_metrics           = local.autoscaling_group_enabled_metrics
-  metrics_granularity       = "1Minute"
+  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
+  metrics_granularity = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore_fast_reader[0].id

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -155,8 +155,8 @@ resource "aws_autoscaling_group" "brainstore_writer" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_writer[0].arn]
   wait_for_elb_capacity     = var.writer_instance_count
-  enabled_metrics           = local.autoscaling_group_enabled_metrics
-  metrics_granularity       = "1Minute"
+  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
+  metrics_granularity = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore_writer[0].id

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -155,6 +155,9 @@ resource "aws_autoscaling_group" "brainstore_writer" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_writer[0].arn]
   wait_for_elb_capacity     = var.writer_instance_count
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
+
   launch_template {
     id      = aws_launch_template.brainstore_writer[0].id
     version = aws_launch_template.brainstore_writer[0].latest_version

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -155,8 +155,8 @@ resource "aws_autoscaling_group" "brainstore_writer" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore_writer[0].arn]
   wait_for_elb_capacity     = var.writer_instance_count
-  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
-  metrics_granularity = "1Minute"
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore_writer[0].id

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -19,7 +19,7 @@ locals {
   brainstore_cache_file_size             = var.cache_file_size_reader != null ? var.cache_file_size_reader : "${floor(data.aws_ec2_instance_type.brainstore.total_instance_storage * 0.9)}gb"
   brainstore_writer_cache_file_size      = var.cache_file_size_writer != null ? var.cache_file_size_writer : "${floor(data.aws_ec2_instance_type.brainstore_writer.total_instance_storage * 0.9)}gb"
   brainstore_fast_reader_cache_file_size = var.cache_file_size_fast_reader != null ? var.cache_file_size_fast_reader : "${floor(data.aws_ec2_instance_type.brainstore_fast_reader.total_instance_storage * 0.9)}gb"
-  autoscaling_group_enabled_metrics     = [
+  autoscaling_group_enabled_metrics = [
     "GroupAndWarmPoolDesiredCapacity",
     "GroupAndWarmPoolTotalCapacity",
     "GroupDesiredCapacity",

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -19,28 +19,6 @@ locals {
   brainstore_cache_file_size             = var.cache_file_size_reader != null ? var.cache_file_size_reader : "${floor(data.aws_ec2_instance_type.brainstore.total_instance_storage * 0.9)}gb"
   brainstore_writer_cache_file_size      = var.cache_file_size_writer != null ? var.cache_file_size_writer : "${floor(data.aws_ec2_instance_type.brainstore_writer.total_instance_storage * 0.9)}gb"
   brainstore_fast_reader_cache_file_size = var.cache_file_size_fast_reader != null ? var.cache_file_size_fast_reader : "${floor(data.aws_ec2_instance_type.brainstore_fast_reader.total_instance_storage * 0.9)}gb"
-  autoscaling_group_enabled_metrics = [
-    "GroupAndWarmPoolDesiredCapacity",
-    "GroupAndWarmPoolTotalCapacity",
-    "GroupDesiredCapacity",
-    "GroupInServiceCapacity",
-    "GroupInServiceInstances",
-    "GroupMaxSize",
-    "GroupMinSize",
-    "GroupPendingCapacity",
-    "GroupPendingInstances",
-    "GroupStandbyCapacity",
-    "GroupStandbyInstances",
-    "GroupTerminatingCapacity",
-    "GroupTerminatingInstances",
-    "GroupTotalCapacity",
-    "GroupTotalInstances",
-    "WarmPoolDesiredCapacity",
-    "WarmPoolPendingCapacity",
-    "WarmPoolTerminatingCapacity",
-    "WarmPoolTotalCapacity",
-    "WarmPoolWarmedCapacity",
-  ]
 }
 
 resource "aws_launch_template" "brainstore" {
@@ -198,8 +176,8 @@ resource "aws_autoscaling_group" "brainstore" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore.arn]
   wait_for_elb_capacity     = var.instance_count
-  enabled_metrics           = local.autoscaling_group_enabled_metrics
-  metrics_granularity       = "1Minute"
+  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
+  metrics_granularity = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore.id

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -19,6 +19,29 @@ locals {
   brainstore_cache_file_size             = var.cache_file_size_reader != null ? var.cache_file_size_reader : "${floor(data.aws_ec2_instance_type.brainstore.total_instance_storage * 0.9)}gb"
   brainstore_writer_cache_file_size      = var.cache_file_size_writer != null ? var.cache_file_size_writer : "${floor(data.aws_ec2_instance_type.brainstore_writer.total_instance_storage * 0.9)}gb"
   brainstore_fast_reader_cache_file_size = var.cache_file_size_fast_reader != null ? var.cache_file_size_fast_reader : "${floor(data.aws_ec2_instance_type.brainstore_fast_reader.total_instance_storage * 0.9)}gb"
+  # Keep this explicit: the Terraform AWS provider only enables ASG metrics collection when enabled_metrics is non-empty.
+  autoscaling_group_enabled_metrics = [
+    "GroupAndWarmPoolDesiredCapacity",
+    "GroupAndWarmPoolTotalCapacity",
+    "GroupDesiredCapacity",
+    "GroupInServiceCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingCapacity",
+    "GroupPendingInstances",
+    "GroupStandbyCapacity",
+    "GroupStandbyInstances",
+    "GroupTerminatingCapacity",
+    "GroupTerminatingInstances",
+    "GroupTotalCapacity",
+    "GroupTotalInstances",
+    "WarmPoolDesiredCapacity",
+    "WarmPoolPendingCapacity",
+    "WarmPoolTerminatingCapacity",
+    "WarmPoolTotalCapacity",
+    "WarmPoolWarmedCapacity",
+  ]
 }
 
 resource "aws_launch_template" "brainstore" {
@@ -176,8 +199,8 @@ resource "aws_autoscaling_group" "brainstore" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore.arn]
   wait_for_elb_capacity     = var.instance_count
-  # AWS enables all Auto Scaling group metrics when granularity is set without an explicit metrics list.
-  metrics_granularity = "1Minute"
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
 
   launch_template {
     id      = aws_launch_template.brainstore.id

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -19,6 +19,28 @@ locals {
   brainstore_cache_file_size             = var.cache_file_size_reader != null ? var.cache_file_size_reader : "${floor(data.aws_ec2_instance_type.brainstore.total_instance_storage * 0.9)}gb"
   brainstore_writer_cache_file_size      = var.cache_file_size_writer != null ? var.cache_file_size_writer : "${floor(data.aws_ec2_instance_type.brainstore_writer.total_instance_storage * 0.9)}gb"
   brainstore_fast_reader_cache_file_size = var.cache_file_size_fast_reader != null ? var.cache_file_size_fast_reader : "${floor(data.aws_ec2_instance_type.brainstore_fast_reader.total_instance_storage * 0.9)}gb"
+  autoscaling_group_enabled_metrics     = [
+    "GroupAndWarmPoolDesiredCapacity",
+    "GroupAndWarmPoolTotalCapacity",
+    "GroupDesiredCapacity",
+    "GroupInServiceCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingCapacity",
+    "GroupPendingInstances",
+    "GroupStandbyCapacity",
+    "GroupStandbyInstances",
+    "GroupTerminatingCapacity",
+    "GroupTerminatingInstances",
+    "GroupTotalCapacity",
+    "GroupTotalInstances",
+    "WarmPoolDesiredCapacity",
+    "WarmPoolPendingCapacity",
+    "WarmPoolTerminatingCapacity",
+    "WarmPoolTotalCapacity",
+    "WarmPoolWarmedCapacity",
+  ]
 }
 
 resource "aws_launch_template" "brainstore" {
@@ -176,6 +198,9 @@ resource "aws_autoscaling_group" "brainstore" {
   health_check_grace_period = 60
   target_group_arns         = [aws_lb_target_group.brainstore.arn]
   wait_for_elb_capacity     = var.instance_count
+  enabled_metrics           = local.autoscaling_group_enabled_metrics
+  metrics_granularity       = "1Minute"
+
   launch_template {
     id      = aws_launch_template.brainstore.id
     version = aws_launch_template.brainstore.latest_version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Enable CloudWatch Auto Scaling group metrics collection for all Brainstore EC2 Auto Scaling Groups:

- reader / dual-use Brainstore ASG
- dedicated writer Brainstore ASG
- dedicated fast-reader Brainstore ASG

Each ASG now sets `metrics_granularity = "1Minute"` and enables all metrics.

## Context
Brainstore runs on EC2 Auto Scaling Groups, but group-level ASG metrics were not enabled in the module. Enabling these metrics improves visibility into desired/in-service/pending/terminating capacity and instance counts.

## Testing
- `PATH="/tmp/terraform-bin:$PATH" terraform fmt -check -diff modules/brainstore-ec2/main.tf modules/brainstore-ec2/main-writer.tf modules/brainstore-ec2/main-fast-reader.tf`
- `PATH="/tmp/terraform-bin:$PATH" terraform init -upgrade && PATH="/tmp/terraform-bin:$PATH" terraform validate`
- `cd examples/braintrust-data-plane` with temporary local-module `main_override.tf`, then `PATH="/tmp/terraform-bin:$PATH" terraform init -upgrade && PATH="/tmp/terraform-bin:$PATH" terraform validate`
<!-- CURSOR_AGENT_PR_BODY_END -->