### PR TITLE
Compress Brainstore EC2 user data with gzip

### DIFF
--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -35,7 +35,7 @@ resource "aws_launch_template" "brainstore_fast_reader" {
     enabled = true
   }
 
-  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
+  user_data = base64gzip(templatefile("${path.module}/templates/user_data.sh.tpl", {
     aws_region                      = data.aws_region.current.region
     deployment_name                 = var.deployment_name
     database_secret_arn             = var.database_secret_arn

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -35,7 +35,7 @@ resource "aws_launch_template" "brainstore_writer" {
     enabled = true
   }
 
-  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
+  user_data = base64gzip(templatefile("${path.module}/templates/user_data.sh.tpl", {
     aws_region                      = data.aws_region.current.region
     deployment_name                 = var.deployment_name
     database_secret_arn             = var.database_secret_arn

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -56,7 +56,7 @@ resource "aws_launch_template" "brainstore" {
     enabled = true
   }
 
-  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
+  user_data = base64gzip(templatefile("${path.module}/templates/user_data.sh.tpl", {
     aws_region                  = data.aws_region.current.region
     deployment_name             = var.deployment_name
     database_secret_arn         = var.database_secret_arn


### PR DESCRIPTION
## Description

Replace `base64encode()` with `base64gzip()` for the Brainstore reader, writer, and fast-reader EC2 launch templates.

Ubuntu cloud-init automatically decompresses gzip user data before execution, so existing behavior and `brainstore_custom_post_install_script` usage remain unchanged. Customers do not need to update their configuration.

## Context

AWS limits EC2 user data to 16 KiB after base64 decoding. The standard rendered Brainstore user-data script is approximately 9.7 KB before adding a custom post-install script. A sufficiently large custom script can therefore cause launch-template creation to fail with:

```text
InvalidUserData.Malformed: User data is limited to 16384 bytes.
```

Without a custom post-install script, gzip reduces the rendered payload from approximately 9.7 KB to 3.9 KB—a 59% reduction that leaves substantially more room for customer configuration.

## Testing

Tested with a valid 21,421-byte custom post-install script.

Before this change, the complete 31,132-byte user-data payload reproduced the AWS 16 KiB error for both the Brainstore reader and writer launch templates.

After this change:

| Launch template | Uncompressed | Compressed |
| --- | ---: | ---: |
| Reader | 31,132 bytes | 5,130 bytes |
| Writer | 31,132 bytes | 5,128 bytes |

The launch-template update completed successfully with compression enabled.

Also:

- Confirmed Terraform formatting and validation is clean
- Deployed this update successfully via Terraform
- Verified user_data (cloud-init) finished successfully
- Verified traces being ingested successfully