### PR TITLE
Added an endpoint for the lock monitoring for the data plane

### DIFF
--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -211,6 +211,9 @@ locals {
           ]
         })
       }
+      "/brainstore/locks-snapshot" = {
+        for method in ["get", "options"] : method => local.snippet_api_json_text_method
+      }
       "/broadcast-key" = {
         for method in ["get", "options", "post"] : method => local.snippet_api_json_text_method
       }

--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -214,6 +214,9 @@ locals {
       "/brainstore/locks-snapshot" = {
         for method in ["get", "options"] : method => local.snippet_api_json_text_method
       }
+      "/brainstore/locks-delete" = {
+        for method in ["post", "options"] : method => local.snippet_api_json_text_method
+      }
       "/broadcast-key" = {
         for method in ["get", "options", "post"] : method => local.snippet_api_json_text_method
       }


### PR DESCRIPTION
## Description
Add the new Brainstore lock monitoring route to the Terraform data-plane module so self-hosted/data-plane deployments expose the same API route as the main repo:
- GET /brainstore/locks-snapshot
- OPTIONS /brainstore/locks-snapshot
- POST /brainstore/locks-delete
- OPTIONS /brainstore/locks-delete

## Context
The Braintrust app PR adds an admin UI for monitoring Brainstore lock state, useful for identifying stuck locks/deadlock-like situations faster. The frontend calls the API route /brainstore/locks-snapshot,

## Testing 
Manual verification

<img width="242" height="181" alt="image" src="https://github.com/user-attachments/assets/777a51f5-1ae5-4dc5-843f-169526eb0cc4" />
