### PR TITLE
Mark Database Password Output as sensitive

### DIFF
--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -26,6 +26,7 @@ output "postgres_database_username" {
 output "postgres_database_password" {
   value       = local.postgres_password
   description = "The password for the main Postgres database"
+  sensitive   = true
 }
 
 output "postgres_database_secret_arn" {


### PR DESCRIPTION
## Description 
Mark the output of postgres_database_password as sensitive.

## Context 
The customer requested that in their security review with following justification:
CI/CD pipeline logs, terraform state show, and any developer running terraform output will see the plaintext database password. In a PHI-regulated environment, this is credential exposure in audit logs.

## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
