### PR TITLE
Add Loop runtime module (ECS service + MicroVM sandbox)

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -40,6 +40,9 @@ module "braintrust-data-plane" {
   # It assumes an EKS deployment is being done outside of terraform.
   use_deployment_mode_external_eks = true
 
+  # Loop runtime is not supported with external EKS deployments.
+  enable_loop_runtime = false
+
   # With external EKS, there are additional configurations that must be applied after the EKS cluster has been created outside of this module.
   # Enable EKS Pod Identity for the Braintrust IAM roles
   #enable_eks_pod_identity = true

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -41,7 +41,8 @@ module "braintrust-data-plane" {
   use_deployment_mode_external_eks = true
 
   # Loop runtime is not supported with external EKS deployments.
-  enable_loop_runtime = false
+  enable_loop_runtime              = false
+  loop_runtime_sandbox_egress_mode = "internet"
 
   # With external EKS, there are additional configurations that must be applied after the EKS cluster has been created outside of this module.
   # Enable EKS Pod Identity for the Braintrust IAM roles

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -31,6 +31,9 @@ module "braintrust-data-plane" {
   # btql_audit_logs_strict_org_ids      = []
   # btql_audit_logs_best_effort_org_ids = []
 
+  # The optional Loop runtime is disabled by default.
+  enable_loop_runtime = false
+
   ### Tagging
   # Recommended: tag resources with your name/team for identification in shared accounts.
   # custom_tags = {

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -32,7 +32,8 @@ module "braintrust-data-plane" {
   # btql_audit_logs_best_effort_org_ids = []
 
   # The optional Loop runtime is disabled by default.
-  enable_loop_runtime = false
+  enable_loop_runtime              = false
+  loop_runtime_sandbox_egress_mode = "internet"
 
   ### Tagging
   # Recommended: tag resources with your name/team for identification in shared accounts.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -31,7 +31,8 @@ module "braintrust-data-plane" {
   # btql_audit_logs_best_effort_org_ids = []
 
   # The optional Loop runtime is disabled by default.
-  enable_loop_runtime = false
+  enable_loop_runtime              = false
+  loop_runtime_sandbox_egress_mode = "internet"
 
   ### Postgres configuration
   # Changing this will incur a short downtime.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -30,6 +30,9 @@ module "braintrust-data-plane" {
   # btql_audit_logs_strict_org_ids      = []
   # btql_audit_logs_best_effort_org_ids = []
 
+  # The optional Loop runtime is disabled by default.
+  enable_loop_runtime = false
+
   ### Postgres configuration
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -11,7 +11,8 @@ module "braintrust-data-plane" {
   # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
   # The optional Loop runtime is disabled by default.
-  enable_loop_runtime = false
+  enable_loop_runtime              = false
+  loop_runtime_sandbox_egress_mode = "internet"
 
   # Optional URL-security inputs are shown in examples/braintrust-data-plane/main.tf.
 }

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -10,6 +10,9 @@ module "braintrust-data-plane" {
   # use_global_ai_gateway_origin   = false
   # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
+  # The optional Loop runtime is disabled by default.
+  enable_loop_runtime = false
+
   # Optional URL-security inputs are shown in examples/braintrust-data-plane/main.tf.
 }
 

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -1,0 +1,130 @@
+locals {
+  # Loop runtime requires the ECS API data plane and Brainstore (it reads
+  # module.brainstore[0] for the reader URL / SG). It is fronted by the shared
+  # CloudFront distribution at /loop/runtime*.
+  create_loop_runtime = local.create_ecs_api && var.enable_brainstore && var.enable_loop_runtime
+
+  loop_runtime_version = (
+    var.loop_runtime_version_override != null
+    ? var.loop_runtime_version_override
+    : jsondecode(file("${path.module}/modules/loop-runtime-ecs/VERSIONS.json"))["loop-runtime"]
+  )
+
+  loop_runtime_brainstore_reader_url = local.create_loop_runtime ? format(
+    "http://%s:%s",
+    var.brainstore_fast_reader_instance_count > 0 ? module.brainstore[0].fast_reader_dns_name : module.brainstore[0].dns_name,
+    module.brainstore[0].port,
+  ) : ""
+}
+
+module "loop_runtime_alb" {
+  source = "./modules/loop-runtime-alb"
+  count  = local.create_loop_runtime ? 1 : 0
+
+  deployment_name                      = var.deployment_name
+  vpc_id                               = local.main_vpc_id
+  private_subnet_ids                   = local.main_vpc_private_subnet_ids
+  enable_cloudfront_vpc_origin_ingress = true
+  authorized_security_groups = {
+    "API"        = module.services_common.api_security_group_id
+    "Brainstore" = module.services_common.brainstore_instance_security_group_id
+  }
+  alb_deregistration_delay = var.loop_runtime_alb_deregistration_delay
+  custom_tags              = local.all_custom_tags
+}
+
+module "loop_runtime_sandbox_aws_microvm" {
+  source = "./modules/loop-runtime-sandbox-aws-microvm"
+  count  = local.create_loop_runtime ? 1 : 0
+
+  deployment_name          = var.deployment_name
+  permissions_boundary_arn = var.permissions_boundary_arn
+  microvm_version_tag      = local.loop_runtime_version
+
+  microvm_minimum_memory_mib            = var.loop_runtime_microvm_minimum_memory_mib
+  microvm_max_idle_duration_seconds     = var.loop_runtime_microvm_max_idle_duration_seconds
+  microvm_suspended_duration_seconds    = var.loop_runtime_microvm_suspended_duration_seconds
+  microvm_maximum_duration_seconds      = var.loop_runtime_microvm_maximum_duration_seconds
+  microvm_auth_token_expiration_minutes = var.loop_runtime_microvm_auth_token_expiration_minutes
+  enable_microvm_runtime_logs           = var.enable_loop_runtime_microvm_runtime_logs
+
+  kms_key_arn = local.kms_key_arn
+  custom_tags = local.all_custom_tags
+}
+
+module "loop_runtime_ecs" {
+  source = "./modules/loop-runtime-ecs"
+  count  = local.create_loop_runtime ? 1 : 0
+
+  deployment_name    = var.deployment_name
+  kms_key_arn        = local.kms_key_arn
+  vpc_id             = local.main_vpc_id
+  private_subnet_ids = local.main_vpc_private_subnet_ids
+  ecs_cluster_arn    = module.ecs[0].cluster_arn
+  ecs_cluster_name   = module.ecs[0].cluster_name
+
+  container_image = format("public.ecr.aws/braintrust/loop-runtime:%s", local.loop_runtime_version)
+
+  cpu                       = var.loop_runtime_task_cpu
+  memory                    = var.loop_runtime_task_memory
+  ephemeral_storage_gib     = var.loop_runtime_ephemeral_storage_gib
+  min_capacity              = var.loop_runtime_min_capacity
+  max_capacity              = var.loop_runtime_max_capacity
+  target_cpu_utilization    = var.loop_runtime_target_cpu_utilization
+  target_memory_utilization = var.loop_runtime_target_memory_utilization
+  log_retention_days        = var.loop_runtime_log_retention_days
+  permissions_boundary_arn  = var.permissions_boundary_arn
+  enable_execute_command    = var.loop_runtime_enable_execute_command
+
+  # ALB wiring
+  target_group_arn               = module.loop_runtime_alb[0].loop_runtime_target_group_arn
+  alb_security_group_id          = module.loop_runtime_alb[0].loop_runtime_alb_security_group_id
+  loop_runtime_http_listener_arn = module.loop_runtime_alb[0].loop_runtime_http_listener_arn
+
+  # Sandbox seam
+  sandbox_env_vars                 = module.loop_runtime_sandbox_aws_microvm[0].sandbox_env_vars
+  additional_task_role_policy_json = module.loop_runtime_sandbox_aws_microvm[0].task_role_policy_json
+
+  # Data-plane connectivity
+  database_url_secret_arn   = module.database.postgres_database_url_secret_arn
+  redis_url_secret_arn      = module.redis.redis_url_secret_arn
+  function_tools_secret_arn = module.services_common.function_tools_secret_arn
+
+  brainstore_s3_bucket_name = module.storage.brainstore_bucket_id
+  brainstore_s3_bucket_arn  = module.storage.brainstore_bucket_arn
+  code_bundle_bucket        = module.storage.code_bundle_bucket_id
+  code_bundle_bucket_arn    = module.storage.code_bundle_bucket_arn
+
+  brainstore_reader_url = local.loop_runtime_brainstore_reader_url
+  ai_proxy_url          = local.api_ecs_ai_proxy_url
+  braintrust_api_url    = module.ingress[0].api_url
+
+  # Shared Brainstore WAL format + lock prefix — must match the API/Brainstore writers.
+  brainstore_locks_s3_path       = var.brainstore_locks_s3_path
+  brainstore_wal_footer_version  = var.brainstore_wal_footer_version
+  skip_pg_for_brainstore_objects = var.skip_pg_for_brainstore_objects
+
+  brainstore_license_key = var.brainstore_license_key
+  monitoring_telemetry   = var.monitoring_telemetry
+
+  # SG ingress targets so tasks can reach Postgres / Redis / Brainstore
+  database_security_group_id   = module.database.rds_security_group_id
+  database_port                = module.database.postgres_database_port
+  redis_security_group_id      = module.redis.redis_security_group_id
+  redis_port                   = module.redis.redis_port
+  brainstore_security_group_id = module.brainstore[0].brainstore_elb_security_group_id
+  brainstore_port              = module.brainstore[0].port
+
+  # Runtime config
+  org_name        = var.loop_runtime_org_name
+  allowed_org_ids = var.allowed_org_ids
+  extra_env_vars  = var.loop_runtime_extra_env_vars
+
+  # Observability
+  internal_observability_enabled            = local.create_internal_observability_secret
+  internal_observability_api_key_secret_arn = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""
+  internal_observability_env_name           = var.internal_observability_env_name
+  internal_observability_region             = var.internal_observability_region
+
+  custom_tags = local.all_custom_tags
+}

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -26,8 +26,7 @@ module "loop_runtime_alb" {
   private_subnet_ids                   = local.main_vpc_private_subnet_ids
   enable_cloudfront_vpc_origin_ingress = true
   authorized_security_groups = {
-    "API"        = module.services_common.api_security_group_id
-    "Brainstore" = module.services_common.brainstore_instance_security_group_id
+    "API" = module.services_common.api_security_group_id
   }
   alb_deregistration_delay = var.loop_runtime_alb_deregistration_delay
   custom_tags              = local.all_custom_tags

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -46,6 +46,7 @@ module "loop_runtime_sandbox_aws_microvm" {
   microvm_maximum_duration_seconds      = var.loop_runtime_microvm_maximum_duration_seconds
   microvm_auth_token_expiration_minutes = var.loop_runtime_microvm_auth_token_expiration_minutes
   enable_microvm_runtime_logs           = var.enable_loop_runtime_microvm_runtime_logs
+  sandbox_egress_mode                   = var.loop_runtime_sandbox_egress_mode
 
   kms_key_arn = local.kms_key_arn
   custom_tags = local.all_custom_tags

--- a/main.tf
+++ b/main.tf
@@ -307,7 +307,7 @@ module "services" {
 
 module "ecs" {
   source = "./modules/ecs"
-  count  = local.create_ai_gateway || local.create_ecs_api ? 1 : 0
+  count  = local.create_ai_gateway || local.create_ecs_api || local.create_loop_runtime ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -518,7 +518,13 @@ module "ingress" {
   api_ecs_alb_arn                    = module.api_ecs[0].alb_arn
   api_ecs_alb_domain                 = module.api_ecs[0].alb_domain
   api_ecs_alb_https_enabled          = module.api_ecs[0].alb_https_enabled
-  custom_tags                        = local.all_custom_tags
+
+  enable_loop_runtime                     = local.create_loop_runtime
+  loop_runtime_alb_arn                    = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_alb_arn : null
+  loop_runtime_alb_dns_name               = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_alb_dns_name : null
+  loop_runtime_cloudfront_ingress_rule_id = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_cloudfront_vpc_origin_ingress_rule_id : null
+
+  custom_tags = local.all_custom_tags
 }
 
 module "services_common" {

--- a/main.tf
+++ b/main.tf
@@ -77,10 +77,14 @@ locals {
   gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.gateway_alb[0].gateway_url
   } : {}
-  # Only wire GATEWAY_URL into Lambdas that call the gateway. Do not merge into
-  # MigrateDatabaseFunction or crons — that changes their env hash and re-runs
-  # migrations or replaces unrelated functions on existing deployments.
-  gateway_lambda_env_services = toset(["APIHandler", "AIProxy"])
+  # Only wire per-deployment backend URLs into Lambdas that call them. Do not
+  # merge into MigrateDatabaseFunction or crons — that changes their env hash
+  # and re-runs migrations or replaces unrelated functions on existing
+  # deployments.
+  lambda_env_services = toset(["APIHandler", "AIProxy"])
+  loop_runtime_lambda_env_vars = local.create_loop_runtime ? {
+    LOOP_RUNTIME_URL = module.loop_runtime_alb[0].loop_runtime_url
+  } : {}
   main_vpc_private_subnet_ids = [
     local.main_vpc_private_subnet_1_id,
     local.main_vpc_private_subnet_2_id,
@@ -89,9 +93,10 @@ locals {
   enable_private_ai_gateway_origin = local.create_ai_gateway && var.use_private_ai_gateway_origin
   service_extra_env_vars = merge(
     var.service_extra_env_vars,
-    { for svc in local.gateway_lambda_env_services : svc => merge(
+    { for svc in local.lambda_env_services : svc => merge(
       lookup(var.service_extra_env_vars, svc, {}),
       local.gateway_env_vars,
+      local.loop_runtime_lambda_env_vars,
     ) }
   )
 }

--- a/modules/ingress/cloudfront-loop-runtime-vpc-origin.tf
+++ b/modules/ingress/cloudfront-loop-runtime-vpc-origin.tf
@@ -1,0 +1,20 @@
+resource "aws_cloudfront_vpc_origin" "loop_runtime" {
+  count = var.enable_loop_runtime ? 1 : 0
+
+  vpc_origin_endpoint_config {
+    name                   = "${var.deployment_name}-loop-runtime"
+    arn                    = var.loop_runtime_alb_arn
+    http_port              = 4001
+    https_port             = 443
+    origin_protocol_policy = "http-only"
+
+    origin_ssl_protocols {
+      items    = ["TLSv1.2"]
+      quantity = 1
+    }
+  }
+
+  tags = merge({
+    CloudFrontVpcOriginIngressRuleId = var.loop_runtime_cloudfront_ingress_rule_id
+  }, local.common_tags)
+}

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -8,6 +8,7 @@ locals {
   cloudfront_CloudflareProxy           = "CloudflareProxy"
   cloudfront_GatewayOrigin             = "GatewayOrigin"
   cloudfront_APIGatewayOrigin          = "APIGatewayOrigin"
+  cloudfront_LoopRuntimeOrigin         = "LoopRuntimeOrigin"
   cloudfront_ProxyOrigin               = var.use_global_ai_proxy ? local.cloudfront_CloudflareProxy : local.cloudfront_AIProxyOrigin
 
   cloudfront_api_origin_id = var.enable_ecs_api ? local.cloudfront_ApiEcsOrigin : local.cloudfront_APIGatewayOrigin
@@ -36,12 +37,13 @@ locals {
     : local.cloudfront_AllViewerExceptHostHeader
   )
   cloudfront_origin_request_policy_for_origin = {
-    (local.cloudfront_ApiEcsOrigin)          = local.cloudfront_ecs_origin_request_policy_id
-    (local.cloudfront_APIGatewayOrigin)      = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_AIProxyOrigin)         = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_CloudflareProxy)       = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_GatewayOrigin)         = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_PrivateGatewayOrigin)  = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_ApiEcsOrigin)         = local.cloudfront_ecs_origin_request_policy_id
+    (local.cloudfront_APIGatewayOrigin)     = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_AIProxyOrigin)        = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_CloudflareProxy)      = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_GatewayOrigin)        = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_PrivateGatewayOrigin) = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_LoopRuntimeOrigin)    = local.cloudfront_AllViewerExceptHostHeader
   }
 }
 
@@ -198,6 +200,20 @@ resource "aws_cloudfront_distribution" "dataplane" {
     }
   }
 
+  dynamic "origin" {
+    for_each = var.enable_loop_runtime ? [1] : []
+    content {
+      domain_name = var.loop_runtime_alb_dns_name
+      origin_id   = local.cloudfront_LoopRuntimeOrigin
+
+      vpc_origin_config {
+        vpc_origin_id            = aws_cloudfront_vpc_origin.loop_runtime[0].id
+        origin_read_timeout      = var.cloudfront_origin_read_timeout
+        origin_keepalive_timeout = 60
+      }
+    }
+  }
+
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD", "OPTIONS"]
@@ -237,6 +253,20 @@ resource "aws_cloudfront_distribution" "dataplane" {
 
       cache_policy_id          = local.cloudfront_CachingDisabled
       origin_request_policy_id = local.cloudfront_origin_request_policy_for_origin[local.cloudfront_function_origin_id]
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = var.enable_loop_runtime ? toset(["/loop/runtime", "/loop/runtime/*"]) : toset([])
+    content {
+      path_pattern           = ordered_cache_behavior.value
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD", "OPTIONS"]
+      target_origin_id       = local.cloudfront_LoopRuntimeOrigin
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = local.cloudfront_CachingDisabled
+      origin_request_policy_id = local.cloudfront_origin_request_policy_for_origin[local.cloudfront_LoopRuntimeOrigin]
     }
   }
 

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -57,6 +57,30 @@ variable "gateway_cloudfront_ingress_rule_id" {
   default     = null
 }
 
+variable "enable_loop_runtime" {
+  description = "Add a LoopRuntimeOrigin VPC origin and route /loop/runtime[/*] to the Loop runtime ALB."
+  type        = bool
+  default     = false
+}
+
+variable "loop_runtime_alb_arn" {
+  description = "ARN of the internal Loop runtime ALB for CloudFront VPC origin routing"
+  type        = string
+  default     = null
+}
+
+variable "loop_runtime_alb_dns_name" {
+  description = "DNS name of the internal Loop runtime ALB for CloudFront VPC origin routing"
+  type        = string
+  default     = null
+}
+
+variable "loop_runtime_cloudfront_ingress_rule_id" {
+  description = "ID of the Loop runtime ALB ingress rule for CloudFront VPC origins"
+  type        = string
+  default     = null
+}
+
 variable "global_ai_gateway_origin_domain" {
   description = "Gateway origin domain to use when use_global_ai_gateway_origin is enabled"
   type        = string

--- a/modules/loop-runtime-alb/cloudfront-vpc-origin-ingress.tf
+++ b/modules/loop-runtime-alb/cloudfront-vpc-origin-ingress.tf
@@ -1,0 +1,20 @@
+data "aws_ec2_managed_prefix_list" "cloudfront_vpc_origin" {
+  count = var.enable_cloudfront_vpc_origin_ingress ? 1 : 0
+
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "loop_runtime_alb_from_cloudfront_vpc_origin" {
+  count = var.enable_cloudfront_vpc_origin_ingress ? 1 : 0
+
+  security_group_id = aws_security_group.loop_runtime_alb.id
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.cloudfront_vpc_origin[0].id
+  from_port         = local.loop_runtime_container_port
+  to_port           = local.loop_runtime_container_port
+  ip_protocol       = "tcp"
+  description       = "Allow HTTP from CloudFront VPC origins."
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-alb-cloudfront"
+  }, local.common_tags)
+}

--- a/modules/loop-runtime-alb/main.tf
+++ b/modules/loop-runtime-alb/main.tf
@@ -1,0 +1,88 @@
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+
+  loop_runtime_container_port = 4001
+}
+
+resource "aws_security_group" "loop_runtime_alb" {
+  name        = "${var.deployment_name}-loop-runtime-alb"
+  description = "Security group for private Loop runtime ALB"
+  vpc_id      = var.vpc_id
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-alb"
+  }, local.common_tags)
+}
+
+resource "aws_security_group_rule" "loop_runtime_alb_ingress_from_authorized_security_groups" {
+  for_each = var.authorized_security_groups
+
+  type                     = "ingress"
+  from_port                = local.loop_runtime_container_port
+  to_port                  = local.loop_runtime_container_port
+  protocol                 = "tcp"
+  source_security_group_id = each.value
+  description              = "Allow HTTP traffic from ${each.key}."
+  security_group_id        = aws_security_group.loop_runtime_alb.id
+}
+
+resource "aws_security_group_rule" "loop_runtime_alb_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all outbound traffic from Loop runtime ALB"
+  security_group_id = aws_security_group.loop_runtime_alb.id
+}
+
+resource "aws_lb" "loop_runtime" {
+  name               = "${var.deployment_name}-loop-runtime"
+  internal           = true
+  load_balancer_type = "application"
+  subnets            = var.private_subnet_ids
+  security_groups    = [aws_security_group.loop_runtime_alb.id]
+
+  client_keep_alive          = var.alb_client_keep_alive
+  idle_timeout               = var.alb_idle_timeout
+  drop_invalid_header_fields = var.alb_drop_invalid_header_fields
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime"
+  }, local.common_tags)
+}
+
+resource "aws_lb_target_group" "loop_runtime" {
+  name        = "${var.deployment_name}-loop-runtime"
+  port        = local.loop_runtime_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  deregistration_delay = var.alb_deregistration_delay
+
+  health_check {
+    path                = "/health/liveness"
+    matcher             = "200-399"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 10
+  }
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime"
+  }, local.common_tags)
+}
+
+resource "aws_lb_listener" "loop_runtime_http" {
+  load_balancer_arn = aws_lb.loop_runtime.arn
+  port              = local.loop_runtime_container_port
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.loop_runtime.arn
+  }
+}

