### PR TITLE
Add first class audit log attributes for 2.6.0 & eu-west-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ allowed_org_ids  = "00000000-0000-4000-8000-000000000001,00000000-0000-4000-8000
 
 `allowed_org_ids` is a comma-separated list of Braintrust Org IDs, not org names. Do not include spaces. You can find an org ID by hovering over the org name in the Braintrust UI. If you keep `braintrust_org_name` set to a specific org name for compatibility, that org is allowed by name today; include its Braintrust Org ID in `allowed_org_ids` for forward compatibility. `braintrust_org_name` remains supported for compatibility, but Braintrust plans to move toward ID-based configuration.
 
+### BTQL audit logging
+
+BTQL `query.read` audit logging is disabled by default. Enable it for specific Braintrust Org IDs with either strict or best-effort mode. The two modes are mutually exclusive.
+
+```hcl
+# Strict mode
+btql_audit_logs_strict_org_ids = ["00000000-0000-4000-8000-000000000001"]
+
+# Or best-effort mode
+btql_audit_logs_best_effort_org_ids = ["00000000-0000-4000-8000-000000000001"]
+```
+
+Strict mode writes audit rows before returning query results. Best-effort mode writes audit rows asynchronously and logs failures.
+
 ## Useful scripts
 
 ### dump-logs.sh

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -25,6 +25,12 @@ module "braintrust-data-plane" {
   # If braintrust_org_name is a specific name, include that org's ID here for forward compatibility.
   allowed_org_ids = ""
 
+  # Optional BTQL query.read audit logging by Braintrust Org ID.
+  # Strict mode writes audit rows before returning query results.
+  # Best-effort mode writes audit rows asynchronously and logs failures.
+  # btql_audit_logs_strict_org_ids      = []
+  # btql_audit_logs_best_effort_org_ids = []
+
   ### Tagging
   # Recommended: tag resources with your name/team for identification in shared accounts.
   # custom_tags = {

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -24,6 +24,12 @@ module "braintrust-data-plane" {
   # If braintrust_org_name is a specific name, include that org's ID here for forward compatibility.
   allowed_org_ids = ""
 
+  # Optional BTQL query.read audit logging by Braintrust Org ID.
+  # Strict mode writes audit rows before returning query results.
+  # Best-effort mode writes audit rows asynchronously and logs failures.
+  # btql_audit_logs_strict_org_ids      = []
+  # btql_audit_logs_best_effort_org_ids = []
+
   ### Postgres configuration
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"

--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,8 @@ module "services" {
   braintrust_org_name                        = var.braintrust_org_name
   primary_org_name                           = var.primary_org_name
   allowed_org_ids                            = var.allowed_org_ids
+  btql_audit_logs_strict_org_ids             = var.btql_audit_logs_strict_org_ids
+  btql_audit_logs_best_effort_org_ids        = var.btql_audit_logs_best_effort_org_ids
   api_handler_provisioned_concurrency        = var.api_handler_provisioned_concurrency
   api_handler_reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
   api_handler_memory_limit                   = var.api_handler_memory_limit
@@ -360,6 +362,8 @@ module "api_ecs" {
   braintrust_org_name                   = var.braintrust_org_name
   primary_org_name                      = var.primary_org_name
   allowed_org_ids                       = var.allowed_org_ids
+  btql_audit_logs_strict_org_ids        = var.btql_audit_logs_strict_org_ids
+  btql_audit_logs_best_effort_org_ids   = var.btql_audit_logs_best_effort_org_ids
   cpu                                   = var.api_ecs_cpu
   memory                                = var.api_ecs_memory
   min_count                             = var.api_ecs_min_count

--- a/modules/api-ecs/main.tf
+++ b/modules/api-ecs/main.tf
@@ -23,6 +23,14 @@ locals {
       BRAINTRUST_URL_SECURITY_ALLOW_CIDRS = local.url_security_allow_cidrs
     } : {}
   )
+  btql_audit_log_env_vars = merge(
+    length(var.btql_audit_logs_strict_org_ids) > 0 ? {
+      BTQL_AUDIT_LOGS_STRICT_ORG_IDS = join(",", var.btql_audit_logs_strict_org_ids)
+    } : {},
+    length(var.btql_audit_logs_best_effort_org_ids) > 0 ? {
+      BTQL_AUDIT_LOGS_BEST_EFFORT_ORG_IDS = join(",", var.btql_audit_logs_best_effort_org_ids)
+    } : {}
+  )
 
   base_env_vars = merge({
     ORG_NAME                                          = var.braintrust_org_name
@@ -68,6 +76,7 @@ locals {
     TS_API_ASYNC_SCORING_PROXY_URL                    = "http://127.0.0.1:8000"
     },
     local.url_security_env_vars,
+    local.btql_audit_log_env_vars,
     local.using_brainstore_fast_reader ? {
       BRAINSTORE_FAST_READER_URL           = "http://${var.brainstore_fast_reader_hostname}:${var.brainstore_port}"
       BRAINSTORE_FAST_READER_QUERY_SOURCES = "summaryPaginatedObjectViewer [realtime],summaryPaginatedObjectViewer,a602c972-1843-4ee1-b6bc-d3c1075cd7e7,traceQueryFn-id,traceQueryFn-rootSpanId,fullSpanQueryFn-root_span_id,fullSpanQueryFn-id"

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -146,6 +146,43 @@ variable "allowed_org_ids" {
   }
 }
 
+variable "btql_audit_logs_strict_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in strict mode. Strict mode writes audit rows before returning query results. Mutually exclusive with btql_audit_logs_best_effort_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == length(distinct(var.btql_audit_logs_strict_org_ids))
+    error_message = "btql_audit_logs_strict_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_strict_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_strict_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
+variable "btql_audit_logs_best_effort_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in best-effort mode. Best-effort mode writes audit rows asynchronously and logs failures. Mutually exclusive with btql_audit_logs_strict_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == 0 || length(var.btql_audit_logs_best_effort_org_ids) == 0
+    error_message = "Set either btql_audit_logs_strict_org_ids or btql_audit_logs_best_effort_org_ids, not both."
+  }
+
+  validation {
+    condition     = length(var.btql_audit_logs_best_effort_org_ids) == length(distinct(var.btql_audit_logs_best_effort_org_ids))
+    error_message = "btql_audit_logs_best_effort_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_best_effort_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_best_effort_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
 variable "database_url_secret_arn" {
   type        = string
   description = "ARN of the secret containing the Postgres URL."

--- a/modules/services/lambda-apihandler.tf
+++ b/modules/services/lambda-apihandler.tf
@@ -63,6 +63,14 @@ locals {
     BRAINSTORE_FAST_READER_URL           = local.brainstore_fast_reader_url
     BRAINSTORE_FAST_READER_QUERY_SOURCES = join(",", local.default_fast_reader_query_sources)
   } : {}
+  btql_audit_log_env_vars = merge(
+    length(var.btql_audit_logs_strict_org_ids) > 0 ? {
+      BTQL_AUDIT_LOGS_STRICT_ORG_IDS = join(",", var.btql_audit_logs_strict_org_ids)
+    } : {},
+    length(var.btql_audit_logs_best_effort_org_ids) > 0 ? {
+      BTQL_AUDIT_LOGS_BEST_EFFORT_ORG_IDS = join(",", var.btql_audit_logs_best_effort_org_ids)
+    } : {}
+  )
   # There env vars are specific to the API Handler. Don't add env vars here if you need them for the AI Proxy as well.
   api_handler_specific_env_vars = merge(
     {
@@ -83,7 +91,8 @@ locals {
     } : {},
     var.brainstore_enable_export ? {
       BRAINSTORE_EXPORT_MIGRATION_ENABLED = "true"
-    } : {}
+    } : {},
+    local.btql_audit_log_env_vars
   )
 }
 

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -10,6 +10,7 @@ locals {
     "eu-central-1",
     "eu-west-1",
     "eu-west-2",
+    "eu-west-3",
     "sa-east-1",
     "us-east-1",
     "us-east-2",

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -24,6 +24,43 @@ variable "allowed_org_ids" {
   }
 }
 
+variable "btql_audit_logs_strict_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in strict mode. Strict mode writes audit rows before returning query results. Mutually exclusive with btql_audit_logs_best_effort_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == length(distinct(var.btql_audit_logs_strict_org_ids))
+    error_message = "btql_audit_logs_strict_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_strict_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_strict_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
+variable "btql_audit_logs_best_effort_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in best-effort mode. Best-effort mode writes audit rows asynchronously and logs failures. Mutually exclusive with btql_audit_logs_strict_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == 0 || length(var.btql_audit_logs_best_effort_org_ids) == 0
+    error_message = "Set either btql_audit_logs_strict_org_ids or btql_audit_logs_best_effort_org_ids, not both."
+  }
+
+  validation {
+    condition     = length(var.btql_audit_logs_best_effort_org_ids) == length(distinct(var.btql_audit_logs_best_effort_org_ids))
+    error_message = "btql_audit_logs_best_effort_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_best_effort_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_best_effort_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
 variable "deployment_name" {
   type        = string
   description = "Name of this deployment. Will be included in resource names"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,43 @@ variable "allowed_org_ids" {
   }
 }
 
+variable "btql_audit_logs_strict_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in strict mode. Strict mode writes audit rows before returning query results. Mutually exclusive with btql_audit_logs_best_effort_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == length(distinct(var.btql_audit_logs_strict_org_ids))
+    error_message = "btql_audit_logs_strict_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_strict_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_strict_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
+variable "btql_audit_logs_best_effort_org_ids" {
+  description = "Braintrust Org UUIDs for which BTQL query.read audit logging is enabled in best-effort mode. Best-effort mode writes audit rows asynchronously and logs failures. Mutually exclusive with btql_audit_logs_strict_org_ids."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.btql_audit_logs_strict_org_ids) == 0 || length(var.btql_audit_logs_best_effort_org_ids) == 0
+    error_message = "Set either btql_audit_logs_strict_org_ids or btql_audit_logs_best_effort_org_ids, not both."
+  }
+
+  validation {
+    condition     = length(var.btql_audit_logs_best_effort_org_ids) == length(distinct(var.btql_audit_logs_best_effort_org_ids))
+    error_message = "btql_audit_logs_best_effort_org_ids must not contain duplicate org UUIDs."
+  }
+
+  validation {
+    condition     = alltrue([for org_id in var.btql_audit_logs_best_effort_org_ids : can(regex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", org_id))])
+    error_message = "btql_audit_logs_best_effort_org_ids must contain only Braintrust Org UUIDs."
+  }
+}
+
 variable "deployment_name" {
   type        = string
   default     = "braintrust"


### PR DESCRIPTION
## Description

Adds first-class Terraform variables for enabling BTQL `query.read` audit logging by Braintrust Org UUID:

- `btql_audit_logs_strict_org_ids`
- `btql_audit_logs_best_effort_org_ids`

These variables are wired through to both Lambda

 This also adds `eu-west-3` to the services Lambda layer supported region list.

## Context

Data plane 2.6.0 introduced self-hosted audit logging support. Administrative audit logs work with the base data plane behavior, but BTQL/data-read `query.read` audit logs are intentionally gated by org-specific environment variables because they can be high volume.

Before this change, customers had to use lower-level extra env var hooks to set the BTQL audit logging org IDs manually. 

## Testing
Ran Lambda setup and tested validations with duplicate values and values in both variables