### PR TITLE
[INF-178 follow-up] Plan-mode terraform test for unset license key

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Validate module and example code with OpenTofu
         run: mise run validate-tofu
+
+      - name: Run terraform test
+        run: mise run test
+
+      - name: Run OpenTofu test
+        run: mise run test-tofu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ Tool versions are managed via `mise.toml`:
 mise install        # Install terraform, tflint, uv, pre-commit
 mise run setup      # Install pre-commit hooks, init tflint
 mise run lint       # terraform fmt + tflint
-mise run validate   # terraform init + validate (module + production example)
+mise run validate   # terraform init + validate (module + examples)
+mise run test       # terraform test (plan-mode; catches bugs validate cannot)
 ```
 
-Pre-commit hooks and `tflint` run automatically on commit. Run `mise run lint` to check before committing.
+Pre-commit hooks and `tflint` run automatically on commit. Run `mise run lint` to check before committing. Note that `validate` treats input variables as unknown and will not catch plan-time expression bugs (e.g. `coalesce(null, "")`); use `mise run test` for that class of coverage.

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -36,8 +36,8 @@ module "braintrust-data-plane" {
   # null; only needed if you also enable create_ai_gateway (gateway telemetry).
   # CI runs `validate` on this example with the key unset (null default),
   # exercising null-default wiring for syntax/type/reference errors. Note:
-  # `validate` does NOT catch eval-time errors (e.g. coalesce-on-null) — a
-  # `terraform test` (command=plan) guard for that is tracked separately.
+  # `validate` does NOT catch eval-time errors (e.g. coalesce-on-null) —
+  # that is covered by `mise run test` (terraform test, command=plan).
   brainstore_license_key = var.brainstore_license_key
 
   # Enable external EKS deployment mode

--- a/mise.toml
+++ b/mise.toml
@@ -42,8 +42,8 @@ terraform validate
 validate_example "examples/braintrust-data-plane" "production example"
 # External-EKS leaves brainstore_license_key unset (null default). `validate`
 # catches syntax/type/reference mistakes on that wiring; it does NOT evaluate
-# locals, so it cannot catch coalesce-on-null style bugs. Plan-mode coverage
-# for that is tracked in the follow-up terraform test PR.
+# locals, so it cannot catch coalesce-on-null. Plan-time null evaluation is
+# covered by `mise run test` (terraform test), not validate.
 validate_example "examples/braintrust-data-plane-external-eks-quarantine" "external-EKS example (license key unset)"
 """
 
@@ -79,7 +79,27 @@ tofu validate
 validate_example "examples/braintrust-data-plane" "production example"
 # External-EKS leaves brainstore_license_key unset (null default). `validate`
 # catches syntax/type/reference mistakes on that wiring; it does NOT evaluate
-# locals, so it cannot catch coalesce-on-null style bugs. Plan-mode coverage
-# for that is tracked in the follow-up terraform test PR.
+# locals, so it cannot catch coalesce-on-null. Plan-time null evaluation is
+# covered by `mise run test-tofu` (tofu test), not validate.
 validate_example "examples/braintrust-data-plane-external-eks-quarantine" "external-EKS example (license key unset)"
+"""
+
+[tasks.test]
+description = "Run terraform test (plan-mode coverage that validate cannot provide)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Running terraform test"
+terraform init -upgrade
+terraform test
+"""
+
+[tasks.test-tofu]
+description = "Run OpenTofu test (plan-mode coverage that validate cannot provide)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Running OpenTofu test"
+tofu init -upgrade
+tofu test
 """

--- a/tests/license_key_null.tftest.hcl
+++ b/tests/license_key_null.tftest.hcl
@@ -1,0 +1,58 @@
+# Plan-mode coverage for brainstore_license_key = null.
+# terraform validate treats variables as unknown and will not catch coalesce(null, "")
+# style regressions; command = plan forces evaluation of local.brainstore_license_key_provided.
+#
+# Depends on the INF-178 null-safe ternary in main.tf.
+
+mock_provider "aws" {
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names    = ["us-east-1a", "us-east-1b", "us-east-1c"]
+      zone_ids = ["use1-az1", "use1-az2", "use1-az4"]
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDACKCEVSQ6C2EXAMPLE"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      name   = "us-east-1"
+      region = "us-east-1"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition  = "aws"
+      dns_suffix = "amazonaws.com"
+    }
+  }
+}
+
+mock_provider "http" {
+  mock_data "http" {
+    defaults = {
+      status_code   = 200
+      response_body = "test-version"
+    }
+  }
+}
+
+mock_provider "random" {}
+
+run "license_key_unset_plans" {
+  command = plan
+
+  variables {
+    braintrust_org_name              = "test-org"
+    brainstore_license_key           = null
+    use_deployment_mode_external_eks = true
+    enable_quarantine_vpc            = false
+  }
+}


### PR DESCRIPTION
## Summary
- Follow-up to #307: add real regression coverage for `brainstore_license_key = null`.
- `terraform validate` does **not** catch `coalesce(null, "")` (variables stay unknown); this uses `terraform test` with `command = plan` and mocked providers.
- Wires `mise run test` / `mise run test-tofu` into Terraform CI.

Stacked on #307 (`erikdw/ecs-ec2-secrets-from-sm`).

https://linear.app/braintrustdata/issue/INF-178

## Test plan
- [ ] `mise run test` passes on this branch
- [ ] With the old `coalesce(var.brainstore_license_key, "")` local restored locally, `mise run test` fails
- [ ] CI runs the new test / test-tofu jobs


Made with [Cursor](https://cursor.com)