### PR TITLE
emit v3 span IDs by default in py+ts SDK

### DIFF
--- a/modules/api-ecs/main.tf
+++ b/modules/api-ecs/main.tf
@@ -29,6 +29,7 @@ locals {
     PRIMARY_ORG_NAME                                  = var.primary_org_name
     ALLOWED_ORG_IDS                                   = var.allowed_org_ids
     BRAINTRUST_DEPLOYMENT_NAME                        = var.deployment_name
+    BRAINTRUST_LEGACY_IDS                             = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
     RESPONSE_BUCKET                                   = var.response_bucket
     CODE_BUNDLE_BUCKET                                = var.code_bundle_bucket
     WHITELISTED_ORIGINS                               = join(",", var.whitelisted_origins)

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -23,6 +23,7 @@ locals {
     PRIMARY_ORG_NAME           = var.primary_org_name
     ALLOWED_ORG_IDS            = var.allowed_org_ids
     BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
+    BRAINTRUST_LEGACY_IDS      = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
 
     PG_URL             = local.postgres_url
     REDIS_HOST         = var.redis_host

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -31,6 +31,7 @@ resource "aws_lambda_function" "automation_cron" {
   environment {
     variables = merge({
       ORG_NAME                                  = var.braintrust_org_name
+      BRAINTRUST_LEGACY_IDS                     = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
       PG_URL                                    = local.postgres_url
       REDIS_HOST                                = var.redis_host
       REDIS_PORT                                = var.redis_port

--- a/modules/services/lambda-billing-cron.tf
+++ b/modules/services/lambda-billing-cron.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "billing_cron" {
   environment {
     variables = merge({
       ORG_NAME                      = var.braintrust_org_name
+      BRAINTRUST_LEGACY_IDS         = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
       PG_URL                        = local.postgres_url
       REDIS_HOST                    = var.redis_host
       REDIS_PORT                    = var.redis_port

--- a/modules/services/lambda-catchup-etl.tf
+++ b/modules/services/lambda-catchup-etl.tf
@@ -23,6 +23,7 @@ resource "aws_lambda_function" "catchup_etl" {
   environment {
     variables = merge({
       ORG_NAME                                  = var.braintrust_org_name
+      BRAINTRUST_LEGACY_IDS                     = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
       PG_URL                                    = local.postgres_url
       REDIS_HOST                                = var.redis_host
       REDIS_PORT                                = var.redis_port

--- a/modules/services/lambda-migrate-database.tf
+++ b/modules/services/lambda-migrate-database.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "migrate_database" {
   }
   environment {
     variables = merge({
+      BRAINTRUST_LEGACY_IDS           = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
       BRAINTRUST_RUN_DRAFT_MIGRATIONS = var.run_draft_migrations
       PG_URL                          = local.postgres_url
       INSERT_LOGS2                    = "true"

--- a/modules/services/lambda-quarantine-warmup.tf
+++ b/modules/services/lambda-quarantine-warmup.tf
@@ -30,6 +30,7 @@ resource "aws_lambda_function" "quarantine_warmup" {
     variables = merge({
       ORG_NAME                   = var.braintrust_org_name
       BRAINTRUST_DEPLOYMENT_NAME = var.deployment_name
+      BRAINTRUST_LEGACY_IDS      = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
 
       PG_URL     = local.postgres_url
       REDIS_HOST = var.redis_host


### PR DESCRIPTION
the py+ts SDKs by default emit v4 span components. This is fine because our backend already supports v4 span components.

However, pieces of the backend share code with the SDKs, so to be conservative we're setting this flag to tell the SDKs to behave as they did before.

This flag will be removed once we fully switch to v4.