### PR TITLE
Patch ec2-connect script

### DIFF
--- a/modules/remote-support/bastion-user-data.sh
+++ b/modules/remote-support/bastion-user-data.sh
@@ -51,13 +51,39 @@ EOF
 
 cat <<'EOF' > /home/ubuntu/ec2-connect.sh
 #!/bin/bash
+set -euo pipefail
 
+instance_id="$1"
 os_user="ubuntu"
-echo "Connecting to instance $os_user@$1"
-aws ec2-instance-connect ssh \
-  --instance-id "$1" \
-  --os-user "$os_user" \
-  --connection-type direct
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+key="$tmpdir/eic_key"
+ssh-keygen -q -t ed25519 -N "" -f "$key"
+
+az="$(aws ec2 describe-instances \
+  --instance-ids "$instance_id" \
+  --query 'Reservations[0].Instances[0].Placement.AvailabilityZone' \
+  --output text)"
+
+aws ec2-instance-connect send-ssh-public-key \
+  --instance-id "$instance_id" \
+  --instance-os-user "$os_user" \
+  --availability-zone "$az" \
+  --ssh-public-key "file://$key.pub" >/dev/null
+
+
+private_ip="$(aws ec2 describe-instances \
+  --instance-ids "$instance_id" \
+  --query 'Reservations[0].Instances[0].PrivateIpAddress' \
+  --output text)"
+
+echo "Connecting to instance $os_user@$instance_id ($private_ip)"
+/usr/bin/ssh \
+  -i "$key" \
+  -o StrictHostKeyChecking=no \
+  "$os_user@$private_ip"
 EOF
 
 chmod +x /home/ubuntu/*.sh


### PR DESCRIPTION
## Description 

The current script fails with an openssl issue
```
ubuntu@bastion:~$ ./ec2-connect.sh i-0b473ed23cdbe9ebd
Connecting to instance ubuntu@i-0b473ed23cdbe9ebd
OpenSSL version mismatch. Built against 30000020, you have 30500060
```

We're not totally sure what the issue is, but ankur had AI patch up the script and this seems to work. See [slack
thread](https://braintrustdata.slack.com/archives/C08G0934WG1/p1781995810259459?thread_ts=1781741949.780009&cid=C08G0934WG1) for more context.

<!-- Help the reviewer understand what you changed and what the expected behavior is now -->
<!-- Include exact details of what customers need to do, or what they should expect, if anything -->

## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
Tried in prod.