### PR TITLE
Fetch Brainstore service token from Secrets Manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ module "brainstore" {
   use_redis_replication_group           = var.use_redis_replication_group
   redis_host                            = module.redis.redis_endpoint
   redis_port                            = module.redis.redis_port
-  service_token_secret_key              = module.services_common.function_tools_secret_key
+  service_token_secret_arn              = module.services_common.function_tools_secret_arn
   brainstore_s3_bucket_arn              = module.storage.brainstore_bucket_arn
   lambda_responses_s3_bucket_arn        = module.storage.lambda_responses_bucket_arn
   code_bundle_s3_bucket_arn             = module.storage.code_bundle_bucket_arn

--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -59,7 +59,7 @@ resource "aws_launch_template" "brainstore_fast_reader" {
     internal_observability_api_key  = var.internal_observability_api_key
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
-    service_token_secret_key        = var.service_token_secret_key
+    service_token_secret_arn        = var.service_token_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_fast_reader_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -59,7 +59,7 @@ resource "aws_launch_template" "brainstore_writer" {
     internal_observability_api_key  = var.internal_observability_api_key
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
-    service_token_secret_key        = var.service_token_secret_key
+    service_token_secret_arn        = var.service_token_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_writer_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -81,7 +81,7 @@ resource "aws_launch_template" "brainstore" {
     internal_observability_api_key  = var.internal_observability_api_key
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
-    service_token_secret_key        = var.service_token_secret_key
+    service_token_secret_arn        = var.service_token_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -127,6 +127,12 @@ DB_CREDS=$(aws secretsmanager get-secret-value --secret-id ${database_secret_arn
 DB_USERNAME=$(echo $DB_CREDS | jq -r .username)
 DB_PASSWORD=$(echo $DB_CREDS | jq -r .password)
 
+# Get the function tools secret used by Brainstore as SERVICE_TOKEN_SECRET_KEY from Secrets Manager
+if ! SERVICE_TOKEN_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id ${service_token_secret_arn} --query SecretString --output text); then
+  echo "Failed to retrieve SERVICE_TOKEN_SECRET_KEY from Secrets Manager. Exiting with failure."
+  exit 1
+fi
+
 cat <<EOF > /etc/brainstore.env
 # WARNING: Do NOT use quotes around values here. They get passed as literals by docker.
 BRAINSTORE_VERBOSE=1
@@ -142,7 +148,7 @@ BRAINSTORE_CODE_BUNDLE_URI=s3://${code_bundle_bucket_id}
 BRAINSTORE_LICENSE_KEY=${brainstore_license_key}
 BRAINSTORE_READER_ONLY_MODE=${is_dedicated_reader_node}
 BRAINSTORE_CONTROL_PLANE_TELEMETRY=${monitoring_telemetry}
-SERVICE_TOKEN_SECRET_KEY=${service_token_secret_key}
+SERVICE_TOKEN_SECRET_KEY=$SERVICE_TOKEN_SECRET_KEY
 NO_COLOR=1
 AWS_DEFAULT_REGION=${aws_region}
 AWS_REGION=${aws_region}

--- a/modules/brainstore-ec2/variables.tf
+++ b/modules/brainstore-ec2/variables.tf
@@ -166,10 +166,9 @@ variable "internal_observability_region" {
   default     = "us5"
 }
 
-variable "service_token_secret_key" {
+variable "service_token_secret_arn" {
   type        = string
-  description = "The secret encryption key for SERVICE_TOKEN_SECRET_KEY. Typically this re-uses the function tools secret key."
-  sensitive   = true
+  description = "The ARN of the Secrets Manager secret containing SERVICE_TOKEN_SECRET_KEY."
 }
 
 variable "ai_proxy_url_ssm_parameter" {

--- a/modules/services-common/iam-brainstore.tf
+++ b/modules/services-common/iam-brainstore.tf
@@ -121,9 +121,12 @@ resource "aws_iam_role_policy" "brainstore_secrets_access" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = "secretsmanager:GetSecretValue"
-        Resource = var.database_secret_arn
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = [
+          var.database_secret_arn,
+          aws_secretsmanager_secret.function_tools_secret.arn
+        ]
       }
     ]
   })

--- a/modules/services-common/outputs.tf
+++ b/modules/services-common/outputs.tf
@@ -29,7 +29,7 @@ output "api_security_group_id" {
 }
 
 output "function_tools_secret_key" {
-  description = "The function tools encryption key. This is used by brainstore as the SERVICE_TOKEN_SECRET_KEY."
+  description = "The function tools encryption key. This is used by Lambda services."
   value       = aws_secretsmanager_secret_version.function_tools_secret.secret_string
   sensitive   = true
 }
@@ -53,4 +53,3 @@ output "quarantine_lambda_security_group_id" {
   description = "The ID of the security group for quarantine Lambda functions"
   value       = one(aws_security_group.quarantine_lambda[*].id)
 }
-


### PR DESCRIPTION
## Description 
Pass the function tools secret ARN to the Brainstore EC2 module instead of passing its plaintext value.

Brainstore reader/read-writer, writer, and fast-reader instances now retrieve `SERVICE_TOKEN_SECRET_KEY` from Secrets Manager during bootstrap (cloud-init), following the existing database-secret pattern. The Brainstore IAM role is granted `secretsmanager:GetSecretValue` access to the function tools secret.

Users do not need to provide any new inputs or change their configuration. Applying this change creates new Brainstore launch-template versions and triggers rolling instance refreshes for the corresponding Auto Scaling Groups.


## Context 
The service token was previously rendered directly into Brainstore EC2 launch-template user data. EC2 user data is base64-encoded rather than encrypted and can be retrieved through EC2 APIs by principals with the relevant permissions.

This change keeps the secret value out of launch-template user data by passing only its Secrets Manager ARN through Terraform. The instance retrieves the value at boot using its IAM role.


## Testing 
- Successfully deployed update via Terraform
- Confirmed cloud-init completed successfully and populated `SERVICE_TOKEN_SECRET_KEY` in the correct place
- Confirmed traces are being ingested after the change