### PR TITLE
Fix sandbox gp3 storage settings

### DIFF
--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -47,9 +47,10 @@ module "braintrust-data-plane" {
 
   postgres_storage_type = "gp3"
 
-  # gp3 volumes under 400GB receive baseline performance (3000 IOPS, 125 MiB/s). These match the baseline.
-  postgres_storage_iops       = 3000
-  postgres_storage_throughput = 125
+  # RDS PostgreSQL only allows explicit gp3 IOPS/throughput when storage is >= 400 GiB.
+  # Leave these unset so the 100 GiB sandbox instance uses gp3 baseline performance.
+  postgres_storage_iops       = null
+  postgres_storage_throughput = null
 
   postgres_version                    = "15"
   postgres_auto_minor_version_upgrade = true


### PR DESCRIPTION
## Summary

- Stop explicitly setting gp3 IOPS and throughput in the sandbox data plane example.
- Leave those values unset so the 100 GiB RDS PostgreSQL instance uses baseline gp3 performance.

## Why

AWS RDS PostgreSQL rejects explicit gp3 IOPS or throughput settings when allocated storage is less than 400 GiB, even when those values match gp3 baseline performance. The sandbox example uses 100 GiB, so setting these arguments causes `CreateDBInstance` to fail with `InvalidParameterCombination`.

## Validation

- `terraform fmt -check examples/braintrust-data-plane-sandbox/main.tf`
- `terraform validate` could not complete because the example module has not been installed in this checkout; Terraform reported `Module not installed` and requested `terraform init`.