### PR TITLE
[INF-173] Move gateway ALB to services-common and auto-wire GATEWAY_URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,15 @@ The `internal_observability_*` variables (Datadog API key, env name, region) are
 
 Python scripts in `scripts/` use `#!/usr/bin/env -S uv run --script` with inline dependency metadata. This allows zero-setup execution without managing virtual environments. Do not replace these with plain `python3` shebangs or add `requirements.txt` files.
 
-## Critical Safety Constraints
+### In-place upgrades on existing deployments
+
+Module changes must be applyable directly to live customer stacks without tear-down or multi-phase hacks. When restructuring resources:
+
+- Add `moved` blocks to `moved_state.tf` instead of taint/recreate (see existing brainstore, ingress, and gateway ALB moves).
+- Avoid env-only changes on Lambdas that do not need them — e.g. do not merge shared env into `MigrateDatabaseFunction` or crons, because that publishes a new Lambda version and re-invokes migrations.
+- Prefer state moves and in-place updates over replace; if a resource must be replaced, document why and whether downtime is expected.
+- `terraform plan` on an existing gateway deployment should show `has moved to` for relocated ALB resources, in-place env updates for APIHandler/AIProxy/ECS API, and no unexpected destroys.
+
 
 ### Upgrade Sequencing (for customers upgrading from pre-2.0)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,21 @@ Python scripts in `scripts/` use `#!/usr/bin/env -S uv run --script` with inline
 
 Module changes must be applyable directly to live customer stacks without tear-down or multi-phase hacks. When restructuring resources:
 
-- Add `moved` blocks to `moved_state.tf` instead of taint/recreate (see existing brainstore, ingress, and gateway ALB moves).
+- Add `moved` blocks to `moved_state.tf` instead of taint/recreate when restructuring resources that customers have in state (see existing brainstore and ingress moves).
 - Avoid env-only changes on Lambdas that do not need them — e.g. do not merge shared env into `MigrateDatabaseFunction` or crons, because that publishes a new Lambda version and re-invokes migrations.
 - Prefer state moves and in-place updates over replace; if a resource must be replaced, document why and whether downtime is expected.
-- `terraform plan` on an existing gateway deployment should show `has moved to` for relocated ALB resources, in-place env updates for APIHandler/AIProxy/ECS API, and no unexpected destroys.
+
+### Private gateway ALB relocation
+
+The gateway internal ALB moved from `gateway-ecs` to `services-common`. Stacks that already applied the old layout will destroy/recreate gateway ALB resources (new DNS). No `moved` blocks: private gateway is not in production use yet. Gateway ECS tasks may recycle when the target group is replaced.
+
+### Private gateway: `create_ai_gateway` vs `enable_ai_gateway`
+
+Mirrors `create_ecs_api` / `enable_ecs_api`:
+- **`create_ai_gateway`**: internal ALB, target group, listener, and gateway ECS service.
+- **`enable_ai_gateway`**: wire `GATEWAY_URL` on APIHandler, AIProxy, and ECS API. Requires `create_ai_gateway`.
+
+Use `create_ai_gateway = true` with `enable_ai_gateway = false` for a two-step prod cutover (stand up infra while keeping caller-supplied `GATEWAY_URL`, e.g. hosted gateway). Set both true for single-apply wiring on greenfield deployments.
 
 
 ### Upgrade Sequencing (for customers upgrading from pre-2.0)