--- a/modules/loop-runtime-alb/outputs.tf
+++ b/modules/loop-runtime-alb/outputs.tf
@@ -1,0 +1,34 @@
+output "loop_runtime_alb_dns_name" {
+  description = "Internal DNS name of the private Loop runtime ALB"
+  value       = aws_lb.loop_runtime.dns_name
+}
+
+output "loop_runtime_alb_arn" {
+  description = "ARN of the private Loop runtime ALB"
+  value       = aws_lb.loop_runtime.arn
+}
+
+output "loop_runtime_alb_security_group_id" {
+  description = "Security group ID attached to the private Loop runtime ALB"
+  value       = aws_security_group.loop_runtime_alb.id
+}
+
+output "loop_runtime_target_group_arn" {
+  description = "ARN of the Loop runtime ALB target group"
+  value       = aws_lb_target_group.loop_runtime.arn
+}
+
+output "loop_runtime_http_listener_arn" {
+  description = "ARN of the Loop runtime ALB HTTP listener"
+  value       = aws_lb_listener.loop_runtime_http.arn
+}
+
+output "loop_runtime_url" {
+  description = "Internal in-VPC URL of the Loop runtime ALB (informational; external traffic reaches it directly via the CloudFront /loop/runtime* behavior, not through the API)."
+  value       = "http://${aws_lb.loop_runtime.dns_name}:${local.loop_runtime_container_port}"
+}
+
+output "loop_runtime_cloudfront_vpc_origin_ingress_rule_id" {
+  description = "Security group ingress rule allowing CloudFront VPC origins to reach the Loop runtime ALB."
+  value       = try(aws_vpc_security_group_ingress_rule.loop_runtime_alb_from_cloudfront_vpc_origin[0].id, null)
+}

