### PR TITLE
Expose provider error headers in AIProxy CORS

### DIFF
--- a/modules/services/lambda-aiproxy.tf
+++ b/modules/services/lambda-aiproxy.tf
@@ -90,7 +90,9 @@ resource "aws_lambda_function_url" "ai_proxy" {
       "access-control-allow-origin",
       "access-control-allow-methods",
       "x-bt-internal-trace-id",
-      "x-bt-span-id"
+      "x-bt-span-id",
+      "x-bt-error-origin",
+      "x-bt-used-endpoint"
     ]
     max_age = 86400
   }


### PR DESCRIPTION
## Summary
Expose `x-bt-error-origin` and `x-bt-used-endpoint` in the AIProxy Lambda URL CORS configuration so the Terraform data-plane module matches braintrust#15593's API Gateway CORS change.


## Related PRs
<!-- codex-related-prs:start -->
- [braintrust #15593](https://github.com/braintrustdata/braintrust/pull/15593) - Mirrors API CORS header exposure
<!-- codex-related-prs:end -->
