### PR TITLE
[INF-196] Add opt-in allowlist for S3 export AssumeRole

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -129,4 +129,10 @@ module "braintrust-data-plane" {
   # s3_additional_allowed_origins                  = ["https://app.example.com"]
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
+
+  # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # s3_export_assume_role_arns = [
+  #   "arn:aws:iam::123456789012:role/customer-export-role",
+  #   "arn:aws:iam::*:role/braintrust-export-*",
+  # ]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -113,4 +113,10 @@ module "braintrust-data-plane" {
   # s3_additional_allowed_origins                  = ["https://app.example.com"]
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
+
+  # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # s3_export_assume_role_arns = [
+  #   "arn:aws:iam::123456789012:role/customer-export-role",
+  #   "arn:aws:iam::*:role/braintrust-export-*",
+  # ]
 }

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -155,6 +155,11 @@ module "braintrust-data-plane" {
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
 
+  # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # s3_export_assume_role_arns = [
+  #   "arn:aws:iam::123456789012:role/customer-export-role",
+  #   "arn:aws:iam::*:role/braintrust-export-*",
+  # ]
 
   ### Braintrust Remote Support
 

--- a/main.tf
+++ b/main.tf
@@ -535,6 +535,7 @@ module "services_common" {
   service_additional_policy_arns            = var.service_additional_policy_arns
   brainstore_additional_policy_arns         = var.brainstore_additional_policy_arns
   brainstore_enable_export                  = var.brainstore_enable_export
+  s3_export_assume_role_arns                = var.s3_export_assume_role_arns
   permissions_boundary_arn                  = var.permissions_boundary_arn
   eks_cluster_arn                           = var.existing_eks_cluster_arn
   eks_namespace                             = var.eks_namespace

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -36,12 +36,12 @@ locals {
     : local.cloudfront_AllViewerExceptHostHeader
   )
   cloudfront_origin_request_policy_for_origin = {
-    (local.cloudfront_ApiEcsOrigin)          = local.cloudfront_ecs_origin_request_policy_id
-    (local.cloudfront_APIGatewayOrigin)      = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_AIProxyOrigin)         = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_CloudflareProxy)       = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_GatewayOrigin)         = local.cloudfront_AllViewerExceptHostHeader
-    (local.cloudfront_PrivateGatewayOrigin)  = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_ApiEcsOrigin)         = local.cloudfront_ecs_origin_request_policy_id
+    (local.cloudfront_APIGatewayOrigin)     = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_AIProxyOrigin)        = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_CloudflareProxy)      = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_GatewayOrigin)        = local.cloudfront_AllViewerExceptHostHeader
+    (local.cloudfront_PrivateGatewayOrigin) = local.cloudfront_AllViewerExceptHostHeader
   }
 }
 

--- a/modules/services-common/iam-api.tf
+++ b/modules/services-common/iam-api.tf
@@ -162,7 +162,7 @@ resource "aws_iam_policy" "api_handler_policy" {
           Sid      = "AssumeRoleInCustomerAccountForS3Export"
           Action   = "sts:AssumeRole"
           Effect   = "Allow"
-          Resource = "*"
+          Resource = length(var.s3_export_assume_role_arns) > 0 ? var.s3_export_assume_role_arns : ["*"]
           Condition = {
             StringLike = {
               "sts:ExternalId" = "bt:*"

--- a/modules/services-common/iam-brainstore.tf
+++ b/modules/services-common/iam-brainstore.tf
@@ -144,7 +144,7 @@ resource "aws_iam_role_policy" "brainstore_export_assume_role" {
       {
         Action   = "sts:AssumeRole"
         Effect   = "Allow"
-        Resource = "*"
+        Resource = length(var.s3_export_assume_role_arns) > 0 ? var.s3_export_assume_role_arns : ["*"]
         Condition = {
           StringLike = {
             "sts:ExternalId" = "bt:*"

--- a/modules/services-common/variables.tf
+++ b/modules/services-common/variables.tf
@@ -93,7 +93,6 @@ variable "s3_export_assume_role_arns" {
     Optional allowlist of IAM role ARNs that the API handler and Brainstore roles may assume for S3 export (sts:AssumeRole with ExternalId bt:*).
     When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
     When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted.
-    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
   EOT
   default     = []
 

--- a/modules/services-common/variables.tf
+++ b/modules/services-common/variables.tf
@@ -87,6 +87,25 @@ variable "brainstore_enable_export" {
   default     = false
 }
 
+variable "s3_export_assume_role_arns" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of IAM role ARNs that the API handler and Brainstore roles may assume for S3 export (sts:AssumeRole with ExternalId bt:*).
+    When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
+    When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted.
+    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for arn in var.s3_export_assume_role_arns :
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+    ])
+    error_message = "s3_export_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}
+
 variable "enable_brainstore_ec2_ssm" {
   description = "Optional. true will enable ssm (session manager) for the brainstore EC2s. Helpful for debugging without changing firewall rules"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -1181,7 +1181,6 @@ variable "s3_export_assume_role_arns" {
     When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility with arbitrary export destinations.
     When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted, for example:
       ["arn:aws:iam::123456789012:role/customer-export-role", "arn:aws:iam::*:role/braintrust-export-*"]
-    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
   EOT
   default     = []
 

--- a/variables.tf
+++ b/variables.tf
@@ -1174,6 +1174,26 @@ variable "brainstore_enable_export" {
   default     = false
 }
 
+variable "s3_export_assume_role_arns" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of IAM role ARNs that the API handler and Brainstore roles may assume for S3 export (sts:AssumeRole with ExternalId bt:*).
+    When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility with arbitrary export destinations.
+    When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted, for example:
+      ["arn:aws:iam::123456789012:role/customer-export-role", "arn:aws:iam::*:role/braintrust-export-*"]
+    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for arn in var.s3_export_assume_role_arns :
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+    ])
+    error_message = "s3_export_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}
+
 variable "brainstore_s3_bucket_retention_days" {
   type        = number
   description = "The number of days to retain non-current S3 objects. e.g. deleted objects"


### PR DESCRIPTION
## Summary
- Adds `s3_export_assume_role_arns` so self-hosted customers can opt in to bounding API + Brainstore `sts:AssumeRole` used for S3 export
- Empty default keeps `Resource: "*"`; when set, only listed role ARNs / IAM Resource patterns may be assumed (`ExternalId: bt:*` unchanged)
- Brainstore export AssumeRole policy remains gated by `brainstore_enable_export`

## Test plan
- [x] `mise run lint`
- [x] `mise run validate`
- [x] Confirm empty `s3_export_assume_role_arns` produces `Resource: ["*"]` on API + Brainstore export AssumeRole statements
- [x] Confirm a non-empty allowlist (exact ARN and/or pattern) appears in the planned IAM policy JSON
- [x] Confirm Brainstore export policy is still gated by `brainstore_enable_export`

Verified against `erikdw-sandbox` (`examples/braintrust-data-plane-sandbox-private-gateway.deployed`, plan-only):
- Empty allowlist: API stays `Resource: ["*"]`; with `brainstore_enable_export=true`, Brainstore `export-assume-role` is created with `Resource: ["*"]`
- Non-empty allowlist + `brainstore_enable_export=true`: API + Brainstore Resource become the exact ARN + pattern list
- Allowlist + `brainstore_enable_export=false`: API allowlist still applies; no Brainstore `export-assume-role` create

Part of https://linear.app/braintrustdata/issue/INF-196