### PR TITLE
Update v6 migration to include note about overrides

### DIFF
--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -19,7 +19,7 @@ These services have new variables that require consideration:
   - If for some reason you are locked onto a specific version of our services with `lambda_version_tag_override`, then you need to copy that here. 
 - `braintrust_api_min_count` / `braintrust_api_max_count`
   - The defaults are 3 and 50 which is sensible for nearly all but the most high traffic deployments
-- `braintrust_api_ingest_min_count / `braintrust_api_ingest_max_count`
+- `braintrust_api_ingest_min_count` / `braintrust_api_ingest_max_count`
   - The defaults are 6 and 200
 - `braintrust_api_background_min_count` / `braintrust_api_background_max_count`
   - The defaults are 3 and 50

--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -12,17 +12,32 @@ APIHandler and AIProxy now run as ECS services alongside the existing Lambdas. T
 - `braintrust-api-ingest` — ingestion paths (`/logs3`, `/otel/v1/traces`)
 - `braintrust-api-background` — background paths (evals, function invoke, proxy)
 
+These services have new variables that require consideration:
+- `braintrust_api_extra_env_vars`
+  - If you modified `service_extra_env_vars.APIHandler` or `service_extra_env_vars.AIProxy` you will need to duplicate those values here.
+- `braintrust_api_version_override`
+  - If for some reason you are locked onto a specific version of our services with `lambda_version_tag_override`, then you need to copy that here. 
+- `braintrust_api_min_count` / `braintrust_api_max_count`
+  - The defaults are 3 and 50 which is sensible for nearly all but the most high traffic deployments
+- `braintrust_api_ingest_min_count / `braintrust_api_ingest_max_count`
+  - The defaults are 6 and 200
+- `braintrust_api_background_min_count` / `braintrust_api_background_max_count`
+  - The defaults are 3 and 50
+
+
 ## Upgrade steps
 
 1. **Bump the module to v6** and apply Terraform with `enable_ecs_api` left at its default (`false`).
 
    This creates the ECS services, ALB, and related infrastructure. CloudFront continues to send traffic to Lambda. ECS and Lambda run side by side while ECS warms up.
 
-2. **Verify your Data Plane is still healthy**
+   If you have customized `service_extra_env_vars` or `lambda_version_tag_override` then add them to your config (see Whats Changed above)
+
+3. **Verify your Data Plane is still healthy**
 
    Terraform should have successfully applied without error. You should exercise the data plane with a few calls in the UI.
 
-3. **Cut over traffic to ECS** by setting:
+4. **Cut over traffic to ECS** by setting:
 
    ```hcl
    enable_ecs_api = true
@@ -30,7 +45,7 @@ APIHandler and AIProxy now run as ECS services alongside the existing Lambdas. T
 
    Apply again. CloudFront will route API traffic to the ECS ALB instead of API Gateway / Lambda.
 
-4. **Verify the cutover** by exercising the data plane again (API requests, ingestion, evals).
+5. **Verify the cutover** by exercising the data plane again (API requests, ingestion, evals).
 
 ## Rollback
 


### PR DESCRIPTION
Missed some docs about variables in the v6 migration guide