--- a/modules/loop-runtime-alb/variables.tf
+++ b/modules/loop-runtime-alb/variables.tf
@@ -1,0 +1,76 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Will be included in resource names."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where the private Loop runtime ALB is deployed."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the Loop runtime internal ALB."
+
+  validation {
+    condition     = length(var.private_subnet_ids) >= 2 && length(distinct(var.private_subnet_ids)) == length(var.private_subnet_ids)
+    error_message = "private_subnet_ids must contain at least 2 unique subnet IDs."
+  }
+}
+
+variable "authorized_security_groups" {
+  type        = map(string)
+  description = "Security groups authorized to reach the Loop runtime ALB on port 4001 (e.g. API, Brainstore, custom callers)."
+  default     = {}
+}
+
+variable "enable_cloudfront_vpc_origin_ingress" {
+  type        = bool
+  description = "Allow inbound HTTP to the Loop runtime ALB from the CloudFront VPC origin managed prefix list."
+  default     = false
+}
+
+variable "alb_client_keep_alive" {
+  type        = number
+  description = "Client keep-alive duration in seconds for the Loop runtime ALB."
+  default     = 4000
+
+  validation {
+    condition     = var.alb_client_keep_alive >= 60 && var.alb_client_keep_alive <= 604800
+    error_message = "alb_client_keep_alive must be between 60 and 604800 seconds."
+  }
+}
+
+variable "alb_idle_timeout" {
+  type        = number
+  description = "Idle timeout in seconds for the Loop runtime ALB."
+  default     = 3600
+
+  validation {
+    condition     = var.alb_idle_timeout >= 1 && var.alb_idle_timeout <= 4000
+    error_message = "alb_idle_timeout must be between 1 and 4000 seconds."
+  }
+}
+
+variable "alb_deregistration_delay" {
+  type        = number
+  description = "Seconds for the Loop runtime target group to wait before deregistering draining targets."
+  default     = 900
+
+  validation {
+    condition     = var.alb_deregistration_delay >= 0 && var.alb_deregistration_delay <= 3600
+    error_message = "alb_deregistration_delay must be between 0 and 3600 seconds."
+  }
+}
+
+variable "alb_drop_invalid_header_fields" {
+  type        = bool
+  description = "Whether the Loop runtime ALB removes HTTP headers with invalid header names before routing requests."
+  default     = false
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Tags to apply to created resources."
+  default     = {}
+}

--- a/modules/loop-runtime-alb/versions.tf
+++ b/modules/loop-runtime-alb/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.23.0, < 7.0.0"
+    }
+  }
+}

--- a/modules/loop-runtime-ecs/VERSIONS.json
+++ b/modules/loop-runtime-ecs/VERSIONS.json
@@ -1,0 +1,3 @@
+{
+    "loop-runtime": "latest"
+}

--- a/modules/loop-runtime-ecs/VERSIONS.json
+++ b/modules/loop-runtime-ecs/VERSIONS.json
@@ -1,3 +1,3 @@
 {
-    "loop-runtime": "latest"
+    "loop-runtime": "latest-2.x"
 }

