### PR TITLE
Add `/reschedule` endpoint for cron automation to API allowlist

### DIFF
--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -693,6 +693,18 @@ locals {
           ]
         })
       }
+      "/automation/cron/{id}/reschedule" = {
+        for method in ["options", "post"] : method => merge(local.snippet_api_json_text_method, {
+          parameters = [
+            {
+              name     = "id"
+              in       = "path"
+              required = true
+              type     = "string"
+            }
+          ]
+        })
+      }
       "/billing/status" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }


### PR DESCRIPTION
Add `/automation/cron/{id}/reschedule` to the API Gateway OpenAPI allowlist.

## Testing
- Not run; route-only Terraform allowlist update
