### PR TITLE
Expose `drop_invalid_header_fields` setting on the API and gateway ALBs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -318,10 +318,11 @@ module "gateway_alb" {
     },
     var.ai_gateway_authorized_security_groups,
   )
-  alb_client_keep_alive    = var.ai_gateway_alb_client_keep_alive
-  alb_idle_timeout         = var.ai_gateway_alb_idle_timeout
-  alb_deregistration_delay = var.ai_gateway_alb_deregistration_delay
-  custom_tags              = var.custom_tags
+  alb_client_keep_alive          = var.ai_gateway_alb_client_keep_alive
+  alb_idle_timeout               = var.ai_gateway_alb_idle_timeout
+  alb_deregistration_delay       = var.ai_gateway_alb_deregistration_delay
+  alb_drop_invalid_header_fields = var.ai_gateway_alb_drop_invalid_header_fields
+  custom_tags                    = var.custom_tags
 }
 
 module "gateway_ecs" {
@@ -470,8 +471,9 @@ module "api_ecs" {
   )
   authorized_cidr_blocks = var.braintrust_api_authorized_cidr_blocks
 
-  alb_certificate_arn = var.braintrust_api_alb_certificate_arn
-  alb_custom_domain   = var.braintrust_api_alb_custom_domain
+  alb_certificate_arn            = var.braintrust_api_alb_certificate_arn
+  alb_custom_domain              = var.braintrust_api_alb_custom_domain
+  alb_drop_invalid_header_fields = var.braintrust_api_alb_drop_invalid_header_fields
 
   kms_key_arn            = local.kms_key_arn
   ecs_cluster_arn        = module.ecs[0].cluster_arn

--- a/modules/api-ecs/alb.tf
+++ b/modules/api-ecs/alb.tf
@@ -77,6 +77,7 @@ resource "aws_lb" "api_ecs" {
   enable_http2                     = true
   desync_mitigation_mode           = "defensive"
   enable_cross_zone_load_balancing = true
+  drop_invalid_header_fields       = var.alb_drop_invalid_header_fields
 
   tags = merge({
     Name = "${var.deployment_name}-api-ecs"

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -658,6 +658,12 @@ variable "alb_custom_domain" {
   }
 }
 
+variable "alb_drop_invalid_header_fields" {
+  type        = bool
+  description = "Whether the API ECS ALB removes HTTP headers with invalid header names before routing requests."
+  default     = false
+}
+
 variable "custom_tags" {
   description = "Custom tags to apply to all created resources."
   type        = map(string)

--- a/modules/gateway-alb/main.tf
+++ b/modules/gateway-alb/main.tf
@@ -45,8 +45,9 @@ resource "aws_lb" "gateway" {
   subnets            = local.gateway_alb_subnet_ids
   security_groups    = [aws_security_group.gateway_alb.id]
 
-  client_keep_alive = var.alb_client_keep_alive
-  idle_timeout      = var.alb_idle_timeout
+  client_keep_alive          = var.alb_client_keep_alive
+  idle_timeout               = var.alb_idle_timeout
+  drop_invalid_header_fields = var.alb_drop_invalid_header_fields
 
   tags = merge({
     Name = "${var.deployment_name}-gateway"

--- a/modules/gateway-alb/variables.tf
+++ b/modules/gateway-alb/variables.tf
@@ -74,6 +74,12 @@ variable "alb_deregistration_delay" {
   }
 }
 
+variable "alb_drop_invalid_header_fields" {
+  type        = bool
+  description = "Whether the gateway ALB removes HTTP headers with invalid header names before routing requests."
+  default     = false
+}
+
 variable "custom_tags" {
   type        = map(string)
   description = "Tags to apply to created resources."

--- a/variables.tf
+++ b/variables.tf
@@ -513,6 +513,12 @@ variable "ai_gateway_alb_deregistration_delay" {
   }
 }
 
+variable "ai_gateway_alb_drop_invalid_header_fields" {
+  description = "Whether the AI gateway ALB removes HTTP headers with invalid header names before routing requests."
+  type        = bool
+  default     = false
+}
+
 variable "ai_gateway_extra_env_vars" {
   description = "Extra environment variables for the gateway ECS container"
   type        = map(string)
@@ -860,6 +866,12 @@ variable "braintrust_api_alb_custom_domain" {
     condition     = (var.braintrust_api_alb_custom_domain == null) == (var.braintrust_api_alb_certificate_arn == null)
     error_message = "braintrust_api_alb_custom_domain and braintrust_api_alb_certificate_arn must both be set or both be null."
   }
+}
+
+variable "braintrust_api_alb_drop_invalid_header_fields" {
+  description = "Whether the Braintrust API ALB removes HTTP headers with invalid header names before routing requests."
+  type        = bool
+  default     = false
 }
 
 variable "api_ecs_enable_execute_command" {


### PR DESCRIPTION
## Description

Adds the following new boolean input variables for enabling dropping invalid HTTP header fields on the Braintrust API and AI Gateway Application Load Balancers (ALBs):

- `braintrust_api_alb_drop_invalid_header_fields`
- `ai_gateway_alb_drop_invalid_header_fields`

Both variables default to `false`, which matches the existing Terraform AWS provider default behavior. Customers can enable this setting going forward by setting either of these inputs to `true`.

Wiring after #290:
- API: root → `modules/api-ecs` (`alb_drop_invalid_header_fields`)
- Gateway: root → `modules/gateway-alb` (`alb_drop_invalid_header_fields`)

## Context
A customer security scan flagged that their Application Load Balancer was forwarding invalid HTTP header fields. AWS supports dropping these headers, but the module previously did not expose that setting.
The settings are separate so customers can enable filtering independently for each ALB.

## Testing
- Ran `terraform fmt -check -recursive`
- Generated a Terraform plan with `braintrust_api_alb_drop_invalid_header_fields = true`
- Confirmed the existing API ALB updates in place from `false` to `true,` with no resources added or destroyed
- The AI Gateway ALB was not present in the test deployment because `create_ai_gateway`  still defaults to `false`
- Successfully ingested traces
- Rebased onto `main` after #290 and rewired gateway toggle through `modules/gateway-alb`