### PR TITLE
Pass Brainstore license key to API ECS containers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -414,6 +414,7 @@ module "api_ecs" {
   brainstore_wal_footer_version   = var.brainstore_wal_footer_version
   skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects
   brainstore_enable_export        = var.brainstore_enable_export
+  brainstore_license_key          = var.brainstore_license_key
 
   # Storage
   code_bundle_bucket = module.storage.code_bundle_bucket_id

--- a/modules/api-ecs/locals.tf
+++ b/modules/api-ecs/locals.tf
@@ -108,7 +108,11 @@ locals {
     } : {},
   )
 
-  merged_env_vars = merge(local.base_env_vars, var.extra_env_vars)
+  plain_license_env_var = var.brainstore_license_key == null ? {} : {
+    BRAINSTORE_LICENSE_KEY = var.brainstore_license_key
+  }
+
+  merged_env_vars = merge(local.base_env_vars, local.plain_license_env_var, var.extra_env_vars)
 
   api_service_names = ["braintrust-api", "braintrust-api-ingest", "braintrust-api-background"]
 

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -622,6 +622,11 @@ variable "extra_env_vars" {
   type        = map(string)
   description = "Extra environment variables to inject into the API ECS container."
   default     = {}
+
+  validation {
+    condition     = !contains(keys(var.extra_env_vars), "BRAINSTORE_LICENSE_KEY")
+    error_message = "Do not set BRAINSTORE_LICENSE_KEY in extra_env_vars; use brainstore_license_key."
+  }
 }
 
 variable "brainstore_license_key" {

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -624,6 +624,12 @@ variable "extra_env_vars" {
   default     = {}
 }
 
+variable "brainstore_license_key" {
+  type        = string
+  description = "License key for the Brainstore instance. Passed to the API container for telemetry authorization and status/metrics reporting."
+  default     = null
+}
+
 variable "authorized_security_groups" {
   type        = map(string)
   description = "Map of security group names to IDs authorized to access the API ECS ALB."

--- a/variables.tf
+++ b/variables.tf
@@ -837,6 +837,11 @@ variable "braintrust_api_extra_env_vars" {
   description = "Extra environment variables for the API ECS container."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition     = !contains(keys(var.braintrust_api_extra_env_vars), "BRAINSTORE_LICENSE_KEY")
+    error_message = "Do not set BRAINSTORE_LICENSE_KEY in braintrust_api_extra_env_vars; use brainstore_license_key."
+  }
 }
 
 variable "braintrust_api_authorized_security_groups" {


### PR DESCRIPTION
## Description 
The Brainstore license key was already wired into the Brainstore instances and the AI gateway, but not the API ECS containers. The API needs it for telemetry authorization and status/metrics reporting (the Helm chart already passes BRAINSTORE_LICENSE_KEY to the API).



<!-- sfk:bot-coauthor -->
Co-authored by @starfolkai[bot]