--- a/main.tf
+++ b/main.tf
@@ -51,10 +51,13 @@ locals {
   # MigrateDatabaseFunction or crons — that changes their env hash and re-runs
   # migrations or replaces unrelated functions on existing deployments.
   gateway_lambda_env_services = toset(["APIHandler", "AIProxy"])
-  service_extra_env_vars = {
-    for service_name, env in var.service_extra_env_vars :
-    service_name => contains(local.gateway_lambda_env_services, service_name) ? merge(env, local.gateway_env_vars) : env
-  }
+  service_extra_env_vars = merge(
+    var.service_extra_env_vars,
+    { for svc in local.gateway_lambda_env_services : svc => merge(
+      lookup(var.service_extra_env_vars, svc, {}),
+      local.gateway_env_vars,
+    ) }
+  )
 }
 
 module "main_vpc" {
@@ -298,6 +301,7 @@ module "gateway_ecs" {
   redis_security_group_id   = module.redis.redis_security_group_id
   target_group_arn          = module.services_common.gateway_target_group_arn
   alb_security_group_id     = module.services_common.gateway_alb_security_group_id
+  gateway_http_listener_arn = module.services_common.gateway_http_listener_arn
   extra_env_vars            = var.ai_gateway_extra_env_vars
   custom_tags               = var.custom_tags
   brainstore_license_key    = var.brainstore_license_key

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,17 @@ locals {
   ai_proxy_url_ssm_parameter_name            = "/braintrust/${var.deployment_name}/ai-proxy-url"
   api_ecs_url_ssm_parameter_name             = "/braintrust/${var.deployment_name}/ecs-api-url"
   brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
+  gateway_env_vars = var.enable_ai_gateway ? {
+    GATEWAY_URL = module.services_common.gateway_url
+  } : {}
+  # Only wire GATEWAY_URL into Lambdas that call the gateway. Do not merge into
+  # MigrateDatabaseFunction or crons — that changes their env hash and re-runs
+  # migrations or replaces unrelated functions on existing deployments.
+  gateway_lambda_env_services = toset(["APIHandler", "AIProxy"])
+  service_extra_env_vars = {
+    for service_name, env in var.service_extra_env_vars :
+    service_name => contains(local.gateway_lambda_env_services, service_name) ? merge(env, local.gateway_env_vars) : env
+  }
 }
 
 module "main_vpc" {
@@ -210,7 +221,7 @@ module "services" {
   unsafe_url_request_mode                    = var.unsafe_url_request_mode
   url_security_dns_servers                   = var.url_security_dns_servers
   url_security_allow_cidrs                   = var.url_security_allow_cidrs
-  extra_env_vars                             = var.service_extra_env_vars
+  extra_env_vars                             = local.service_extra_env_vars
 
   # Billing usage telemetry
   disable_billing_telemetry_aggregation = var.disable_billing_telemetry_aggregation
@@ -282,28 +293,20 @@ module "gateway_ecs" {
   target_cpu_utilization    = var.ai_gateway_target_cpu_utilization
   target_memory_utilization = var.ai_gateway_target_memory_utilization
   log_retention_days        = var.ai_gateway_log_retention_days
-  alb_client_keep_alive     = var.ai_gateway_alb_client_keep_alive
-  alb_idle_timeout          = var.ai_gateway_alb_idle_timeout
-  alb_deregistration_delay  = var.ai_gateway_alb_deregistration_delay
   redis_host                = module.redis.redis_endpoint
   redis_port                = module.redis.redis_port
   redis_security_group_id   = module.redis.redis_security_group_id
-  authorized_security_groups = merge(
-    {
-      "API"        = module.services_common.api_security_group_id
-      "Brainstore" = module.services_common.brainstore_instance_security_group_id
-    },
-    var.ai_gateway_authorized_security_groups,
-  )
-  extra_env_vars           = var.ai_gateway_extra_env_vars
-  custom_tags              = var.custom_tags
-  brainstore_license_key   = var.brainstore_license_key
-  enable_execute_command   = var.ai_gateway_enable_execute_command
-  braintrust_app_url       = var.ai_gateway_braintrust_app_url
-  braintrust_api_url       = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
-  unsafe_url_request_mode  = var.unsafe_url_request_mode
-  url_security_dns_servers = var.url_security_dns_servers
-  url_security_allow_cidrs = var.url_security_allow_cidrs
+  target_group_arn          = module.services_common.gateway_target_group_arn
+  alb_security_group_id     = module.services_common.gateway_alb_security_group_id
+  extra_env_vars            = var.ai_gateway_extra_env_vars
+  custom_tags               = var.custom_tags
+  brainstore_license_key    = var.brainstore_license_key
+  enable_execute_command    = var.ai_gateway_enable_execute_command
+  braintrust_app_url        = var.ai_gateway_braintrust_app_url
+  braintrust_api_url        = var.use_deployment_mode_external_eks ? var.braintrust_api_url : module.ingress[0].api_url
+  unsafe_url_request_mode   = var.unsafe_url_request_mode
+  url_security_dns_servers  = var.url_security_dns_servers
+  url_security_allow_cidrs  = var.url_security_allow_cidrs
 
   # Observability
   internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
@@ -365,7 +368,7 @@ module "api_ecs" {
   unsafe_url_request_mode               = var.unsafe_url_request_mode
   url_security_dns_servers              = var.url_security_dns_servers
   url_security_allow_cidrs              = var.url_security_allow_cidrs
-  extra_env_vars                        = var.api_ecs_extra_env_vars
+  extra_env_vars                        = merge(var.api_ecs_extra_env_vars, local.gateway_env_vars)
 
   # Quarantine VPC
   use_quarantine_vpc = var.enable_quarantine_vpc
@@ -446,6 +449,16 @@ module "services_common" {
   override_brainstore_iam_role_trust_policy = var.override_brainstore_iam_role_trust_policy
   enable_quarantine_vpc                     = var.enable_quarantine_vpc
   quarantine_vpc_id                         = local.quarantine_vpc_id
+  enable_ai_gateway                         = var.enable_ai_gateway
+  private_subnet_ids = [
+    local.main_vpc_private_subnet_1_id,
+    local.main_vpc_private_subnet_2_id,
+    local.main_vpc_private_subnet_3_id,
+  ]
+  ai_gateway_authorized_security_groups = var.ai_gateway_authorized_security_groups
+  ai_gateway_alb_client_keep_alive      = var.ai_gateway_alb_client_keep_alive
+  ai_gateway_alb_idle_timeout           = var.ai_gateway_alb_idle_timeout
+  ai_gateway_alb_deregistration_delay   = var.ai_gateway_alb_deregistration_delay
 }
 
 module "brainstore" {

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,14 @@ locals {
 
   create_ecs_api                             = !var.use_deployment_mode_external_eks && var.create_ecs_api
   enable_ecs_api                             = local.create_ecs_api && var.enable_ecs_api
+  create_ai_gateway                          = var.create_ai_gateway
+  enable_ai_gateway                          = local.create_ai_gateway && var.enable_ai_gateway
   enable_internal_observability              = trimspace(nonsensitive(var.internal_observability_api_key)) != ""
-  create_internal_observability_secret       = local.enable_internal_observability && (local.create_ecs_api || var.enable_ai_gateway)
+  create_internal_observability_secret       = local.enable_internal_observability && (local.create_ecs_api || local.create_ai_gateway)
   ai_proxy_url_ssm_parameter_name            = "/braintrust/${var.deployment_name}/ai-proxy-url"
   api_ecs_url_ssm_parameter_name             = "/braintrust/${var.deployment_name}/ecs-api-url"
   brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
-  gateway_env_vars = var.enable_ai_gateway ? {
+  gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.services_common.gateway_url
   } : {}
   # Only wire GATEWAY_URL into Lambdas that call the gateway. Do not merge into
@@ -266,7 +268,7 @@ module "services" {
 
 module "ecs" {
   source = "./modules/ecs"
-  count  = var.enable_ai_gateway || local.create_ecs_api ? 1 : 0
+  count  = local.create_ai_gateway || local.create_ecs_api ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -276,7 +278,7 @@ module "ecs" {
 
 module "gateway_ecs" {
   source = "./modules/gateway-ecs"
-  count  = var.enable_ai_gateway ? 1 : 0
+  count  = local.create_ai_gateway ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -453,7 +455,7 @@ module "services_common" {
   override_brainstore_iam_role_trust_policy = var.override_brainstore_iam_role_trust_policy
   enable_quarantine_vpc                     = var.enable_quarantine_vpc
   quarantine_vpc_id                         = local.quarantine_vpc_id
-  enable_ai_gateway                         = var.enable_ai_gateway
+  create_ai_gateway                         = local.create_ai_gateway
   private_subnet_ids = [
     local.main_vpc_private_subnet_1_id,
     local.main_vpc_private_subnet_2_id,

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -190,37 +190,6 @@ resource "aws_cloudwatch_log_group" "service" {
   }, local.common_tags)
 }
 
-resource "aws_security_group" "alb" {
-  name        = "${var.deployment_name}-gateway-alb"
-  description = "Security group for private gateway ALB"
-  vpc_id      = var.vpc_id
-  tags = merge({
-    Name = "${var.deployment_name}-gateway-alb"
-  }, local.common_tags)
-}
-
-resource "aws_security_group_rule" "alb_ingress_from_authorized_security_groups" {
-  for_each = var.authorized_security_groups
-
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  source_security_group_id = each.value
-  description              = "Allow HTTP traffic from ${each.key}."
-  security_group_id        = aws_security_group.alb.id
-}
-
-resource "aws_security_group_rule" "alb_egress_all" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "Allow all outbound traffic from gateway ALB"
-  security_group_id = aws_security_group.alb.id
-}
-
 resource "aws_security_group" "task" {
   name        = "${var.deployment_name}-gateway-task"
   description = "Security group for gateway ECS tasks"
@@ -235,7 +204,7 @@ resource "aws_security_group_rule" "task_ingress_from_alb" {
   from_port                = local.container_port
   to_port                  = local.container_port
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.alb.id
+  source_security_group_id = var.alb_security_group_id
   description              = "Allow inbound traffic from gateway ALB to gateway tasks"
   security_group_id        = aws_security_group.task.id
 }
@@ -259,55 +228,6 @@ resource "aws_vpc_security_group_ingress_rule" "cache_allow_ingress_from_gateway
 
   security_group_id = var.redis_security_group_id
   tags              = local.common_tags
-}
-
-resource "aws_lb" "gateway" {
-  name               = "${var.deployment_name}-gateway"
-  internal           = true
-  load_balancer_type = "application"
-  subnets            = var.private_subnet_ids
-  security_groups    = [aws_security_group.alb.id]
-
-  client_keep_alive = var.alb_client_keep_alive
-  idle_timeout      = var.alb_idle_timeout
-
-  tags = merge({
-    Name = "${var.deployment_name}-gateway"
-  }, local.common_tags)
-}
-
-resource "aws_lb_target_group" "gateway" {
-  name        = "${var.deployment_name}-gateway"
-  port        = local.container_port
-  protocol    = "HTTP"
-  target_type = "ip"
-  vpc_id      = var.vpc_id
-
-  deregistration_delay = var.alb_deregistration_delay
-
-  health_check {
-    path                = "/health"
-    matcher             = "200"
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    timeout             = 5
-    interval            = 10
-  }
-
-  tags = merge({
-    Name = "${var.deployment_name}-gateway"
-  }, local.common_tags)
-}
-
-resource "aws_lb_listener" "gateway_http" {
-  load_balancer_arn = aws_lb.gateway.arn
-  port              = 80
-  protocol          = "HTTP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.gateway.arn
-  }
 }
 
 resource "aws_iam_role" "task_execution" {
@@ -418,12 +338,10 @@ resource "aws_ecs_service" "gateway" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.gateway.arn
+    target_group_arn = var.target_group_arn
     container_name   = local.container_name
     container_port   = local.container_port
   }
-
-  depends_on = [aws_lb_listener.gateway_http]
 
   lifecycle {
     ignore_changes = [desired_count]

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -315,6 +315,10 @@ resource "aws_ecs_task_definition" "gateway" {
   }
 }
 
+resource "terraform_data" "gateway_http_listener" {
+  input = var.gateway_http_listener_arn
+}
+
 resource "aws_ecs_service" "gateway" {
   name                              = "${var.deployment_name}-gateway"
   cluster                           = var.ecs_cluster_arn
@@ -342,6 +346,8 @@ resource "aws_ecs_service" "gateway" {
     container_name   = local.container_name
     container_port   = local.container_port
   }
+
+  depends_on = [terraform_data.gateway_http_listener]
 
   lifecycle {
     ignore_changes = [desired_count]

--- a/modules/gateway-ecs/outputs.tf
+++ b/modules/gateway-ecs/outputs.tf
@@ -3,21 +3,6 @@ output "service_name" {
   value       = aws_ecs_service.gateway.name
 }
 
-output "alb_arn" {
-  description = "ARN of the private gateway ALB"
-  value       = aws_lb.gateway.arn
-}
-
-output "alb_dns_name" {
-  description = "DNS name of the private gateway ALB"
-  value       = aws_lb.gateway.dns_name
-}
-
-output "target_group_arn" {
-  description = "ARN of the gateway ALB target group"
-  value       = aws_lb_target_group.gateway.arn
-}
-
 output "task_security_group_id" {
   description = "Security group ID attached to gateway ECS tasks"
   value       = aws_security_group.task.id

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -108,37 +108,14 @@ variable "log_retention_days" {
   }
 }
 
-variable "alb_client_keep_alive" {
-  type        = number
-  description = "Client keep-alive duration in seconds for the gateway ALB."
-  default     = 4000
-
-  validation {
-    condition     = var.alb_client_keep_alive >= 60 && var.alb_client_keep_alive <= 604800
-    error_message = "alb_client_keep_alive must be between 60 and 604800 seconds."
-  }
+variable "target_group_arn" {
+  type        = string
+  description = "ARN of the gateway ALB target group created in services-common."
 }
 
-variable "alb_idle_timeout" {
-  type        = number
-  description = "Idle timeout in seconds for the gateway ALB."
-  default     = 3600
-
-  validation {
-    condition     = var.alb_idle_timeout >= 1 && var.alb_idle_timeout <= 4000
-    error_message = "alb_idle_timeout must be between 1 and 4000 seconds."
-  }
-}
-
-variable "alb_deregistration_delay" {
-  type        = number
-  description = "Seconds for the gateway target group to wait before deregistering draining targets."
-  default     = 600
-
-  validation {
-    condition     = var.alb_deregistration_delay >= 0 && var.alb_deregistration_delay <= 3600
-    error_message = "alb_deregistration_delay must be between 0 and 3600 seconds."
-  }
+variable "alb_security_group_id" {
+  type        = string
+  description = "Security group ID of the gateway ALB created in services-common."
 }
 
 variable "internal_observability_api_key_secret_arn" {
@@ -235,12 +212,6 @@ variable "redis_port" {
 variable "redis_security_group_id" {
   type        = string
   description = "Security group ID of the dedicated gateway ElastiCache instance."
-}
-
-variable "authorized_security_groups" {
-  type        = map(string)
-  description = "Map of security group names to their IDs that are authorized to access the gateway ALB on port 80. Format: { name = <security_group_id> }"
-  default     = {}
 }
 
 variable "custom_tags" {

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -111,11 +111,19 @@ variable "log_retention_days" {
 variable "target_group_arn" {
   type        = string
   description = "ARN of the gateway ALB target group created in services-common."
+  nullable    = true
 }
 
 variable "alb_security_group_id" {
   type        = string
   description = "Security group ID of the gateway ALB created in services-common."
+  nullable    = true
+}
+
+variable "gateway_http_listener_arn" {
+  type        = string
+  description = "ARN of the gateway ALB HTTP listener created in services-common; orders ECS registration after the listener exists."
+  nullable    = true
 }
 
 variable "internal_observability_api_key_secret_arn" {

--- a/modules/services-common/gateway-alb.tf
+++ b/modules/services-common/gateway-alb.tf
@@ -1,0 +1,100 @@
+locals {
+  gateway_container_port = 8080
+  gateway_alb_authorized_security_groups = merge(
+    {
+      "API"        = aws_security_group.api.id
+      "Brainstore" = aws_security_group.brainstore_instance.id
+    },
+    var.ai_gateway_authorized_security_groups,
+  )
+}
+
+resource "aws_security_group" "gateway_alb" {
+  count = var.enable_ai_gateway ? 1 : 0
+
+  name        = "${var.deployment_name}-gateway-alb"
+  description = "Security group for private gateway ALB"
+  vpc_id      = var.vpc_id
+  tags = merge({
+    Name = "${var.deployment_name}-gateway-alb"
+  }, local.common_tags)
+}
+
+resource "aws_security_group_rule" "gateway_alb_ingress_from_authorized_security_groups" {
+  for_each = var.enable_ai_gateway ? local.gateway_alb_authorized_security_groups : {}
+
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = each.value
+  description              = "Allow HTTP traffic from ${each.key}."
+  security_group_id        = aws_security_group.gateway_alb[0].id
+}
+
+resource "aws_security_group_rule" "gateway_alb_egress_all" {
+  count = var.enable_ai_gateway ? 1 : 0
+
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all outbound traffic from gateway ALB"
+  security_group_id = aws_security_group.gateway_alb[0].id
+}
+
+resource "aws_lb" "gateway" {
+  count = var.enable_ai_gateway ? 1 : 0
+
+  name               = "${var.deployment_name}-gateway"
+  internal           = true
+  load_balancer_type = "application"
+  subnets            = var.private_subnet_ids
+  security_groups    = [aws_security_group.gateway_alb[0].id]
+
+  client_keep_alive = var.ai_gateway_alb_client_keep_alive
+  idle_timeout      = var.ai_gateway_alb_idle_timeout
+
+  tags = merge({
+    Name = "${var.deployment_name}-gateway"
+  }, local.common_tags)
+}
+
+resource "aws_lb_target_group" "gateway" {
+  count = var.enable_ai_gateway ? 1 : 0
+
+  name        = "${var.deployment_name}-gateway"
+  port        = local.gateway_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  deregistration_delay = var.ai_gateway_alb_deregistration_delay
+
+  health_check {
+    path                = "/health"
+    matcher             = "200"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 10
+  }
+
+  tags = merge({
+    Name = "${var.deployment_name}-gateway"
+  }, local.common_tags)
+}
+
+resource "aws_lb_listener" "gateway_http" {
+  count = var.enable_ai_gateway ? 1 : 0
+
+  load_balancer_arn = aws_lb.gateway[0].arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.gateway[0].arn
+  }
+}

--- a/modules/services-common/gateway-alb.tf
+++ b/modules/services-common/gateway-alb.tf
@@ -10,7 +10,7 @@ locals {
 }
 
 resource "aws_security_group" "gateway_alb" {
-  count = var.enable_ai_gateway ? 1 : 0
+  count = var.create_ai_gateway ? 1 : 0
 
   name        = "${var.deployment_name}-gateway-alb"
   description = "Security group for private gateway ALB"
@@ -21,7 +21,7 @@ resource "aws_security_group" "gateway_alb" {
 }
 
 resource "aws_security_group_rule" "gateway_alb_ingress_from_authorized_security_groups" {
-  for_each = var.enable_ai_gateway ? local.gateway_alb_authorized_security_groups : {}
+  for_each = var.create_ai_gateway ? local.gateway_alb_authorized_security_groups : {}
 
   type                     = "ingress"
   from_port                = 80
@@ -33,7 +33,7 @@ resource "aws_security_group_rule" "gateway_alb_ingress_from_authorized_security
 }
 
 resource "aws_security_group_rule" "gateway_alb_egress_all" {
-  count = var.enable_ai_gateway ? 1 : 0
+  count = var.create_ai_gateway ? 1 : 0
 
   type              = "egress"
   from_port         = 0
@@ -45,7 +45,7 @@ resource "aws_security_group_rule" "gateway_alb_egress_all" {
 }
 
 resource "aws_lb" "gateway" {
-  count = var.enable_ai_gateway ? 1 : 0
+  count = var.create_ai_gateway ? 1 : 0
 
   name               = "${var.deployment_name}-gateway"
   internal           = true
@@ -62,7 +62,7 @@ resource "aws_lb" "gateway" {
 }
 
 resource "aws_lb_target_group" "gateway" {
-  count = var.enable_ai_gateway ? 1 : 0
+  count = var.create_ai_gateway ? 1 : 0
 
   name        = "${var.deployment_name}-gateway"
   port        = local.gateway_container_port
@@ -87,7 +87,7 @@ resource "aws_lb_target_group" "gateway" {
 }
 
 resource "aws_lb_listener" "gateway_http" {
-  count = var.enable_ai_gateway ? 1 : 0
+  count = var.create_ai_gateway ? 1 : 0
 
   load_balancer_arn = aws_lb.gateway[0].arn
   port              = 80

--- a/modules/services-common/outputs.tf
+++ b/modules/services-common/outputs.tf
@@ -74,7 +74,12 @@ output "gateway_target_group_arn" {
   value       = try(aws_lb_target_group.gateway[0].arn, null)
 }
 
+output "gateway_http_listener_arn" {
+  description = "ARN of the gateway ALB HTTP listener"
+  value       = try(aws_lb_listener.gateway_http[0].arn, null)
+}
+
 output "gateway_url" {
   description = "Private in-VPC gateway URL for GATEWAY_URL on api-ts services"
-  value       = var.enable_ai_gateway ? "http://${aws_lb.gateway[0].dns_name}" : null
+  value       = try("http://${aws_lb.gateway[0].dns_name}", null)
 }

--- a/modules/services-common/outputs.tf
+++ b/modules/services-common/outputs.tf
@@ -53,3 +53,28 @@ output "quarantine_lambda_security_group_id" {
   description = "The ID of the security group for quarantine Lambda functions"
   value       = one(aws_security_group.quarantine_lambda[*].id)
 }
+
+output "gateway_alb_dns_name" {
+  description = "Internal DNS name of the private gateway ALB"
+  value       = try(aws_lb.gateway[0].dns_name, null)
+}
+
+output "gateway_alb_arn" {
+  description = "ARN of the private gateway ALB"
+  value       = try(aws_lb.gateway[0].arn, null)
+}
+
+output "gateway_alb_security_group_id" {
+  description = "Security group ID attached to the private gateway ALB"
+  value       = try(aws_security_group.gateway_alb[0].id, null)
+}
+
+output "gateway_target_group_arn" {
+  description = "ARN of the gateway ALB target group"
+  value       = try(aws_lb_target_group.gateway[0].arn, null)
+}
+
+output "gateway_url" {
+  description = "Private in-VPC gateway URL for GATEWAY_URL on api-ts services"
+  value       = var.enable_ai_gateway ? "http://${aws_lb.gateway[0].dns_name}" : null
+}

--- a/modules/services-common/variables.tf
+++ b/modules/services-common/variables.tf
@@ -127,7 +127,7 @@ variable "quarantine_vpc_id" {
   }
 }
 
-variable "enable_ai_gateway" {
+variable "create_ai_gateway" {
   type        = bool
   description = "When true, create the private gateway internal ALB and target group in this module."
   default     = false
@@ -139,8 +139,8 @@ variable "private_subnet_ids" {
   default     = []
 
   validation {
-    condition     = !var.enable_ai_gateway || (length(var.private_subnet_ids) >= 2 && length(distinct(var.private_subnet_ids)) == length(var.private_subnet_ids))
-    error_message = "private_subnet_ids must contain at least 2 unique subnet IDs when enable_ai_gateway is true."
+    condition     = !var.create_ai_gateway || (length(var.private_subnet_ids) >= 2 && length(distinct(var.private_subnet_ids)) == length(var.private_subnet_ids))
+    error_message = "private_subnet_ids must contain at least 2 unique subnet IDs when create_ai_gateway is true."
   }
 }
 

--- a/modules/services-common/variables.tf
+++ b/modules/services-common/variables.tf
@@ -126,3 +126,59 @@ variable "quarantine_vpc_id" {
     error_message = "quarantine_vpc_id is required when enable_quarantine_vpc is true."
   }
 }
+
+variable "enable_ai_gateway" {
+  type        = bool
+  description = "When true, create the private gateway internal ALB and target group in this module."
+  default     = false
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the gateway internal ALB."
+  default     = []
+
+  validation {
+    condition     = !var.enable_ai_gateway || (length(var.private_subnet_ids) >= 2 && length(distinct(var.private_subnet_ids)) == length(var.private_subnet_ids))
+    error_message = "private_subnet_ids must contain at least 2 unique subnet IDs when enable_ai_gateway is true."
+  }
+}
+
+variable "ai_gateway_authorized_security_groups" {
+  type        = map(string)
+  description = "Additional security groups authorized to reach the gateway ALB on port 80."
+  default     = {}
+}
+
+variable "ai_gateway_alb_client_keep_alive" {
+  type        = number
+  description = "Client keep-alive duration in seconds for the gateway ALB."
+  default     = 4000
+
+  validation {
+    condition     = var.ai_gateway_alb_client_keep_alive >= 60 && var.ai_gateway_alb_client_keep_alive <= 604800
+    error_message = "ai_gateway_alb_client_keep_alive must be between 60 and 604800 seconds."
+  }
+}
+
+variable "ai_gateway_alb_idle_timeout" {
+  type        = number
+  description = "Idle timeout in seconds for the gateway ALB."
+  default     = 3600
+
+  validation {
+    condition     = var.ai_gateway_alb_idle_timeout >= 1 && var.ai_gateway_alb_idle_timeout <= 4000
+    error_message = "ai_gateway_alb_idle_timeout must be between 1 and 4000 seconds."
+  }
+}
+
+variable "ai_gateway_alb_deregistration_delay" {
+  type        = number
+  description = "Seconds for the gateway target group to wait before deregistering draining targets."
+  default     = 600
+
+  validation {
+    condition     = var.ai_gateway_alb_deregistration_delay >= 0 && var.ai_gateway_alb_deregistration_delay <= 3600
+    error_message = "ai_gateway_alb_deregistration_delay must be between 0 and 3600 seconds."
+  }
+}

--- a/moved_state.tf
+++ b/moved_state.tf
@@ -251,38 +251,3 @@ moved {
   from = module.services[0].aws_security_group_rule.quarantine_lambda_allow_egress_all[0]
   to   = module.services_common.aws_security_group_rule.quarantine_lambda_allow_egress_all[0]
 }
-
-moved {
-  from = module.gateway_ecs[0].aws_security_group.alb
-  to   = module.services_common.aws_security_group.gateway_alb[0]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_security_group_rule.alb_ingress_from_authorized_security_groups["API"]
-  to   = module.services_common.aws_security_group_rule.gateway_alb_ingress_from_authorized_security_groups["API"]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_security_group_rule.alb_ingress_from_authorized_security_groups["Brainstore"]
-  to   = module.services_common.aws_security_group_rule.gateway_alb_ingress_from_authorized_security_groups["Brainstore"]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_security_group_rule.alb_egress_all
-  to   = module.services_common.aws_security_group_rule.gateway_alb_egress_all[0]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_lb.gateway
-  to   = module.services_common.aws_lb.gateway[0]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_lb_target_group.gateway
-  to   = module.services_common.aws_lb_target_group.gateway[0]
-}
-
-moved {
-  from = module.gateway_ecs[0].aws_lb_listener.gateway_http
-  to   = module.services_common.aws_lb_listener.gateway_http[0]
-}

--- a/moved_state.tf
+++ b/moved_state.tf
@@ -251,3 +251,38 @@ moved {
   from = module.services[0].aws_security_group_rule.quarantine_lambda_allow_egress_all[0]
   to   = module.services_common.aws_security_group_rule.quarantine_lambda_allow_egress_all[0]
 }
+
+moved {
+  from = module.gateway_ecs[0].aws_security_group.alb
+  to   = module.services_common.aws_security_group.gateway_alb[0]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_security_group_rule.alb_ingress_from_authorized_security_groups["API"]
+  to   = module.services_common.aws_security_group_rule.gateway_alb_ingress_from_authorized_security_groups["API"]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_security_group_rule.alb_ingress_from_authorized_security_groups["Brainstore"]
+  to   = module.services_common.aws_security_group_rule.gateway_alb_ingress_from_authorized_security_groups["Brainstore"]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_security_group_rule.alb_egress_all
+  to   = module.services_common.aws_security_group_rule.gateway_alb_egress_all[0]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_lb.gateway
+  to   = module.services_common.aws_lb.gateway[0]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_lb_target_group.gateway
+  to   = module.services_common.aws_lb_target_group.gateway[0]
+}
+
+moved {
+  from = module.gateway_ecs[0].aws_lb_listener.gateway_http
+  to   = module.services_common.aws_lb_listener.gateway_http[0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,18 +84,23 @@ output "gateway_service_name" {
 }
 
 output "gateway_alb_dns_name" {
-  value       = var.enable_ai_gateway ? module.gateway_ecs[0].alb_dns_name : null
+  value       = var.enable_ai_gateway ? module.services_common.gateway_alb_dns_name : null
   description = "Internal DNS name of the private gateway ALB"
 }
 
 output "gateway_alb_arn" {
-  value       = var.enable_ai_gateway ? module.gateway_ecs[0].alb_arn : null
+  value       = var.enable_ai_gateway ? module.services_common.gateway_alb_arn : null
   description = "ARN of the private gateway ALB"
 }
 
 output "gateway_target_group_arn" {
-  value       = var.enable_ai_gateway ? module.gateway_ecs[0].target_group_arn : null
+  value       = var.enable_ai_gateway ? module.services_common.gateway_target_group_arn : null
   description = "ARN of the gateway ALB target group"
+}
+
+output "gateway_url" {
+  value       = var.enable_ai_gateway ? module.services_common.gateway_url : null
+  description = "Private in-VPC gateway URL for GATEWAY_URL on api-ts services"
 }
 
 output "gateway_task_security_group_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,37 +74,37 @@ output "api_security_group_id" {
 }
 
 output "ecs_cluster_arn" {
-  value       = var.enable_ai_gateway || local.create_ecs_api ? module.ecs[0].cluster_arn : null
+  value       = local.create_ai_gateway || local.create_ecs_api ? module.ecs[0].cluster_arn : null
   description = "ARN of the ECS cluster used for ECS services"
 }
 
 output "gateway_service_name" {
-  value       = var.enable_ai_gateway ? module.gateway_ecs[0].service_name : null
+  value       = local.create_ai_gateway ? module.gateway_ecs[0].service_name : null
   description = "Name of the ECS gateway service"
 }
 
 output "gateway_alb_dns_name" {
-  value       = var.enable_ai_gateway ? module.services_common.gateway_alb_dns_name : null
+  value       = local.create_ai_gateway ? module.services_common.gateway_alb_dns_name : null
   description = "Internal DNS name of the private gateway ALB"
 }
 
 output "gateway_alb_arn" {
-  value       = var.enable_ai_gateway ? module.services_common.gateway_alb_arn : null
+  value       = local.create_ai_gateway ? module.services_common.gateway_alb_arn : null
   description = "ARN of the private gateway ALB"
 }
 
 output "gateway_target_group_arn" {
-  value       = var.enable_ai_gateway ? module.services_common.gateway_target_group_arn : null
+  value       = local.create_ai_gateway ? module.services_common.gateway_target_group_arn : null
   description = "ARN of the gateway ALB target group"
 }
 
 output "gateway_url" {
-  value       = var.enable_ai_gateway ? module.services_common.gateway_url : null
-  description = "Private in-VPC gateway URL for GATEWAY_URL on api-ts services"
+  value       = local.create_ai_gateway ? module.services_common.gateway_url : null
+  description = "Private in-VPC gateway URL. Set enable_ai_gateway to wire GATEWAY_URL on api-ts services."
 }
 
 output "gateway_task_security_group_id" {
-  value       = var.enable_ai_gateway ? module.gateway_ecs[0].task_security_group_id : null
+  value       = local.create_ai_gateway ? module.gateway_ecs[0].task_security_group_id : null
   description = "ID of the security group for ECS gateway tasks"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -335,10 +335,21 @@ variable "redis_authorized_security_groups" {
 
 ## Services
 
-variable "enable_ai_gateway" {
-  description = "Enable ECS gateway service deployment (Fargate with private ALB)"
+variable "create_ai_gateway" {
+  description = "Create the private gateway infrastructure (internal ALB and ECS gateway service)."
   type        = bool
   default     = false
+}
+
+variable "enable_ai_gateway" {
+  description = "Wire GATEWAY_URL on APIHandler, AIProxy, and ECS API to the private gateway. Requires create_ai_gateway."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.enable_ai_gateway || var.create_ai_gateway
+    error_message = "enable_ai_gateway requires create_ai_gateway."
+  }
 }
 
 variable "container_insights" {
@@ -650,8 +661,8 @@ variable "braintrust_api_url" {
   default     = null
 
   validation {
-    condition     = !(var.use_deployment_mode_external_eks && var.enable_ai_gateway) || var.braintrust_api_url != null
-    error_message = "braintrust_api_url is required when use_deployment_mode_external_eks and enable_ai_gateway are both true."
+    condition     = !(var.use_deployment_mode_external_eks && var.create_ai_gateway) || var.braintrust_api_url != null
+    error_message = "braintrust_api_url is required when use_deployment_mode_external_eks and create_ai_gateway are both true."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -342,7 +342,7 @@ variable "create_ai_gateway" {
 }
 
 variable "enable_ai_gateway" {
-  description = "Wire GATEWAY_URL on APIHandler, AIProxy, and ECS API to the private gateway. Requires create_ai_gateway."
+  description = "Wire GATEWAY_URL on APIHandler, AIProxy, and ECS API to the private gateway. For existing dataplanes, required: set create_ai_gateway = true (with enable_ai_gateway = false) and apply first, then set enable_ai_gateway = true in a subsequent apply once the private gateway is healthy. Greenfield dataplanes can enable both create_ai_gateway and enable_ai_gateway in a single apply."
   type        = bool
   default     = false
 


### PR DESCRIPTION
## Summary

Part of fixing: [INF-173](https://linear.app/braintrustdata/issue/INF-173)

- Move the internal gateway ALB (SG, listener, target group) from `gateway-ecs` into `services-common` so the ALB DNS is available before gateway ECS wiring (breaks the dependency cycle for auto-wiring `GATEWAY_URL`).
- Split `enable_ai_gateway` into **`create_ai_gateway`** (infra: ALB + gateway ECS) and **`enable_ai_gateway`** (wire `GATEWAY_URL` on APIHandler, AIProxy, and ECS API). Supports a two-step prod cutover: create infra first, flip wiring after health checks.
- When `enable_ai_gateway = true`, set `GATEWAY_URL` on **APIHandler**, **AIProxy**, and **ECS API** in a single `terraform apply` — no manual `internal_gateway_url` / two-phase hack.
- **No `moved` blocks** for gateway ALB resources. Existing stacks that already applied the old layout will **destroy/recreate** the gateway ALB (new DNS). Acceptable because private gateway is not in broad production use yet; gateway ECS tasks may recycle when the target group is replaced.
- Do **not** merge `GATEWAY_URL` into `MigrateDatabaseFunction` or crons — avoids publishing new Lambda versions and re-running migrations on upgrade.
- Add `terraform_data.gateway_http_listener` in `gateway-ecs` to enforce listener dependency ordering across modules (see below).
- Add root `gateway_url` output and upgrade guidance in `AGENTS.md`.

**Out of scope for this PR** (follow-up): CloudFront `/v1/proxy` VPC origin cutover to private gateway ALB (bypass AI Proxy Lambda), AI Proxy Lambda removal.

### `terraform_data.gateway_http_listener` (why it exists)

Before this PR, the gateway HTTP listener lived in the same `gateway-ecs` module as the ECS service, so Terraform could order “create listener → attach ECS service” within one module.

After moving the listener to `services-common`, `gateway-ecs` only receives `gateway_http_listener_arn` as an input. Passing an output into a variable does **not** always make Terraform wait for that listener to exist before updating the ECS service — especially on upgrades where the listener is being destroyed and recreated in another module.

`terraform_data` is a small state-only resource that records the listener ARN and gives `aws_ecs_service.gateway` an explicit `depends_on`. That forces the ECS service update to run **after** the new listener in `services-common` exists. It creates no AWS resources (plan shows `+ create` only in Terraform state); it is dependency glue, not new infrastructure.

## Test plan

- [x] Greenfield apply on `erikdw-sandbox` (`create_ai_gateway=true`, `enable_ai_gateway=true`, `use_global_ai_gateway_origin=false`, `BRAINSTORE_ASYNC_SCORING_USE_GATEWAY=all`) — ~175 resources, gateway ECS healthy
- [x] `terraform output gateway_url` returns internal ALB URL; `GATEWAY_URL` present on APIHandler / ECS API when `enable_ai_gateway=true`, absent on MigrateDatabaseFunction
- [x] In-VPC async scoring path: brainstore → internal API ECS ALB → api-ts `forwardToGateway` → internal gateway ALB → OpenAI (gateway CloudWatch logs show `request.source=async_scoring_*`, `passthrough_endpoint=false`)
- [x] In-place upgrade on a deployment with gateway ALB already in `gateway_ecs` state (plan shows ALB destroy/recreate in `services_common`, no `moved` blocks)
- [x] Two-step cutover: `create_ai_gateway=true` + `enable_ai_gateway=false` leaves caller-supplied `GATEWAY_URL` unchanged; flip `enable_ai_gateway=true` wires internal ALB URL
- [x] `terraform plan` with `create_ai_gateway=false` — no gateway resources created