--- a/modules/loop-runtime-ecs/autoscaling.tf
+++ b/modules/loop-runtime-ecs/autoscaling.tf
@@ -1,0 +1,43 @@
+resource "aws_appautoscaling_target" "loop_runtime" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${var.ecs_cluster_name}/${aws_ecs_service.loop_runtime.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "loop_runtime_cpu_target" {
+  name               = "${var.deployment_name}-loop-runtime-cpu-target"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.loop_runtime.resource_id
+  scalable_dimension = aws_appautoscaling_target.loop_runtime.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.loop_runtime.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value       = var.target_cpu_utilization
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_policy" "loop_runtime_memory_target" {
+  name               = "${var.deployment_name}-loop-runtime-memory-target"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.loop_runtime.resource_id
+  scalable_dimension = aws_appautoscaling_target.loop_runtime.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.loop_runtime.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+
+    target_value       = var.target_memory_utilization
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/modules/loop-runtime-ecs/main.tf
+++ b/modules/loop-runtime-ecs/main.tf
@@ -1,0 +1,622 @@
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+
+  container_name           = "loop-runtime"
+  container_port           = 4001
+  observability_enabled    = var.internal_observability_enabled
+  loop_runtime_version_tag = element(reverse(split(":", var.container_image)), 0)
+  brainstore_s3_bucket     = var.brainstore_s3_bucket_name
+  use_object_store_locks   = var.brainstore_object_store_locks
+
+  # Normalize like modules/brainstore-ec2 so Loop uses the deployment's shared
+  # lock prefix (the writers must acquire locks from the same S3 namespace).
+  locks_s3_path = trimprefix(var.brainstore_locks_s3_path, "/")
+
+  # Match the API/Brainstore writers' WAL format so the shared realtime WAL stays
+  # readable by every writer (same derivation as modules/api-ecs & modules/services).
+  brainstore_wal_env = merge(
+    var.brainstore_wal_footer_version != "" ? {
+      BRAINSTORE_WAL_FOOTER_VERSION = var.brainstore_wal_footer_version
+    } : {},
+    var.skip_pg_for_brainstore_objects != "" ? {
+      SKIP_PG_FOR_BRAINSTORE_OBJECTS = var.skip_pg_for_brainstore_objects
+    } : {},
+    (var.brainstore_wal_footer_version != "" || var.skip_pg_for_brainstore_objects != "") ? {
+      BRAINSTORE_WAL_USE_EFFICIENT_FORMAT = "true"
+    } : {},
+  )
+
+  # Plain (non-secret) environment. Secrets (DB/Redis/service-token URLs) are
+  # injected via the container `secrets` block below. Sandbox-specific env comes
+  # from var.sandbox_env_vars so this module stays sandbox-agnostic.
+  core_env = merge(
+    {
+      BRAINTRUST_LEGACY_IDS              = "true"
+      LOOP_RUNTIME_HOST                  = "0.0.0.0"
+      LOOP_RUNTIME_PORT                  = tostring(local.container_port)
+      LOOP_RUNTIME_LIFECYCLE_LOG         = var.loop_runtime_lifecycle_log
+      LOOP_RUNTIME_REDIS_NAMESPACE       = "loop-runtime:${var.deployment_name}"
+      LOOP_RUNTIME_STATE_DIR             = "/mnt/tmp/loop-runtime"
+      ORG_NAME                           = var.org_name
+      BRAINTRUST_API_URL                 = var.braintrust_api_url
+      LOOP_RUNTIME_AI_PROXY_URL          = var.ai_proxy_url
+      LOOP_RUNTIME_BRAINSTORE_READER_URL = var.brainstore_reader_url
+      BRAINSTORE_VERBOSE                 = "1"
+      BRAINSTORE_INDEX_URI               = "s3://${local.brainstore_s3_bucket}/brainstore/index"
+      BRAINSTORE_REALTIME_WAL_URI        = "s3://${local.brainstore_s3_bucket}/brainstore/wal"
+      BRAINSTORE_CODE_BUNDLE_URI         = "s3://${var.code_bundle_bucket}"
+      BRAINSTORE_CACHE_DIR               = "/mnt/tmp/brainstore"
+      BRAINSTORE_CONTROL_PLANE_TELEMETRY = var.monitoring_telemetry
+      BRAINSTORE_DISABLE_STATUS_UPDATES  = var.brainstore_disable_status_updates
+      NO_COLOR                           = "1"
+      AWS_DEFAULT_REGION                 = data.aws_region.current.region
+      AWS_REGION                         = data.aws_region.current.region
+    },
+    local.use_object_store_locks ? {
+      BRAINSTORE_LOCKS_URI = "s3://${local.brainstore_s3_bucket}/${local.locks_s3_path}"
+    } : {},
+    local.brainstore_wal_env,
+    trimspace(var.allowed_org_ids) != "" ? {
+      ALLOWED_ORG_IDS = var.allowed_org_ids
+    } : {},
+    var.brainstore_license_key == null ? {} : {
+      BRAINSTORE_LICENSE_KEY = var.brainstore_license_key
+    },
+    local.observability_enabled ? {
+      BRAINSTORE_STATSD_ENDPOINT                   = "127.0.0.1:8125"
+      BRAINSTORE_OTLP_HTTP_ENDPOINT                = "http://localhost:4318"
+      BRAINSTORE_OTLP_TELEMETRY                    = "metrics,traces"
+      BRAINSTORE_ENABLE_OTEL_ENV_RESOURCE_DETECTOR = "true"
+      OTEL_RESOURCE_ATTRIBUTES                     = "deployment.environment.name=${var.internal_observability_env_name},env=${var.internal_observability_env_name}"
+    } : {},
+  )
+
+  merged_env_vars = merge(local.core_env, var.sandbox_env_vars, var.extra_env_vars)
+
+  container_secrets = concat(
+    [
+      { name = "BRAINSTORE_METADATA_URI", valueFrom = var.database_url_secret_arn },
+      { name = "BRAINSTORE_WAL_URI", valueFrom = var.database_url_secret_arn },
+      { name = "BRAINSTORE_XACT_MANAGER_URI", valueFrom = var.redis_url_secret_arn },
+      { name = "BRAINSTORE_REDIS_URI", valueFrom = var.redis_url_secret_arn },
+      { name = "SERVICE_TOKEN_SECRET_KEY", valueFrom = var.function_tools_secret_arn },
+    ],
+    local.use_object_store_locks ? [] : [
+      { name = "BRAINSTORE_LOCKS_URI", valueFrom = var.redis_url_secret_arn },
+    ],
+  )
+
+  app_log_configuration = jsondecode(local.observability_enabled ? jsonencode({
+    logDriver = "awsfirelens"
+    options = {
+      Name           = "datadog"
+      Host           = "http-intake.logs.${var.internal_observability_region}.datadoghq.com"
+      TLS            = "on"
+      provider       = "ecs"
+      dd_service     = "loop-runtime"
+      dd_source      = "rust"
+      dd_message_key = "message"
+      dd_tags        = "env:${var.internal_observability_env_name}"
+      compress       = "gzip"
+    }
+    secretOptions = [
+      { name = "apikey", valueFrom = var.internal_observability_api_key_secret_arn }
+    ]
+    }) : jsonencode({
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.service.name
+      awslogs-region        = data.aws_region.current.region
+      awslogs-stream-prefix = "loop-runtime"
+    }
+  }))
+
+  loop_runtime_container_definition = {
+    name      = local.container_name
+    image     = var.container_image
+    essential = true
+    user      = "1000:1000"
+    linuxParameters = {
+      initProcessEnabled = true
+      capabilities = {
+        drop = ["ALL"]
+      }
+    }
+    portMappings = [
+      {
+        containerPort = local.container_port
+        hostPort      = local.container_port
+        protocol      = "tcp"
+      }
+    ]
+    environment = [
+      for key in sort(keys(local.merged_env_vars)) : {
+        name  = key
+        value = local.merged_env_vars[key]
+      }
+    ]
+    secrets = local.container_secrets
+    dependsOn = [
+      for dep in [
+        { containerName = "log-router", condition = "START" },
+        { containerName = "datadog-agent", condition = "START" },
+      ] : dep if local.observability_enabled
+    ]
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:${local.container_port}/health/liveness || exit 1"]
+      interval    = 30
+      retries     = 3
+      startPeriod = 10
+      timeout     = 5
+    }
+    logConfiguration = local.app_log_configuration
+    mountPoints      = []
+    systemControls   = []
+    volumesFrom      = []
+  }
+
+  observability_sidecars = [
+    for sidecar in [
+      {
+        name           = "log-router"
+        essential      = true
+        image          = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+        user           = "0"
+        environment    = []
+        mountPoints    = []
+        portMappings   = []
+        systemControls = []
+        volumesFrom    = []
+        firelensConfiguration = {
+          type = "fluentbit"
+          options = {
+            enable-ecs-log-metadata = "true"
+            config-file-type        = "file"
+            config-file-value       = "/fluent-bit/configs/parse-json.conf"
+          }
+        }
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.service.name
+            awslogs-region        = data.aws_region.current.region
+            awslogs-stream-prefix = "log-router"
+          }
+        }
+        memoryReservation = 50
+      },
+      {
+        name           = "datadog-agent"
+        essential      = true
+        image          = "public.ecr.aws/datadog/agent:7"
+        mountPoints    = []
+        portMappings   = []
+        systemControls = []
+        volumesFrom    = []
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.service.name
+            awslogs-region        = data.aws_region.current.region
+            awslogs-stream-prefix = "datadog-agent"
+          }
+        }
+        environment = [
+          { name = "ECS_FARGATE", value = "true" },
+          { name = "DD_SITE", value = "${var.internal_observability_region}.datadoghq.com" },
+          { name = "DD_ENV", value = var.internal_observability_env_name },
+          { name = "DD_SERVICE", value = "loop-runtime" },
+          { name = "DD_VERSION", value = local.loop_runtime_version_tag },
+          { name = "DD_PROCESS_AGENT_ENABLED", value = "true" },
+          { name = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value = "0.0.0.0:4318" },
+        ]
+        secrets = [
+          { name = "DD_API_KEY", valueFrom = var.internal_observability_api_key_secret_arn }
+        ]
+        healthCheck = {
+          command     = ["CMD-SHELL", "agent health"]
+          interval    = 30
+          retries     = 3
+          startPeriod = 15
+          timeout     = 5
+        }
+      }
+    ] : sidecar if local.observability_enabled
+  ]
+
+  valid_fargate_memory_by_cpu = {
+    "256"   = [512, 1024, 2048]
+    "512"   = [1024, 2048, 3072, 4096]
+    "1024"  = [2048, 3072, 4096, 5120, 6144, 7168, 8192]
+    "2048"  = [for value in range(4096, 16385, 1024) : value]
+    "4096"  = [for value in range(8192, 30721, 1024) : value]
+    "8192"  = [for value in range(16384, 61441, 4096) : value]
+    "16384" = [for value in range(32768, 122881, 8192) : value]
+  }
+}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "ecs_task_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "service" {
+  name              = "/ecs/${var.deployment_name}/loop-runtime"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-logs"
+  }, local.common_tags)
+}
+
+resource "aws_security_group" "task" {
+  name        = "${var.deployment_name}-loop-runtime-task"
+  description = "Security group for Loop runtime ECS tasks"
+  vpc_id      = var.vpc_id
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-task"
+  }, local.common_tags)
+}
+
+resource "aws_security_group_rule" "task_ingress_from_alb" {
+  type                     = "ingress"
+  from_port                = local.container_port
+  to_port                  = local.container_port
+  protocol                 = "tcp"
+  source_security_group_id = var.alb_security_group_id
+  description              = "Allow inbound traffic from Loop runtime ALB to tasks"
+  security_group_id        = aws_security_group.task.id
+}
+
+resource "aws_security_group_rule" "task_egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all outbound traffic from Loop runtime ECS tasks"
+  security_group_id = aws_security_group.task.id
+}
+
+# Allow the Loop runtime tasks to reach Postgres, Redis and Brainstore by adding
+# ingress rules on those services' security groups.
+resource "aws_vpc_security_group_ingress_rule" "postgres_from_task" {
+  count = var.database_security_group_id == null ? 0 : 1
+
+  from_port                    = var.database_port
+  to_port                      = var.database_port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.task.id
+  description                  = "Allow inbound traffic from Loop runtime tasks."
+  security_group_id            = var.database_security_group_id
+  tags                         = local.common_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_from_task" {
+  count = var.redis_security_group_id == null ? 0 : 1
+
+  from_port                    = var.redis_port
+  to_port                      = var.redis_port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.task.id
+  description                  = "Allow inbound traffic from Loop runtime tasks."
+  security_group_id            = var.redis_security_group_id
+  tags                         = local.common_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "brainstore_from_task" {
+  count = var.brainstore_security_group_id == null ? 0 : 1
+
+  from_port                    = var.brainstore_port
+  to_port                      = var.brainstore_port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.task.id
+  description                  = "Allow inbound traffic from Loop runtime tasks."
+  security_group_id            = var.brainstore_security_group_id
+  tags                         = local.common_tags
+}
+
+# --- Task execution role (pulls secrets at container start) ---
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.deployment_name}-loop-runtime-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-task-exec"
+  }, local.common_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_default" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "task_execution_secrets" {
+  name = "${var.deployment_name}-loop-runtime-task-exec-secrets"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue"]
+        Resource = concat(
+          [
+            var.database_url_secret_arn,
+            var.function_tools_secret_arn,
+            var.redis_url_secret_arn,
+          ],
+          local.observability_enabled ? [var.internal_observability_api_key_secret_arn] : [],
+        )
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = var.kms_key_arn
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# --- Dedicated task role (no secretsmanager access: no secrets in sandbox) ---
+resource "aws_iam_role" "task" {
+  name                 = "${var.deployment_name}-loop-runtime-task"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-task"
+  }, local.common_tags)
+
+  lifecycle {
+    precondition {
+      # Enforce the no-secrets-in-sandbox posture: the injected sandbox policy
+      # must never grant Secrets Manager reads to the task role.
+      condition     = !strcontains(lower(var.additional_task_role_policy_json), "secretsmanager")
+      error_message = "additional_task_role_policy_json must not grant Secrets Manager access to the Loop runtime task role."
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "brainstore_s3_access" {
+  name = "LoopRuntimeBrainstoreS3Access"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:PutObject"]
+          Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/wal/object-store-objects/*"]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:GetObject", "s3:PutObject"]
+          Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/wal/recently-updated/*"]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:ListBucket"]
+          Resource = [var.brainstore_s3_bucket_arn]
+          Condition = {
+            StringLike = { "s3:prefix" = ["brainstore/wal/recently-updated/*"] }
+          }
+        },
+      ],
+      [
+        for stmt in [
+          {
+            Effect   = "Allow"
+            Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+            Resource = ["${var.brainstore_s3_bucket_arn}/${local.locks_s3_path}/*"]
+          },
+          {
+            Effect   = "Allow"
+            Action   = ["s3:ListBucket"]
+            Resource = [var.brainstore_s3_bucket_arn]
+            Condition = {
+              StringLike = { "s3:prefix" = ["${local.locks_s3_path}/*"] }
+            }
+          },
+        ] : stmt if local.use_object_store_locks
+      ],
+    )
+  })
+}
+
+resource "aws_iam_role_policy" "code_bundle_access" {
+  name = "LoopRuntimeCodeBundleAccess"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = ["${var.code_bundle_bucket_arn}/exo/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.code_bundle_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["exo", "exo/*"] }
+        }
+      }
+    ]
+  })
+}
+
+# The Brainstore and code-bundle buckets are encrypted with kms_key_arn, so
+# SSE-KMS reads/writes need key access in addition to the S3 grants above.
+resource "aws_iam_role_policy" "kms_access" {
+  name = "LoopRuntimeKmsAccess"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+      Resource = var.kms_key_arn
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "s3.${data.aws_region.current.region}.amazonaws.com"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "cloudwatch_metrics_access" {
+  name = "LoopRuntimeCloudWatchMetricsAccess"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "cloudwatch:PutMetricData", Resource = "*" }]
+  })
+}
+
+resource "aws_iam_role_policy" "ec2_tags_read_access" {
+  name = "LoopRuntimeEC2TagsReadAccess"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "ec2:DescribeTags", Resource = "*" }]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_tags_read_access" {
+  name = "LoopRuntimeECSResourceTagsReadAccess"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "ecs:ListTagsForResource", Resource = "*" }]
+  })
+}
+
+# ECS Exec needs SSM messages channels on the task role; only granted when Exec is enabled.
+resource "aws_iam_role_policy" "execute_command" {
+  count = var.enable_execute_command ? 1 : 0
+
+  name = "LoopRuntimeExecuteCommand"
+  role = aws_iam_role.task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+# Sandbox-supplied IAM (MicroVM lifecycle, network connectors, optional PassRole).
+resource "aws_iam_role_policy" "sandbox" {
+  name   = "LoopRuntimeSandbox"
+  role   = aws_iam_role.task.id
+  policy = var.additional_task_role_policy_json
+}
+
+resource "aws_ecs_task_definition" "loop_runtime" {
+  family                   = "${var.deployment_name}-loop-runtime"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+
+  dynamic "ephemeral_storage" {
+    for_each = var.ephemeral_storage_gib == null ? [] : [var.ephemeral_storage_gib]
+    content {
+      size_in_gib = ephemeral_storage.value
+    }
+  }
+
+  container_definitions = jsonencode(concat([local.loop_runtime_container_definition], local.observability_sidecars))
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime"
+  }, local.common_tags)
+
+  lifecycle {
+    precondition {
+      condition     = contains(keys(local.valid_fargate_memory_by_cpu), tostring(var.cpu))
+      error_message = "cpu must be a valid Fargate CPU value: 256, 512, 1024, 2048, 4096, 8192, or 16384."
+    }
+    precondition {
+      condition     = contains(local.valid_fargate_memory_by_cpu[tostring(var.cpu)], var.memory)
+      error_message = "memory must be a valid Fargate memory value for the configured cpu."
+    }
+  }
+}
+
+resource "terraform_data" "loop_runtime_http_listener" {
+  input = var.loop_runtime_http_listener_arn
+}
+
+resource "aws_ecs_service" "loop_runtime" {
+  name                              = "${var.deployment_name}-loop-runtime"
+  cluster                           = var.ecs_cluster_arn
+  task_definition                   = aws_ecs_task_definition.loop_runtime.arn
+  desired_count                     = var.min_capacity
+  launch_type                       = "FARGATE"
+  enable_execute_command            = var.enable_execute_command
+  health_check_grace_period_seconds = 60
+  wait_for_steady_state             = true
+
+  # Instant rollback on first deploy otherwise. Must be off (same as api-ecs/gateway-ecs).
+  sigint_rollback = false
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.task.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = local.container_name
+    container_port   = local.container_port
+  }
+
+  depends_on = [terraform_data.loop_runtime_http_listener]
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime"
+  }, local.common_tags)
+}

--- a/modules/loop-runtime-ecs/main.tf
+++ b/modules/loop-runtime-ecs/main.tf
@@ -328,8 +328,9 @@ resource "aws_vpc_security_group_ingress_rule" "brainstore_from_task" {
 
 # --- Task execution role (pulls secrets at container start) ---
 resource "aws_iam_role" "task_execution" {
-  name               = "${var.deployment_name}-loop-runtime-task-exec"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  name                 = "${var.deployment_name}-loop-runtime-task-exec"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
   tags = merge({
     Name = "${var.deployment_name}-loop-runtime-task-exec"
   }, local.common_tags)

--- a/modules/loop-runtime-ecs/main.tf
+++ b/modules/loop-runtime-ecs/main.tf
@@ -423,7 +423,7 @@ resource "aws_iam_role_policy" "brainstore_s3_access" {
         for stmt in [
           {
             Effect   = "Allow"
-            Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+            Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:DeleteObjectVersion"]
             Resource = ["${var.brainstore_s3_bucket_arn}/${local.locks_s3_path}/*"]
           },
           {

--- a/modules/loop-runtime-ecs/outputs.tf
+++ b/modules/loop-runtime-ecs/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Name of the ECS Loop runtime service"
+  value       = aws_ecs_service.loop_runtime.name
+}
+
+output "task_security_group_id" {
+  description = "Security group ID attached to Loop runtime ECS tasks"
+  value       = aws_security_group.task.id
+}
+
+output "task_role_arn" {
+  description = "ARN of the Loop runtime ECS task role"
+  value       = aws_iam_role.task.arn
+}

--- a/modules/loop-runtime-ecs/variables.tf
+++ b/modules/loop-runtime-ecs/variables.tf
@@ -1,0 +1,371 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Will be included in resource names."
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS key ARN used to encrypt Loop runtime resources that support customer-managed KMS keys."
+}
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to the Loop runtime task role."
+  default     = null
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where ECS resources are deployed."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for ECS tasks."
+
+  validation {
+    condition     = length(var.private_subnet_ids) >= 2 && length(distinct(var.private_subnet_ids)) == length(var.private_subnet_ids)
+    error_message = "private_subnet_ids must contain at least 2 unique subnet IDs."
+  }
+}
+
+variable "ecs_cluster_arn" {
+  type        = string
+  description = "ARN of the ECS cluster where the Loop runtime service will run."
+}
+
+variable "ecs_cluster_name" {
+  type        = string
+  description = "Name of the ECS cluster where the Loop runtime service will run."
+}
+
+variable "container_image" {
+  type        = string
+  description = "Container image for the Loop runtime ECS service."
+
+  validation {
+    condition     = trimspace(var.container_image) != ""
+    error_message = "container_image must not be empty."
+  }
+}
+
+variable "cpu" {
+  type        = number
+  description = "CPU units for the Loop runtime task definition."
+  default     = 2048
+}
+
+variable "memory" {
+  type        = number
+  description = "Memory (MiB) for the Loop runtime task definition."
+  default     = 8192
+}
+
+variable "ephemeral_storage_gib" {
+  type        = number
+  description = "Task ephemeral storage in GiB (21-200). Null uses the Fargate default (20 GiB)."
+  default     = null
+
+  validation {
+    condition     = var.ephemeral_storage_gib == null || (var.ephemeral_storage_gib >= 21 && var.ephemeral_storage_gib <= 200)
+    error_message = "ephemeral_storage_gib must be between 21 and 200 when set."
+  }
+}
+
+variable "min_capacity" {
+  type        = number
+  description = "Minimum number of Loop runtime ECS tasks."
+  default     = 1
+}
+
+variable "max_capacity" {
+  type        = number
+  description = "Maximum number of Loop runtime ECS tasks."
+  default     = 4
+
+  validation {
+    condition     = var.max_capacity >= var.min_capacity
+    error_message = "max_capacity must be greater than or equal to min_capacity."
+  }
+}
+
+variable "target_cpu_utilization" {
+  type        = number
+  description = "Target average CPU utilization percentage for Loop runtime ECS service autoscaling."
+  default     = 40
+
+  validation {
+    condition     = var.target_cpu_utilization > 0 && var.target_cpu_utilization <= 100
+    error_message = "target_cpu_utilization must be between 1 and 100."
+  }
+}
+
+variable "target_memory_utilization" {
+  type        = number
+  description = "Target average memory utilization percentage for Loop runtime ECS service autoscaling."
+  default     = 50
+
+  validation {
+    condition     = var.target_memory_utilization > 0 && var.target_memory_utilization <= 100
+    error_message = "target_memory_utilization must be between 1 and 100."
+  }
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch log retention days for Loop runtime container logs."
+  default     = 14
+
+  validation {
+    condition = contains([
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180,
+      365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653
+    ], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "cpu_architecture" {
+  type        = string
+  description = "CPU architecture for the Loop runtime task definition."
+  default     = "ARM64"
+
+  validation {
+    condition     = contains(["ARM64", "X86_64"], var.cpu_architecture)
+    error_message = "cpu_architecture must be either ARM64 or X86_64."
+  }
+}
+
+variable "enable_execute_command" {
+  type        = bool
+  description = "Enable ECS Exec on the Loop runtime service."
+  default     = false
+}
+
+# --- ALB wiring (from loop-runtime-alb) ---
+variable "target_group_arn" {
+  type        = string
+  description = "ARN of the Loop runtime ALB target group."
+  nullable    = true
+}
+
+variable "alb_security_group_id" {
+  type        = string
+  description = "Security group ID of the Loop runtime ALB."
+  nullable    = true
+}
+
+variable "loop_runtime_http_listener_arn" {
+  type        = string
+  description = "ARN of the Loop runtime ALB HTTP listener; orders ECS registration after the listener exists."
+  nullable    = true
+}
+
+# --- Sandbox seam (from loop-runtime-sandbox-* module) ---
+variable "sandbox_env_vars" {
+  type        = map(string)
+  description = "Sandbox backend environment variables merged into the container (e.g. EXO_SANDBOX_PROVIDER + AWS_LAMBDA_MICROVM_*)."
+  default     = {}
+}
+
+variable "additional_task_role_policy_json" {
+  type        = string
+  description = "IAM policy JSON attached to the task role for the sandbox backend (e.g. MicroVM lifecycle). Must not grant Secrets Manager access."
+  default     = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+}
+
+# --- Data-plane connectivity ---
+variable "database_url_secret_arn" {
+  type        = string
+  description = "Secrets Manager ARN of the Postgres connection URL (BRAINSTORE_METADATA_URI / BRAINSTORE_WAL_URI)."
+}
+
+variable "redis_url_secret_arn" {
+  type        = string
+  description = "Secrets Manager ARN of the Redis connection URL (BRAINSTORE_XACT_MANAGER_URI / BRAINSTORE_REDIS_URI / locks)."
+}
+
+variable "function_tools_secret_arn" {
+  type        = string
+  description = "Secrets Manager ARN of the function-tools/service-token secret (SERVICE_TOKEN_SECRET_KEY)."
+}
+
+variable "brainstore_s3_bucket_name" {
+  type        = string
+  description = "Brainstore S3 bucket name (for index/WAL/locks URIs)."
+}
+
+variable "brainstore_s3_bucket_arn" {
+  type        = string
+  description = "Brainstore S3 bucket ARN (for the task role S3 policy)."
+}
+
+variable "code_bundle_bucket" {
+  type        = string
+  description = "Code bundle S3 bucket name (BRAINSTORE_CODE_BUNDLE_URI)."
+}
+
+variable "code_bundle_bucket_arn" {
+  type        = string
+  description = "Code bundle S3 bucket ARN (for the task role S3 policy)."
+}
+
+variable "brainstore_object_store_locks" {
+  type        = bool
+  description = "Use S3 object-store locks (true) vs Redis locks (false) for BRAINSTORE_LOCKS_URI."
+  default     = true
+}
+
+variable "brainstore_locks_s3_path" {
+  type        = string
+  description = "S3 path prefix under the Brainstore bucket for BRAINSTORE_LOCKS_URI. Must match the deployment's Brainstore nodes so lock namespaces overlap."
+  default     = "/locks"
+}
+
+variable "brainstore_wal_footer_version" {
+  type        = string
+  description = "WAL footer version for the shared realtime WAL. Must match the API/Brainstore writers. Empty leaves it unset."
+  default     = ""
+}
+
+variable "skip_pg_for_brainstore_objects" {
+  type        = string
+  description = "SKIP_PG_FOR_BRAINSTORE_OBJECTS setting; also enables BRAINSTORE_WAL_USE_EFFICIENT_FORMAT. Must match the API writers. Empty disables."
+  default     = ""
+}
+
+variable "brainstore_reader_url" {
+  type        = string
+  description = "URL of the Brainstore reader (LOOP_RUNTIME_BRAINSTORE_READER_URL)."
+}
+
+variable "ai_proxy_url" {
+  type        = string
+  description = "AI proxy URL used by the Loop runtime (LOOP_RUNTIME_AI_PROXY_URL)."
+}
+
+variable "brainstore_license_key" {
+  type        = string
+  description = "Brainstore license key (plain env)."
+  default     = null
+}
+
+variable "brainstore_disable_status_updates" {
+  type        = string
+  description = "Value for BRAINSTORE_DISABLE_STATUS_UPDATES."
+  default     = "false"
+}
+
+variable "monitoring_telemetry" {
+  type        = string
+  description = "Value for BRAINSTORE_CONTROL_PLANE_TELEMETRY."
+  default     = "status,metrics,usage,traces,logs"
+}
+
+# --- Service-side SG ingress targets ---
+variable "database_security_group_id" {
+  type        = string
+  description = "Security group ID of Postgres; an ingress rule from the task SG is added when set."
+  default     = null
+}
+
+variable "database_port" {
+  type        = number
+  description = "Postgres port."
+  default     = 5432
+}
+
+variable "redis_security_group_id" {
+  type        = string
+  description = "Security group ID of Redis; an ingress rule from the task SG is added when set."
+  default     = null
+}
+
+variable "redis_port" {
+  type        = number
+  description = "Redis port."
+  default     = 6379
+}
+
+variable "brainstore_security_group_id" {
+  type        = string
+  description = "Security group ID of Brainstore instances; an ingress rule from the task SG is added when set."
+  default     = null
+}
+
+variable "brainstore_port" {
+  type        = number
+  description = "Brainstore service port."
+  default     = 4000
+}
+
+# --- Runtime config ---
+variable "org_name" {
+  type        = string
+  description = "Org this runtime serves (ORG_NAME). '*' allows any."
+  default     = "*"
+}
+
+variable "allowed_org_ids" {
+  type        = string
+  description = "Comma-separated allowed org IDs (ALLOWED_ORG_IDS). Empty to omit."
+  default     = ""
+}
+
+variable "braintrust_api_url" {
+  type        = string
+  description = "Braintrust API URL (BRAINTRUST_API_URL)."
+}
+
+variable "loop_runtime_lifecycle_log" {
+  type        = string
+  description = "Value for LOOP_RUNTIME_LIFECYCLE_LOG (\"0\" or \"1\")."
+  default     = "0"
+
+  validation {
+    condition     = contains(["0", "1"], var.loop_runtime_lifecycle_log)
+    error_message = "loop_runtime_lifecycle_log must be \"0\" or \"1\"."
+  }
+}
+
+variable "extra_env_vars" {
+  type        = map(string)
+  description = "Extra environment variables merged into the Loop runtime container (overrides core/sandbox env)."
+  default     = {}
+
+  validation {
+    condition     = !contains(keys(var.extra_env_vars), "BRAINSTORE_LICENSE_KEY")
+    error_message = "Do not set BRAINSTORE_LICENSE_KEY in extra_env_vars; use brainstore_license_key."
+  }
+}
+
+# --- Observability ---
+variable "internal_observability_enabled" {
+  type        = bool
+  description = "Whether to enable internal Datadog observability for the Loop runtime."
+  default     = false
+}
+
+variable "internal_observability_api_key_secret_arn" {
+  type        = string
+  description = "Secrets Manager secret ARN containing the internal observability API key."
+  default     = ""
+}
+
+variable "internal_observability_region" {
+  type        = string
+  description = "Datadog region suffix (e.g. us5) used to build DD_SITE."
+  default     = "us5"
+}
+
+variable "internal_observability_env_name" {
+  type        = string
+  description = "Datadog environment name used for DD_ENV / OTEL attributes."
+  default     = ""
+}
+
+variable "custom_tags" {
+  description = "Custom tags to apply to all created resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/loop-runtime-ecs/versions.tf
+++ b/modules/loop-runtime-ecs/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.23.0, < 7.0.0"
+    }
+  }
+}

--- a/modules/loop-runtime-sandbox-aws-microvm/main.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/main.tf
@@ -20,7 +20,13 @@ locals {
   managed_ingress_connector_arn = "arn:${local.partition}:lambda:${local.region}:aws:network-connector:aws-network-connector:ALL_INGRESS"
   managed_egress_connector_arn  = "arn:${local.partition}:lambda:${local.region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS"
   ingress_connector_arns        = length(var.ingress_network_connector_arns) > 0 ? var.ingress_network_connector_arns : [local.managed_ingress_connector_arn]
-  egress_connector_arns         = length(var.egress_network_connector_arns) > 0 ? var.egress_network_connector_arns : [local.managed_egress_connector_arn]
+
+  # Match CloudFormation's fail-closed behavior: only the exact value
+  # "internet" permits public Internet egress from sandbox MicroVMs.
+  use_restricted_egress = var.sandbox_egress_mode != "internet"
+  egress_connector_arns = local.use_restricted_egress ? [
+    aws_cloudformation_stack.restricted_egress_connector[0].outputs["NetworkConnectorArn"]
+  ] : [local.managed_egress_connector_arn]
 
   # Resolve the content-addressed artifact key from the published version pointer
   # (same convention as modules/services lambda zips).
@@ -130,6 +136,188 @@ data "aws_iam_policy_document" "microvm_build_assume_role" {
       identifiers = ["lambda.amazonaws.com"]
     }
   }
+}
+
+data "aws_iam_policy_document" "network_connector_operator_assume_role" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_availability_zones" "available" {
+  count = local.use_restricted_egress ? 1 : 0
+  state = "available"
+}
+
+resource "aws_vpc" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  cidr_block           = "10.255.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-restricted-egress"
+  }, local.common_tags)
+}
+
+resource "aws_route_table" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  vpc_id = aws_vpc.restricted_egress[0].id
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-restricted-egress"
+  }, local.common_tags)
+}
+
+resource "aws_subnet" "restricted_egress" {
+  count = local.use_restricted_egress ? 3 : 0
+
+  availability_zone       = data.aws_availability_zones.available[0].names[count.index]
+  cidr_block              = "10.255.${count.index + 1}.0/24"
+  map_public_ip_on_launch = false
+  vpc_id                  = aws_vpc.restricted_egress[0].id
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-restricted-egress-subnet-${count.index + 1}"
+  }, local.common_tags)
+}
+
+resource "aws_route_table_association" "restricted_egress" {
+  count = local.use_restricted_egress ? 3 : 0
+
+  route_table_id = aws_route_table.restricted_egress[0].id
+  subnet_id      = aws_subnet.restricted_egress[count.index].id
+}
+
+resource "aws_route53_resolver_firewall_domain_list" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  domains = ["*"]
+  name    = "bt-loop-${var.deployment_name}-dns-domains"
+  tags    = local.common_tags
+}
+
+resource "aws_route53_resolver_firewall_rule_group" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  name = "bt-loop-${var.deployment_name}-dns-rules"
+  tags = local.common_tags
+}
+
+resource "aws_route53_resolver_firewall_rule" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  action                  = "BLOCK"
+  block_response          = "NXDOMAIN"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.restricted_egress[0].id
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.restricted_egress[0].id
+  name                    = "bt-loop-${var.deployment_name}-dns-block-all"
+  priority                = 100
+}
+
+resource "aws_route53_resolver_firewall_rule_group_association" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  depends_on = [aws_route53_resolver_firewall_rule.restricted_egress]
+
+  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.restricted_egress[0].id
+  name                   = "bt-loop-${var.deployment_name}-dns-assoc"
+  priority               = 101
+  vpc_id                 = aws_vpc.restricted_egress[0].id
+  tags                   = local.common_tags
+}
+
+resource "aws_security_group" "restricted_egress" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  description = "Security group for restricted Loop runtime sandbox egress"
+  egress      = []
+  name        = "${var.deployment_name}-loop-runtime-restricted-egress"
+  vpc_id      = aws_vpc.restricted_egress[0].id
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-restricted-egress"
+  }, local.common_tags)
+}
+
+resource "aws_iam_role" "network_connector_operator" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  name                 = "${var.deployment_name}-loop-runtime-network-connector"
+  assume_role_policy   = data.aws_iam_policy_document.network_connector_operator_assume_role[0].json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-network-connector"
+  }, local.common_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "network_connector_operator" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  role       = aws_iam_role.network_connector_operator[0].name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/AWSLambdaNetworkConnectorOperatorPolicy"
+}
+
+# AWS provider v6 does not expose AWS::Lambda::NetworkConnector. Keep this
+# isolated CloudFormation stack alongside the existing MicroVM image stack,
+# while Terraform manages the surrounding network and IAM resources.
+resource "aws_cloudformation_stack" "restricted_egress_connector" {
+  count = local.use_restricted_egress ? 1 : 0
+
+  name = "${var.deployment_name}-loop-runtime-restricted-egress-connector"
+
+  depends_on = [
+    aws_iam_role_policy_attachment.network_connector_operator,
+    aws_route53_resolver_firewall_rule_group_association.restricted_egress,
+  ]
+
+  parameters = {
+    ConnectorName   = "bt-loop-${var.deployment_name}-restricted-egress"
+    OperatorRoleArn = aws_iam_role.network_connector_operator[0].arn
+    SecurityGroupId = aws_security_group.restricted_egress[0].id
+    SubnetIds       = join(",", aws_subnet.restricted_egress[*].id)
+  }
+
+  template_body = <<-YAML
+    AWSTemplateFormatVersion: "2010-09-09"
+    Parameters:
+      ConnectorName:
+        Type: String
+      OperatorRoleArn:
+        Type: String
+      SecurityGroupId:
+        Type: String
+      SubnetIds:
+        Type: CommaDelimitedList
+    Resources:
+      RestrictedEgressConnector:
+        Type: AWS::Lambda::NetworkConnector
+        Properties:
+          Name: !Ref ConnectorName
+          OperatorRole: !Ref OperatorRoleArn
+          Configuration:
+            VpcEgressConfiguration:
+              AssociatedComputeResourceTypes:
+                - MicroVm
+              NetworkProtocol: IPv4
+              SecurityGroupIds:
+                - !Ref SecurityGroupId
+              SubnetIds: !Ref SubnetIds
+    Outputs:
+      NetworkConnectorArn:
+        Value: !GetAtt RestrictedEgressConnector.Arn
+  YAML
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role" "microvm_image_build" {

--- a/modules/loop-runtime-sandbox-aws-microvm/main.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/main.tf
@@ -1,0 +1,269 @@
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+
+  region    = data.aws_region.current.region
+  partition = data.aws_partition.current.partition
+
+  artifact_bucket_name = coalesce(var.artifact_bucket_name, "braintrust-assets-${local.region}")
+
+  # MicroVM image name; must be unique per deployment.
+  image_name = "bt-loop-${var.deployment_name}"
+
+  base_image_arn = "arn:${local.partition}:lambda:${local.region}:aws:microvm-image:al2023-1"
+
+  # AWS-managed network connectors used at RunMicrovm time.
+  managed_ingress_connector_arn = "arn:${local.partition}:lambda:${local.region}:aws:network-connector:aws-network-connector:ALL_INGRESS"
+  managed_egress_connector_arn  = "arn:${local.partition}:lambda:${local.region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS"
+  ingress_connector_arns        = length(var.ingress_network_connector_arns) > 0 ? var.ingress_network_connector_arns : [local.managed_ingress_connector_arn]
+  egress_connector_arns         = length(var.egress_network_connector_arns) > 0 ? var.egress_network_connector_arns : [local.managed_egress_connector_arn]
+
+  # Resolve the content-addressed artifact key from the published version pointer
+  # (same convention as modules/services lambda zips).
+  artifact_key      = trimspace(data.http.microvm_artifact_version.response_body)
+  code_artifact_uri = "s3://${local.artifact_bucket_name}/${local.artifact_key}"
+
+  image_arn = aws_cloudformation_stack.microvm_image.outputs["ImageArn"]
+
+  # IAM statements the Loop runtime ECS *task* role needs to drive MicroVMs.
+  # Emitted as an output so the compute module can attach it without knowing
+  # anything MicroVM-specific.
+  task_role_policy = {
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid    = "LoopRuntimeMicrovmLifecycle"
+        Effect = "Allow"
+        Action = [
+          "lambda:RunMicrovm",
+          "lambda:GetMicrovm",
+          "lambda:ResumeMicrovm",
+          "lambda:SuspendMicrovm",
+          "lambda:CreateMicrovmAuthToken",
+          "lambda:TerminateMicrovm",
+        ]
+        Resource = local.image_arn
+      },
+      {
+        Sid      = "LoopRuntimeMicrovmNetworkConnectors"
+        Effect   = "Allow"
+        Action   = ["lambda:PassNetworkConnector"]
+        Resource = distinct(concat(local.ingress_connector_arns, local.egress_connector_arns))
+      },
+      ], var.enable_microvm_runtime_logs ? [
+      {
+        Sid      = "LoopRuntimeMicrovmPassExecutionRole"
+        Effect   = "Allow"
+        Action   = ["iam:PassRole"]
+        Resource = aws_iam_role.microvm_execution[0].arn
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "lambda.amazonaws.com"
+          }
+        }
+      }
+    ] : [])
+  }
+
+  # Environment variables the compute module merges into the container. Nothing
+  # else in the compute module references MicroVMs.
+  sandbox_env_vars = merge({
+    EXO_SANDBOX_PROVIDER                              = "aws-lambda-microvm"
+    EXO_SANDBOX_IMAGE                                 = "lambda-microvm"
+    AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER               = local.image_arn
+    AWS_LAMBDA_MICROVM_REGION                         = local.region
+    AWS_LAMBDA_MICROVM_INGRESS_NETWORK_CONNECTOR_ARNS = join(",", local.ingress_connector_arns)
+    AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARNS  = join(",", local.egress_connector_arns)
+    AWS_LAMBDA_MICROVM_MAX_IDLE_DURATION_SECONDS      = tostring(var.microvm_max_idle_duration_seconds)
+    AWS_LAMBDA_MICROVM_SUSPENDED_DURATION_SECONDS     = tostring(var.microvm_suspended_duration_seconds)
+    AWS_LAMBDA_MICROVM_AUTO_RESUME_ENABLED            = "true"
+    AWS_LAMBDA_MICROVM_MAXIMUM_DURATION_SECONDS       = tostring(var.microvm_maximum_duration_seconds)
+    AWS_LAMBDA_MICROVM_AUTH_TOKEN_EXPIRATION_MINUTES  = tostring(var.microvm_auth_token_expiration_minutes)
+    AWS_LAMBDA_MICROVM_RUNTIME_PORT                   = tostring(var.microvm_runtime_port)
+    },
+    var.enable_microvm_runtime_logs ? {
+      AWS_LAMBDA_MICROVM_EXECUTION_ROLE_ARN   = aws_iam_role.microvm_execution[0].arn
+      AWS_LAMBDA_MICROVM_ALLOW_EXECUTION_ROLE = "true"
+    } : {}
+  )
+}
+
+# Resolve the published MicroVM guest-zip version pointer (body is the key).
+data "http" "microvm_artifact_version" {
+  url = "https://${local.artifact_bucket_name}.s3.${local.region}.amazonaws.com/${var.artifact_key_prefix}/version-${var.microvm_version_tag}"
+
+  retry {
+    attempts     = 5
+    min_delay_ms = 500
+    max_delay_ms = 5000
+  }
+  request_timeout_ms = 10000
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code < 400
+      error_message = "Failed to resolve MicroVM artifact version pointer at ${self.url} (status ${self.status_code})."
+    }
+  }
+}
+
+# Single log group used for image build logs and (opt-in) MicroVM runtime logs.
+resource "aws_cloudwatch_log_group" "microvm_image" {
+  name              = "/aws/lambda/microvms/${local.image_name}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-microvm"
+  }, local.common_tags)
+}
+
+data "aws_iam_policy_document" "microvm_build_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "microvm_image_build" {
+  name                 = "${var.deployment_name}-loop-runtime-microvm-build"
+  assume_role_policy   = data.aws_iam_policy_document.microvm_build_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-microvm-build"
+  }, local.common_tags)
+}
+
+data "aws_iam_policy_document" "microvm_image_build" {
+  statement {
+    sid       = "ReadMicrovmArtifact"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:${local.partition}:s3:::${local.artifact_bucket_name}/*"]
+  }
+  statement {
+    sid = "MicrovmBuildLogs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "microvm_image_build" {
+  name   = "${var.deployment_name}-loop-runtime-microvm-build"
+  role   = aws_iam_role.microvm_image_build.id
+  policy = data.aws_iam_policy_document.microvm_image_build.json
+}
+
+# Opt-in execution role for exporting MicroVM stdout/stderr to CloudWatch.
+data "aws_iam_policy_document" "microvm_execution_assume_role" {
+  count = var.enable_microvm_runtime_logs ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "microvm_execution" {
+  count                = var.enable_microvm_runtime_logs ? 1 : 0
+  name                 = "${var.deployment_name}-loop-runtime-microvm-exec"
+  assume_role_policy   = data.aws_iam_policy_document.microvm_execution_assume_role[0].json
+  permissions_boundary = var.permissions_boundary_arn
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-microvm-exec"
+  }, local.common_tags)
+}
+
+resource "aws_iam_role_policy" "microvm_execution" {
+  count = var.enable_microvm_runtime_logs ? 1 : 0
+  name  = "${var.deployment_name}-loop-runtime-microvm-exec"
+  role  = aws_iam_role.microvm_execution[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup"]
+        Resource = "arn:${local.partition}:logs:${local.region}:*:log-group:${aws_cloudwatch_log_group.microvm_image.name}"
+      },
+      {
+        Effect = "Allow"
+        Action = ["logs:CreateLogStream", "logs:PutLogEvents"]
+        # Stream actions operate on log-stream ARNs beneath the group. TF's
+        # log-group .arn has no ":*" suffix (unlike CFN's GetAtt), so append it.
+        Resource = "${aws_cloudwatch_log_group.microvm_image.arn}:*"
+      }
+    ]
+  })
+}
+
+# MicroVM image built via a scoped nested CloudFormation stack. The AWS provider
+# has no native AWS::Lambda::MicrovmImage resource, and the awscc provider cannot
+# create it (Cloud Control prunes the empty-but-required EgressNetworkConnectors/
+# EnvironmentVariables/Hooks keys -> 400). CloudFormation accepts them, matching
+# the BYOC template semantics.
+resource "aws_cloudformation_stack" "microvm_image" {
+  name = "${var.deployment_name}-loop-runtime-microvm-image"
+
+  # The image build assumes microvm_image_build to fetch the artifact and write
+  # logs; without this the stack can start before the role's inline policy is
+  # attached, so the build assumes an unprivileged role and fails on first apply.
+  depends_on = [aws_iam_role_policy.microvm_image_build]
+
+  template_body = <<-YAML
+    AWSTemplateFormatVersion: "2010-09-09"
+    Resources:
+      MicrovmImage:
+        Type: AWS::Lambda::MicrovmImage
+        UpdateReplacePolicy: Retain
+        Properties:
+          Name: ${local.image_name}
+          BaseImageArn: ${local.base_image_arn}
+          BaseImageVersion: "0"
+          BuildRoleArn: ${aws_iam_role.microvm_image_build.arn}
+          Description: "Braintrust Loop runtime sandbox MicroVM image for ${var.deployment_name}."
+          CodeArtifact:
+            Uri: ${local.code_artifact_uri}
+          CpuConfigurations:
+            - Architecture: ARM_64
+          Resources:
+            - MinimumMemoryInMiB: ${var.microvm_minimum_memory_mib}
+          AdditionalOsCapabilities:
+            - ALL
+          EgressNetworkConnectors: []
+          EnvironmentVariables: []
+          Hooks:
+            MicrovmHooks: {}
+            MicrovmImageHooks: {}
+          Logging:
+            CloudWatch:
+              LogGroup: ${aws_cloudwatch_log_group.microvm_image.name}
+          Tags:
+            - Key: BraintrustLoopRuntime
+              Value: "true"
+    Outputs:
+      ImageArn:
+        Value: !GetAtt MicrovmImage.ImageArn
+  YAML
+
+  tags = local.common_tags
+
+  timeouts {
+    create = "20m"
+    update = "20m"
+    delete = "20m"
+  }
+}

--- a/modules/loop-runtime-sandbox-aws-microvm/outputs.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/outputs.tf
@@ -1,0 +1,19 @@
+output "image_arn" {
+  description = "ARN of the built Loop runtime sandbox MicroVM image."
+  value       = local.image_arn
+}
+
+output "sandbox_env_vars" {
+  description = "Environment variables the Loop runtime compute module merges into the container to drive this sandbox backend. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape."
+  value       = local.sandbox_env_vars
+}
+
+output "task_role_policy_json" {
+  description = "IAM policy (JSON) the Loop runtime ECS task role must attach to drive MicroVMs. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape (empty/adapted as needed)."
+  value       = jsonencode(local.task_role_policy)
+}
+
+output "microvm_log_group_name" {
+  description = "CloudWatch log group used for MicroVM image build and (opt-in) runtime logs."
+  value       = aws_cloudwatch_log_group.microvm_image.name
+}

--- a/modules/loop-runtime-sandbox-aws-microvm/variables.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/variables.tf
@@ -1,0 +1,132 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Will be included in resource names."
+}
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to the MicroVM build/execution roles."
+  default     = null
+}
+
+variable "microvm_version_tag" {
+  type        = string
+  description = "Version tag of the published MicroVM guest artifact (resolves the content-addressed key via the version-<tag> pointer)."
+}
+
+variable "artifact_bucket_name" {
+  type        = string
+  description = "S3 bucket holding the MicroVM guest artifact. Defaults to braintrust-assets-<region>."
+  default     = null
+}
+
+variable "artifact_key_prefix" {
+  type        = string
+  description = "Key prefix under which the MicroVM guest artifact + version pointer are published."
+  default     = "microvm/loop-runtime"
+}
+
+variable "microvm_minimum_memory_mib" {
+  type        = number
+  description = "Minimum memory (MiB) provisioned for sandbox MicroVMs."
+  default     = 2048
+
+  validation {
+    condition     = var.microvm_minimum_memory_mib >= 2048
+    error_message = "microvm_minimum_memory_mib must be at least 2048."
+  }
+}
+
+variable "microvm_max_idle_duration_seconds" {
+  type        = number
+  description = "Seconds without endpoint traffic before a sandbox MicroVM auto-suspends."
+  default     = 900
+
+  validation {
+    condition     = var.microvm_max_idle_duration_seconds >= 1 && var.microvm_max_idle_duration_seconds <= 28800
+    error_message = "microvm_max_idle_duration_seconds must be between 1 and 28800."
+  }
+}
+
+variable "microvm_suspended_duration_seconds" {
+  type        = number
+  description = "Seconds a suspended sandbox MicroVM remains resumable before termination."
+  default     = 28800
+
+  validation {
+    condition     = var.microvm_suspended_duration_seconds >= 1 && var.microvm_suspended_duration_seconds <= 28800
+    error_message = "microvm_suspended_duration_seconds must be between 1 and 28800."
+  }
+}
+
+variable "microvm_maximum_duration_seconds" {
+  type        = number
+  description = "Maximum sandbox MicroVM lifetime in running or suspended states."
+  default     = 28800
+
+  validation {
+    condition     = var.microvm_maximum_duration_seconds >= 1 && var.microvm_maximum_duration_seconds <= 28800
+    error_message = "microvm_maximum_duration_seconds must be between 1 and 28800."
+  }
+}
+
+variable "microvm_auth_token_expiration_minutes" {
+  type        = number
+  description = "Endpoint auth token lifetime in minutes for sandbox MicroVM invocations."
+  default     = 30
+
+  validation {
+    condition     = var.microvm_auth_token_expiration_minutes >= 1 && var.microvm_auth_token_expiration_minutes <= 60
+    error_message = "microvm_auth_token_expiration_minutes must be between 1 and 60."
+  }
+}
+
+variable "microvm_runtime_port" {
+  type        = number
+  description = "Port the MicroVM guest runtime listens on."
+  default     = 8080
+}
+
+variable "ingress_network_connector_arns" {
+  type        = list(string)
+  description = "Ingress network connector ARNs used at RunMicrovm time. Defaults to the AWS-managed ALL_INGRESS connector."
+  default     = []
+}
+
+variable "egress_network_connector_arns" {
+  type        = list(string)
+  description = "Egress network connector ARNs used at RunMicrovm time. Defaults to the AWS-managed INTERNET_EGRESS connector."
+  default     = []
+}
+
+variable "enable_microvm_runtime_logs" {
+  type        = bool
+  description = "Export MicroVM stdout/stderr to CloudWatch (can include sandbox output). Creates an execution role and grants the task role PassRole."
+  default     = false
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch log retention days for the MicroVM image/runtime log group."
+  default     = 365
+
+  validation {
+    condition = contains([
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180,
+      365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653
+    ], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS key ARN for encrypting the MicroVM log group. Null uses the default CloudWatch encryption."
+  default     = null
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Tags to apply to created resources."
+  default     = {}
+}

--- a/modules/loop-runtime-sandbox-aws-microvm/variables.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/variables.tf
@@ -93,10 +93,10 @@ variable "ingress_network_connector_arns" {
   default     = []
 }
 
-variable "egress_network_connector_arns" {
-  type        = list(string)
-  description = "Egress network connector ARNs used at RunMicrovm time. Defaults to the AWS-managed INTERNET_EGRESS connector."
-  default     = []
+variable "sandbox_egress_mode" {
+  type        = string
+  description = "Exactly \"internet\" uses AWS-managed Internet egress. Every other value selects the restricted egress connector."
+  default     = "internet"
 }
 
 variable "enable_microvm_runtime_logs" {

--- a/modules/loop-runtime-sandbox-aws-microvm/versions.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.23.0, < 7.0.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -143,6 +143,16 @@ output "api_ecs_task_security_group_id" {
   description = "ID of the security group for API ECS tasks"
 }
 
+output "loop_runtime_url" {
+  value       = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_url : null
+  description = "Private in-VPC URL of the Loop runtime ALB"
+}
+
+output "loop_runtime_microvm_image_arn" {
+  value       = local.create_loop_runtime ? module.loop_runtime_sandbox_aws_microvm[0].image_arn : null
+  description = "ARN of the Loop runtime sandbox MicroVM image"
+}
+
 output "postgres_database_identifier" {
   value       = module.database.postgres_database_identifier
   description = "Identifier of the main Braintrust Postgres database"

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -127,3 +127,9 @@ variable "enable_loop_runtime_microvm_runtime_logs" {
   description = "Export Loop runtime MicroVM stdout/stderr to CloudWatch (can include sandbox output)."
   default     = false
 }
+
+variable "loop_runtime_sandbox_egress_mode" {
+  type        = string
+  description = "Outbound-network mode for Loop runtime sandbox MicroVMs. Exactly \"internet\" uses AWS-managed Internet egress; any other value uses a restricted connector with no outbound network access."
+  default     = "internet"
+}

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -1,0 +1,129 @@
+variable "enable_loop_runtime" {
+  type        = bool
+  description = "Deploy the dedicated Loop runtime ECS/Fargate service (hosted Loop) and its MicroVM sandbox. Requires the ECS API data plane and Brainstore."
+  default     = false
+
+  validation {
+    condition     = !var.enable_loop_runtime || var.enable_brainstore
+    error_message = "enable_loop_runtime requires enable_brainstore = true (the Loop runtime reads from Brainstore)."
+  }
+
+  validation {
+    condition     = !var.enable_loop_runtime || !var.use_deployment_mode_external_eks
+    error_message = "enable_loop_runtime is not supported with use_deployment_mode_external_eks = true (the Loop runtime requires the in-VPC ECS API data plane)."
+  }
+}
+
+variable "loop_runtime_version_override" {
+  type        = string
+  description = "Pin the Loop runtime container image and MicroVM guest artifact to a specific version tag. Defaults to modules/loop-runtime-ecs/VERSIONS.json."
+  default     = null
+}
+
+variable "loop_runtime_task_cpu" {
+  type        = number
+  description = "CPU units for the Loop runtime ECS task."
+  default     = 2048
+}
+
+variable "loop_runtime_task_memory" {
+  type        = number
+  description = "Memory (MiB) for the Loop runtime ECS task."
+  default     = 8192
+}
+
+variable "loop_runtime_ephemeral_storage_gib" {
+  type        = number
+  description = "Task ephemeral storage in GiB (21-200) for the Loop runtime. Null uses the Fargate default (20)."
+  default     = null
+}
+
+variable "loop_runtime_min_capacity" {
+  type        = number
+  description = "Minimum number of Loop runtime ECS tasks."
+  default     = 1
+}
+
+variable "loop_runtime_max_capacity" {
+  type        = number
+  description = "Maximum number of Loop runtime ECS tasks."
+  default     = 4
+}
+
+variable "loop_runtime_target_cpu_utilization" {
+  type        = number
+  description = "Target average CPU utilization percentage for Loop runtime autoscaling."
+  default     = 40
+}
+
+variable "loop_runtime_target_memory_utilization" {
+  type        = number
+  description = "Target average memory utilization percentage for Loop runtime autoscaling."
+  default     = 50
+}
+
+variable "loop_runtime_log_retention_days" {
+  type        = number
+  description = "CloudWatch log retention days for Loop runtime container logs."
+  default     = 14
+}
+
+variable "loop_runtime_enable_execute_command" {
+  type        = bool
+  description = "Enable ECS Exec on the Loop runtime service."
+  default     = false
+}
+
+variable "loop_runtime_alb_deregistration_delay" {
+  type        = number
+  description = "Deregistration delay (seconds) for the Loop runtime ALB target group."
+  default     = 900
+}
+
+variable "loop_runtime_org_name" {
+  type        = string
+  description = "Org this Loop runtime serves (ORG_NAME). '*' allows any."
+  default     = "*"
+}
+
+variable "loop_runtime_extra_env_vars" {
+  type        = map(string)
+  description = "Extra environment variables merged into the Loop runtime container."
+  default     = {}
+}
+
+variable "loop_runtime_microvm_minimum_memory_mib" {
+  type        = number
+  description = "Minimum memory (MiB) provisioned for sandbox MicroVMs."
+  default     = 2048
+}
+
+variable "loop_runtime_microvm_max_idle_duration_seconds" {
+  type        = number
+  description = "Seconds without endpoint traffic before a sandbox MicroVM auto-suspends."
+  default     = 900
+}
+
+variable "loop_runtime_microvm_suspended_duration_seconds" {
+  type        = number
+  description = "Seconds a suspended sandbox MicroVM remains resumable before termination."
+  default     = 28800
+}
+
+variable "loop_runtime_microvm_maximum_duration_seconds" {
+  type        = number
+  description = "Maximum sandbox MicroVM lifetime in running or suspended states."
+  default     = 28800
+}
+
+variable "loop_runtime_microvm_auth_token_expiration_minutes" {
+  type        = number
+  description = "Endpoint auth token lifetime in minutes for sandbox MicroVM invocations."
+  default     = 30
+}
+
+variable "enable_loop_runtime_microvm_runtime_logs" {
+  type        = bool
+  description = "Export Loop runtime MicroVM stdout/stderr to CloudWatch (can include sandbox output)."
+  default     = false
+}


### PR DESCRIPTION
## Context

Adds support for deploying the Loop runtime — the service behind hosted Loop — to the data plane. It is gated behind a new `enable_loop_runtime` flag that defaults to off, so existing deployments are unaffected until they opt in.

## Description

Three new modules that follow the same patterns as the existing service modules:

- `loop-runtime-alb` — internal load balancer in front of the service.
- `loop-runtime-ecs` — the Fargate service, task definition, autoscaling, and IAM.
- `loop-runtime-sandbox-aws-microvm` — builds the AWS Lambda MicroVM image the service uses to run sandboxed code. It is wired to the service module through a small interface so other sandbox backends can be added later without touching the service module.

Root variables add the `enable_loop_runtime` flag and related `loop_runtime_*` settings, and `/loop/runtime*` is routed through the existing CloudFront distribution. The MicroVM image is created through a small nested CloudFormation stack because the AWS Terraform provider does not yet have a native resource for it.

The MicroVM sandbox defaults to AWS-managed Internet egress. Setting `loop_runtime_sandbox_egress_mode` to any other value provisions a dedicated restricted path with no outbound network access.

## Testing

`terraform validate` and `terraform fmt` pass across the root module and every new submodule. The MicroVM image build was exercised end to end (build succeeds, image reaches the ready state) and torn down.
