### PR TITLE
Fix Brainstore AI proxy SSM dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,9 +43,7 @@ locals {
   enable_ai_gateway                          = local.create_ai_gateway && var.enable_ai_gateway
   enable_internal_observability              = trimspace(nonsensitive(var.internal_observability_api_key)) != ""
   create_internal_observability_secret       = local.enable_internal_observability && (local.create_ecs_api || local.create_ai_gateway)
-  ai_proxy_url_ssm_parameter_name            = "/braintrust/${var.deployment_name}/ai-proxy-url"
-  api_ecs_url_ssm_parameter_name             = "/braintrust/${var.deployment_name}/ecs-api-url"
-  brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
+  brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? module.api_ecs[0].url_ssm_parameter_name : module.services[0].ai_proxy_url_ssm_parameter_name
   gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.services_common.gateway_url
   } : {}

--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -161,16 +161,22 @@ ${env_key}=${env_value}
 %{ endfor ~}
 EOF
 
-BRAINSTORE_AI_PROXY_URL=$(aws ssm get-parameter \
-  --name ${ai_proxy_url_ssm_parameter_name} \
-  --query 'Parameter.Value' \
-  --output text \
-  --region ${aws_region})
+BRAINSTORE_AI_PROXY_URL=""
+for attempt in $(seq 1 30); do
+  BRAINSTORE_AI_PROXY_URL=$(aws ssm get-parameter \
+    --name ${ai_proxy_url_ssm_parameter_name} \
+    --query 'Parameter.Value' \
+    --output text \
+    --region ${aws_region} 2>/dev/null) && [ -n "$BRAINSTORE_AI_PROXY_URL" ] && break
+
+  echo "Waiting for BRAINSTORE_AI_PROXY_URL SSM parameter ${ai_proxy_url_ssm_parameter_name} (attempt $attempt/30)"
+  sleep 10
+done
 
 if [ -n "$BRAINSTORE_AI_PROXY_URL" ]; then
   echo "BRAINSTORE_AI_PROXY_URL=$BRAINSTORE_AI_PROXY_URL" >> /etc/brainstore.env
 else
-  echo "ERROR: Failed to resolve BRAINSTORE_AI_PROXY_URL, aborting" >&2
+  echo "ERROR: Failed to resolve BRAINSTORE_AI_PROXY_URL from ${ai_proxy_url_ssm_parameter_name}, aborting" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes Brainstore startup ordering for deployments that use the AI proxy URL from SSM.

On new deployments, Brainstore can start before the AI proxy URL parameter is available in SSM. When that happens, Brainstore fails to resolve `BRAINSTORE_AI_PROXY_URL`, does not become healthy behind the NLB, and the ASG may replace instances during apply.

Brainstore now receives the SSM parameter name from the Terraform resource that creates it, giving Terraform an explicit dependency before launching Brainstore EC2 instances. The startup script also retries the SSM lookup for a bounded period to tolerate short propagation delays.

- Non-breaking bug fix with possible launch template updates on existing deployments