### PR TITLE
[INF-196] Add opt-in allowlist for Bedrock Gateway AssumeRole

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -135,4 +135,8 @@ module "braintrust-data-plane" {
   #   "arn:aws:iam::123456789012:role/customer-export-role",
   #   "arn:aws:iam::*:role/braintrust-export-*",
   # ]
+
+  # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # Only applies when create_ai_gateway is true.
+  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 }

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -138,5 +138,5 @@ module "braintrust-data-plane" {
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # Only applies when create_ai_gateway is true.
-  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+  # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -121,5 +121,5 @@ module "braintrust-data-plane" {
   # ]
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
-  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+  # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -119,4 +119,7 @@ module "braintrust-data-plane" {
   #   "arn:aws:iam::123456789012:role/customer-export-role",
   #   "arn:aws:iam::*:role/braintrust-export-*",
   # ]
+
+  # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 }

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -161,6 +161,9 @@ module "braintrust-data-plane" {
   #   "arn:aws:iam::*:role/braintrust-export-*",
   # ]
 
+  # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
+  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
   ### Braintrust Remote Support
 
   # Enable sharing of Cloudwatch logs with Braintrust staff

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -162,7 +162,7 @@ module "braintrust-data-plane" {
   # ]
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
-  # bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+  # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
   ### Braintrust Remote Support
 

--- a/main.tf
+++ b/main.tf
@@ -376,7 +376,7 @@ module "gateway_ecs" {
   unsafe_url_request_mode     = var.unsafe_url_request_mode
   url_security_dns_servers    = var.url_security_dns_servers
   url_security_allow_cidrs    = var.url_security_allow_cidrs
-  bedrock_assume_role_arns    = var.bedrock_assume_role_arns
+  bedrock_assume_role_arns    = var.ai_gateway_bedrock_assume_role_arns
 
   # Observability
   internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""

--- a/main.tf
+++ b/main.tf
@@ -376,6 +376,7 @@ module "gateway_ecs" {
   unsafe_url_request_mode     = var.unsafe_url_request_mode
   url_security_dns_servers    = var.url_security_dns_servers
   url_security_allow_cidrs    = var.url_security_allow_cidrs
+  bedrock_assume_role_arns    = var.bedrock_assume_role_arns
 
   # Observability
   internal_observability_api_key_secret_arn     = local.create_internal_observability_secret ? aws_secretsmanager_secret.internal_observability_api_key[0].arn : ""

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -296,7 +296,7 @@ resource "aws_iam_role_policy" "customer_assume_role" {
         Sid      = "AssumeRoleInCustomerAccount"
         Effect   = "Allow"
         Action   = "sts:AssumeRole"
-        Resource = "*"
+        Resource = length(var.bedrock_assume_role_arns) > 0 ? var.bedrock_assume_role_arns : ["*"]
         Condition = {
           StringLike = {
             "sts:ExternalId" = "bt:*"

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -268,7 +268,6 @@ variable "bedrock_assume_role_arns" {
     Optional allowlist of IAM role ARNs that the gateway task role may assume for Bedrock AssumeRole auth (sts:AssumeRole with ExternalId bt:*).
     When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
     When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted.
-    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
   EOT
   default     = []
 

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -261,3 +261,22 @@ variable "enable_execute_command" {
   description = "Enable ECS Exec on the gateway service."
   default     = false
 }
+
+variable "bedrock_assume_role_arns" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of IAM role ARNs that the gateway task role may assume for Bedrock AssumeRole auth (sts:AssumeRole with ExternalId bt:*).
+    When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
+    When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted.
+    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for arn in var.bedrock_assume_role_arns :
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+    ])
+    error_message = "bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1193,6 +1193,27 @@ variable "s3_export_assume_role_arns" {
   }
 }
 
+variable "bedrock_assume_role_arns" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of IAM role ARNs that the AI Gateway task role may assume for Bedrock AssumeRole auth (sts:AssumeRole with ExternalId bt:*).
+    When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
+    When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted, for example:
+      ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
+    Only applies when create_ai_gateway is true.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for arn in var.bedrock_assume_role_arns :
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+    ])
+    error_message = "bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}
+
 variable "brainstore_s3_bucket_retention_days" {
   type        = number
   description = "The number of days to retain non-current S3 objects. e.g. deleted objects"

--- a/variables.tf
+++ b/variables.tf
@@ -1200,7 +1200,6 @@ variable "bedrock_assume_role_arns" {
     When empty (default), AssumeRole remains unrestricted (Resource "*") for backward compatibility.
     When set, only matching role ARNs may be assumed. Exact ARNs and IAM Resource patterns are both accepted, for example:
       ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
-    Decision (reversible): wildcards are allowed so customers can use naming-convention patterns; we can tighten to exact ARNs later if needed.
     Only applies when create_ai_gateway is true.
   EOT
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -1193,7 +1193,7 @@ variable "s3_export_assume_role_arns" {
   }
 }
 
-variable "bedrock_assume_role_arns" {
+variable "ai_gateway_bedrock_assume_role_arns" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of IAM role ARNs that the AI Gateway task role may assume for Bedrock AssumeRole auth (sts:AssumeRole with ExternalId bt:*).
@@ -1206,10 +1206,10 @@ variable "bedrock_assume_role_arns" {
 
   validation {
     condition = alltrue([
-      for arn in var.bedrock_assume_role_arns :
+      for arn in var.ai_gateway_bedrock_assume_role_arns :
       can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
     ])
-    error_message = "bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+    error_message = "ai_gateway_bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `ai_gateway_bedrock_assume_role_arns` so self-hosted customers can opt in to bounding the AI Gateway task role `sts:AssumeRole` used for Bedrock AssumeRole auth
- Empty default keeps `Resource: "*"`; when set, only listed role ARNs / IAM Resource patterns may be assumed (`ExternalId: bt:*` unchanged)
- Stacked on #317 (export allowlist); does not change hosted `infra` Gateway

## Test plan
- [x] `mise run lint`
- [x] Confirm empty `ai_gateway_bedrock_assume_role_arns` leaves Gateway AssumeRole unrestricted
- [x] Confirm a non-empty allowlist appears on the gateway task role policy when `create_ai_gateway` is true
- [x] Confirm no change when `create_ai_gateway` is false

Verified against `erikdw-sandbox` (`examples/braintrust-data-plane-sandbox-private-gateway.deployed`, plan-only):
- Empty allowlist: `gateway_ecs` `customer_assume_role` is no-op with `Resource: "*"`
- Non-empty allowlist: planned update sets `Resource` to the exact ARN + pattern list
- `create_ai_gateway=false`: `customer_assume_role` is deleted with the gateway module (allowlist does not update an existing policy in place)

Stacked on https://github.com/braintrustdata/terraform-aws-braintrust-data-plane/pull/317
Part of https://linear.app/braintrustdata/issue/INF-196