### PR TITLE
Fix remote support template error if no quarantine

### DIFF
--- a/remote_support.tf
+++ b/remote_support.tf
@@ -16,13 +16,13 @@ module "remote_support" {
   redis_host          = module.redis.redis_endpoint
   redis_port          = module.redis.redis_port
   kms_key_arn         = local.kms_key_arn
-  lambda_function_arns = [
+  lambda_function_arns = compact([
     !var.use_deployment_mode_external_eks ? module.services[0].api_handler_arn : null,
     !var.use_deployment_mode_external_eks ? module.services[0].migrate_database_arn : null,
     !var.use_deployment_mode_external_eks ? module.services[0].ai_proxy_arn : null,
     !var.use_deployment_mode_external_eks ? module.services[0].catchup_etl_arn : null,
     !var.use_deployment_mode_external_eks ? module.services[0].quarantine_warmup_arn : null,
-  ]
+  ])
   enable_braintrust_support_logs_access  = var.enable_braintrust_support_logs_access
   enable_braintrust_support_shell_access = var.enable_braintrust_support_shell_access
   vpc_id                                 = local.main_vpc_id


### PR DESCRIPTION
## Description

Resolves an error where the remote support user data template will fail if any of the lambda function ARNs resolve to null.

```
Call to function "templatefile" failed:
/Users/user/src/braintrust/terraform-aws-braintrust-data-plane/modules/remote-support/bastion-user-data.sh:48,20-23:
Invalid function argument; Invalid value for "str" parameter: argument
must not be null., and 1 other diagnostic(s).
```

## Context 

Ran into this when spinning up remote support when `enable_quarantine_vpc` falsey.

## Testing 

Instantiating module with `enable_quarantine_vpc = ture` and `enable_braintrust_support_shell_access = true` should not raise a template error against this branch