### PR TITLE
Disable gateway ECS sigint_rollback (fix Atlantis deploy rollbacks)

### DIFF
--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -351,7 +351,9 @@ resource "aws_ecs_service" "gateway" {
   enable_execute_command            = var.enable_execute_command
   health_check_grace_period_seconds = 60
   wait_for_steady_state             = true
-  sigint_rollback                   = true
+
+  # This causes instant rollbacks on first deploy. Must be off. (Same as api-ecs.)
+  sigint_rollback = false
 
   deployment_circuit_breaker {
     enable   = true


### PR DESCRIPTION
## Summary
- Set `sigint_rollback = false` on `gateway-ecs`, matching `api-ecs` (which already documents: \"This causes instant rollbacks on first deploy. Must be off.\").


## Test plan
- [ ] terraform apply of a gateway task-def bump on test env completes past `aws_ecs_service.gateway` wait
- [ ] Real unhealthy deploys still roll back via `deployment_circuit_breaker`


Made with [Cursor](https://cursor.com)