### PR TITLE
add assume role access for gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,6 +298,7 @@ module "gateway_ecs" {
   target_cpu_utilization    = var.ai_gateway_target_cpu_utilization
   target_memory_utilization = var.ai_gateway_target_memory_utilization
   log_retention_days        = var.ai_gateway_log_retention_days
+  permissions_boundary_arn  = var.permissions_boundary_arn
   redis_host                = module.redis.redis_endpoint
   redis_port                = module.redis.redis_port
   redis_security_group_id   = module.redis.redis_security_group_id

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -283,6 +283,28 @@ resource "aws_iam_role" "task" {
   }, local.common_tags)
 }
 
+resource "aws_iam_role_policy" "customer_assume_role" {
+  name = "${var.deployment_name}-gateway-customer-assume-role"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AssumeRoleInCustomerAccount"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "sts:ExternalId" = "bt:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_ecs_task_definition" "gateway" {
   family                   = "${var.deployment_name}-gateway"
   requires_compatibilities = ["FARGATE"]

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -276,8 +276,9 @@ resource "aws_iam_role_policy" "task_execution_observability_secrets" {
 }
 
 resource "aws_iam_role" "task" {
-  name               = "${var.deployment_name}-gateway-task"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  name                 = "${var.deployment_name}-gateway-task"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
   tags = merge({
     Name = "${var.deployment_name}-gateway-task"
   }, local.common_tags)

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -8,6 +8,12 @@ variable "kms_key_arn" {
   description = "KMS key ARN used to encrypt gateway resources that support customer-managed KMS keys."
 }
 
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to the gateway task role."
+  default     = null
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID where ECS resources are deployed."


### PR DESCRIPTION
## Description
  <!-- Help the reviewer understand what you changed and what the expected behavior is now -->

 This PR adds an inline IAM policy to the Gateway ECS task role, `${deployment_name}-gateway-task`, allowing Gateway tasks to assume customer-provided IAM roles.

This role is used to allow for the `AssumeRole` auth method in braintrust -> https://www.braintrust.dev/docs/integrations/ai-providers/bedrock#connect-bedrock-to-braintrust which is provided as a auth method in the gateway/braintrust platform.

  ## Context
  <!-- Help the reviewer understand the background on why you are doing this -->

  Gateway executes with its own ECS task role, so granting this permission to the shared API role would not authorize
  Gateway’s STS calls.

  This follows the existing cross-account S3 export pattern in modules/services-common/iam-api.tf:162, which already
  allows:

```
  Action   = "sts:AssumeRole"
  Resource = "*"
  Condition = {
    StringLike = {
      "sts:ExternalId" = "bt:*"
    }
  }
```

  The new policy applies that same external-ID boundary to the dedicated Gateway task role in modules/gateway-ecs/
  main.tf:286.

  ## Testing
  <!-- Describe how and what you tested. Include screenshots or videos as needed -->

  - Ran terraform fmt -check -recursive.
  - Ran terraform validate.
  - Ran git diff --check.
