### PR TITLE
[INF-195] Limit API Handler Role S3 permissions

### DIFF
--- a/modules/services-common/iam-api.tf
+++ b/modules/services-common/iam-api.tf
@@ -133,8 +133,14 @@ resource "aws_iam_policy" "api_handler_policy" {
           }
         },
         {
-          Sid    = "S3Access"
-          Action = "s3:*"
+          Sid = "S3Access"
+          Action = [
+            "s3:AbortMultipartUpload",
+            "s3:Get*",
+            "s3:PutObject*",
+            "s3:List*",
+            "s3:DeleteObject*"
+          ]
           Effect = "Allow"
           Resource = concat([
             var.lambda_responses_s3_bucket_arn,


### PR DESCRIPTION
## Summary
- Replaces `s3:*` on `APIHandlerRolePolicy` with object-scoped actions (`AbortMultipartUpload`, `Get*`, `PutObject*`, `List*`, `DeleteObject*`), matching the existing Brainstore allowlist.
- Leaves bucket/object resource ARNs unchanged (lambda responses, code bundle, optional brainstore).
- Blocks bucket-admin actions called out in the security finding (`PutBucketPolicy`, `PutBucketAcl`, `PutEncryptionConfiguration`, `PutBucketPublicAccessBlock`, `DeleteBucket`) without changing data-plane object access.

Fixes [INF-195](https://linear.app/braintrustdata/issue/INF-195/limit-s3-permissions-on-api-handler-role).

## Test plan
- [x] `mise run lint`
- [x] `mise run validate`
- [x] `mise run validate-tofu`
- [x] Confirm CI Terraform/OpenTofu validation passes
- [x] Apply to a sandbox dataplane and smoke-test API object read/write (responses, code bundles, brainstore paths as applicable) — `erikdw-sandbox` (ingest + BTQL + function create; 0 AccessDenied)
- [x] Confirm IAM policy no longer grants `s3:PutBucketPolicy` / `s3:DeleteBucket` on those buckets — IAM simulate: object ops allowed, bucket-admin implicitDeny

Also validated via hosted CFN canary (#18544 staging) and prod CFN promote (#18655), baking ~4–5 days without issues.