### PR TITLE
[INF-203] Add opt-in S3 VPC gateway endpoint allowlists

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -140,7 +140,7 @@ module "braintrust-data-plane" {
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -163,7 +163,8 @@ module "braintrust-data-plane" {
 
   # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
-  # exceptions are added automatically. Only applies when create_vpc is true.
+  # exceptions are added automatically. Applies to any module-managed S3 VPC endpoint
+  # (main and/or quarantine); does not modify customer-managed existing_* VPC endpoints.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
   # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -161,7 +161,7 @@ module "braintrust-data-plane" {
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -160,4 +160,10 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -139,4 +139,10 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -147,4 +147,10 @@ module "braintrust-data-plane" {
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -123,7 +123,7 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -122,4 +122,10 @@ module "braintrust-data-plane" {
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -150,7 +150,8 @@ module "braintrust-data-plane" {
 
   # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
-  # exceptions are added automatically. Only applies when create_vpc is true.
+  # exceptions are added automatically. Applies to any module-managed S3 VPC endpoint
+  # (main and/or quarantine); does not modify customer-managed existing_* VPC endpoints.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
   # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -148,7 +148,7 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -164,7 +164,7 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -194,7 +194,8 @@ module "braintrust-data-plane" {
 
   # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
-  # exceptions are added automatically. Only applies when create_vpc is true.
+  # exceptions are added automatically. Applies to any module-managed S3 VPC endpoint
+  # (main and/or quarantine); does not modify customer-managed existing_* VPC endpoints.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
   # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
 

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -164,6 +164,12 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
+
   ### Braintrust Remote Support
 
   # Enable sharing of Cloudwatch logs with Braintrust staff

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -192,6 +192,12 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
+  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
+  # exceptions are added automatically. Only applies when create_vpc is true.
+  # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]
+  # s3_vpc_endpoint_resource_account_ids = ["123456789012"]
+
   ### Braintrust Remote Support
 
   # Enable sharing of Cloudwatch logs with Braintrust staff

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -192,7 +192,7 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  # Opt-in: restrict S3 VPC gateway endpoint (org IDs win over account IDs; empty = unrestricted).
+  # Opt-in: restrict S3 VPC gateway endpoint (org and account lists compose; empty = unrestricted).
   # Current account is always allowed. When restricted, ECR starport + CloudWatch agent GetObject
   # exceptions are added automatically. Only applies when create_vpc is true.
   # s3_vpc_endpoint_resource_org_ids     = ["o-xxxxxxxxxx"]

--- a/main.tf
+++ b/main.tf
@@ -104,16 +104,18 @@ module "main_vpc" {
   vpc_name        = "main"
   vpc_cidr        = var.vpc_cidr
 
-  public_subnet_1_cidr      = cidrsubnet(var.vpc_cidr, 3, 0)
-  public_subnet_1_az        = local.public_subnet_1_az
-  private_subnet_1_cidr     = cidrsubnet(var.vpc_cidr, 3, 1)
-  private_subnet_1_az       = local.private_subnet_1_az
-  private_subnet_2_cidr     = cidrsubnet(var.vpc_cidr, 3, 2)
-  private_subnet_2_az       = local.private_subnet_2_az
-  private_subnet_3_cidr     = cidrsubnet(var.vpc_cidr, 3, 3)
-  private_subnet_3_az       = local.private_subnet_3_az
-  enable_brainstore_ec2_ssm = var.enable_brainstore_ec2_ssm
-  custom_tags               = local.all_custom_tags
+  public_subnet_1_cidr                 = cidrsubnet(var.vpc_cidr, 3, 0)
+  public_subnet_1_az                   = local.public_subnet_1_az
+  private_subnet_1_cidr                = cidrsubnet(var.vpc_cidr, 3, 1)
+  private_subnet_1_az                  = local.private_subnet_1_az
+  private_subnet_2_cidr                = cidrsubnet(var.vpc_cidr, 3, 2)
+  private_subnet_2_az                  = local.private_subnet_2_az
+  private_subnet_3_cidr                = cidrsubnet(var.vpc_cidr, 3, 3)
+  private_subnet_3_az                  = local.private_subnet_3_az
+  enable_brainstore_ec2_ssm            = var.enable_brainstore_ec2_ssm
+  s3_vpc_endpoint_resource_org_ids     = var.s3_vpc_endpoint_resource_org_ids
+  s3_vpc_endpoint_resource_account_ids = var.s3_vpc_endpoint_resource_account_ids
+  custom_tags                          = local.all_custom_tags
 }
 
 module "quarantine_vpc" {
@@ -124,15 +126,17 @@ module "quarantine_vpc" {
   vpc_name        = "quarantine"
   vpc_cidr        = var.quarantine_vpc_cidr
 
-  public_subnet_1_cidr  = cidrsubnet(var.quarantine_vpc_cidr, 3, 0)
-  public_subnet_1_az    = local.quarantine_public_subnet_1_az
-  private_subnet_1_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 1)
-  private_subnet_1_az   = local.quarantine_private_subnet_1_az
-  private_subnet_2_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 2)
-  private_subnet_2_az   = local.quarantine_private_subnet_2_az
-  private_subnet_3_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 3)
-  private_subnet_3_az   = local.quarantine_private_subnet_3_az
-  custom_tags           = local.all_custom_tags
+  public_subnet_1_cidr                 = cidrsubnet(var.quarantine_vpc_cidr, 3, 0)
+  public_subnet_1_az                   = local.quarantine_public_subnet_1_az
+  private_subnet_1_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 1)
+  private_subnet_1_az                  = local.quarantine_private_subnet_1_az
+  private_subnet_2_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 2)
+  private_subnet_2_az                  = local.quarantine_private_subnet_2_az
+  private_subnet_3_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 3)
+  private_subnet_3_az                  = local.quarantine_private_subnet_3_az
+  s3_vpc_endpoint_resource_org_ids     = var.s3_vpc_endpoint_resource_org_ids
+  s3_vpc_endpoint_resource_account_ids = var.s3_vpc_endpoint_resource_account_ids
+  custom_tags                          = local.all_custom_tags
 }
 
 module "database" {

--- a/main.tf
+++ b/main.tf
@@ -114,16 +114,18 @@ module "main_vpc" {
   vpc_name        = "main"
   vpc_cidr        = var.vpc_cidr
 
-  public_subnet_1_cidr      = cidrsubnet(var.vpc_cidr, 3, 0)
-  public_subnet_1_az        = local.public_subnet_1_az
-  private_subnet_1_cidr     = cidrsubnet(var.vpc_cidr, 3, 1)
-  private_subnet_1_az       = local.private_subnet_1_az
-  private_subnet_2_cidr     = cidrsubnet(var.vpc_cidr, 3, 2)
-  private_subnet_2_az       = local.private_subnet_2_az
-  private_subnet_3_cidr     = cidrsubnet(var.vpc_cidr, 3, 3)
-  private_subnet_3_az       = local.private_subnet_3_az
-  enable_brainstore_ec2_ssm = var.enable_brainstore_ec2_ssm
-  custom_tags               = local.all_custom_tags
+  public_subnet_1_cidr                 = cidrsubnet(var.vpc_cidr, 3, 0)
+  public_subnet_1_az                   = local.public_subnet_1_az
+  private_subnet_1_cidr                = cidrsubnet(var.vpc_cidr, 3, 1)
+  private_subnet_1_az                  = local.private_subnet_1_az
+  private_subnet_2_cidr                = cidrsubnet(var.vpc_cidr, 3, 2)
+  private_subnet_2_az                  = local.private_subnet_2_az
+  private_subnet_3_cidr                = cidrsubnet(var.vpc_cidr, 3, 3)
+  private_subnet_3_az                  = local.private_subnet_3_az
+  enable_brainstore_ec2_ssm            = var.enable_brainstore_ec2_ssm
+  s3_vpc_endpoint_resource_org_ids     = var.s3_vpc_endpoint_resource_org_ids
+  s3_vpc_endpoint_resource_account_ids = var.s3_vpc_endpoint_resource_account_ids
+  custom_tags                          = local.all_custom_tags
 }
 
 module "quarantine_vpc" {
@@ -134,15 +136,17 @@ module "quarantine_vpc" {
   vpc_name        = "quarantine"
   vpc_cidr        = var.quarantine_vpc_cidr
 
-  public_subnet_1_cidr  = cidrsubnet(var.quarantine_vpc_cidr, 3, 0)
-  public_subnet_1_az    = local.quarantine_public_subnet_1_az
-  private_subnet_1_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 1)
-  private_subnet_1_az   = local.quarantine_private_subnet_1_az
-  private_subnet_2_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 2)
-  private_subnet_2_az   = local.quarantine_private_subnet_2_az
-  private_subnet_3_cidr = cidrsubnet(var.quarantine_vpc_cidr, 3, 3)
-  private_subnet_3_az   = local.quarantine_private_subnet_3_az
-  custom_tags           = local.all_custom_tags
+  public_subnet_1_cidr                 = cidrsubnet(var.quarantine_vpc_cidr, 3, 0)
+  public_subnet_1_az                   = local.quarantine_public_subnet_1_az
+  private_subnet_1_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 1)
+  private_subnet_1_az                  = local.quarantine_private_subnet_1_az
+  private_subnet_2_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 2)
+  private_subnet_2_az                  = local.quarantine_private_subnet_2_az
+  private_subnet_3_cidr                = cidrsubnet(var.quarantine_vpc_cidr, 3, 3)
+  private_subnet_3_az                  = local.quarantine_private_subnet_3_az
+  s3_vpc_endpoint_resource_org_ids     = var.s3_vpc_endpoint_resource_org_ids
+  s3_vpc_endpoint_resource_account_ids = var.s3_vpc_endpoint_resource_account_ids
+  custom_tags                          = local.all_custom_tags
 }
 
 module "database" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -11,81 +11,109 @@ locals {
     "ec2messages" : "com.amazonaws.${data.aws_region.current.region}.ec2messages",
   }
 
-  s3_vpc_endpoint_has_org_ids     = length(var.s3_vpc_endpoint_resource_org_ids) > 0
-  s3_vpc_endpoint_has_account_ids = length(var.s3_vpc_endpoint_resource_account_ids) > 0
-  s3_vpc_endpoint_restricted      = local.s3_vpc_endpoint_has_org_ids || local.s3_vpc_endpoint_has_account_ids
+  s3_vpc_endpoint_has_org_ids = length(var.s3_vpc_endpoint_resource_org_ids) > 0
+  s3_vpc_endpoint_restricted  = local.s3_vpc_endpoint_has_org_ids || length(var.s3_vpc_endpoint_resource_account_ids) > 0
 
   # Always include this account so module-owned buckets keep working (org and/or account mode).
   s3_vpc_endpoint_account_ids = distinct(concat(
     var.s3_vpc_endpoint_resource_account_ids,
     [data.aws_caller_identity.current.account_id]
   ))
+}
 
-  # Org and account allowlists compose (union of Allows), so cross-org export destinations
-  # can be allowlisted by account even when org IDs are also set.
-  s3_vpc_endpoint_customer_statements = !local.s3_vpc_endpoint_restricted ? [
-    {
-      Effect    = "Allow"
-      Action    = ["s3:*"]
-      Principal = "*"
-      Resource  = ["*"]
+# Use aws_iam_policy_document (not jsonencode + ternary locals) so unrestricted vs
+# restricted statement shapes do not hit Terraform's inconsistent conditional types.
+# Org and account allowlists compose (union of Allows) for cross-org export destinations.
+data "aws_iam_policy_document" "s3_vpc_endpoint" {
+  dynamic "statement" {
+    for_each = local.s3_vpc_endpoint_restricted ? [] : [1]
+    content {
+      effect    = "Allow"
+      actions   = ["s3:*"]
+      resources = ["*"]
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
     }
-    ] : concat(
-    local.s3_vpc_endpoint_has_org_ids ? [
-      {
-        Sid       = "AllowS3InAllowedOrganizations"
-        Effect    = "Allow"
-        Action    = ["s3:*"]
-        Principal = "*"
-        Resource  = ["*"]
-        Condition = {
-          StringEquals = {
-            "aws:ResourceOrgID" = var.s3_vpc_endpoint_resource_org_ids
-          }
-        }
+  }
+
+  dynamic "statement" {
+    for_each = local.s3_vpc_endpoint_has_org_ids ? [1] : []
+    content {
+      sid       = "AllowS3InAllowedOrganizations"
+      effect    = "Allow"
+      actions   = ["s3:*"]
+      resources = ["*"]
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
       }
-    ] : [],
-    [
-      {
-        Sid       = "AllowS3InAllowedAccounts"
-        Effect    = "Allow"
-        Action    = ["s3:*"]
-        Principal = "*"
-        Resource  = ["*"]
-        Condition = {
-          StringEquals = {
-            "aws:ResourceAccount" = local.s3_vpc_endpoint_account_ids
-          }
-        }
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceOrgID"
+        values   = var.s3_vpc_endpoint_resource_org_ids
       }
-    ]
-  )
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.s3_vpc_endpoint_restricted ? [1] : []
+    content {
+      sid       = "AllowS3InAllowedAccounts"
+      effect    = "Allow"
+      actions   = ["s3:*"]
+      resources = ["*"]
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceAccount"
+        values   = local.s3_vpc_endpoint_account_ids
+      }
+    }
+  }
 
   # Amazon-owned buckets needed when restricted:
   # - ECR starport: private ECR layer pulls (defaults use public.ecr.aws over NAT/CloudFront;
   #   this covers private ECR / custom container_image overrides).
   # - CloudWatch agent: Brainstore user-data .deb from s3.amazonaws.com/amazoncloudwatch-agent/...
-  s3_vpc_endpoint_aws_service_statements = local.s3_vpc_endpoint_restricted ? [
-    {
-      Sid       = "AllowECRStarportLayerBucket"
-      Effect    = "Allow"
-      Action    = ["s3:GetObject"]
-      Principal = "*"
-      Resource  = ["arn:aws:s3:::prod-${data.aws_region.current.region}-starport-layer-bucket/*"]
-    },
-    {
-      Sid       = "AllowCloudWatchAgentBucket"
-      Effect    = "Allow"
-      Action    = ["s3:GetObject"]
-      Principal = "*"
-      Resource  = ["arn:aws:s3:::amazoncloudwatch-agent/*"]
-    }
-  ] : []
+  dynamic "statement" {
+    for_each = local.s3_vpc_endpoint_restricted ? [1] : []
+    content {
+      sid       = "AllowECRStarportLayerBucket"
+      effect    = "Allow"
+      actions   = ["s3:GetObject"]
+      resources = ["arn:aws:s3:::prod-${data.aws_region.current.region}-starport-layer-bucket/*"]
 
-  s3_vpc_endpoint_statements = concat(
-    local.s3_vpc_endpoint_customer_statements,
-    local.s3_vpc_endpoint_aws_service_statements
-  )
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.s3_vpc_endpoint_restricted ? [1] : []
+    content {
+      sid       = "AllowCloudWatchAgentBucket"
+      effect    = "Allow"
+      actions   = ["s3:GetObject"]
+      resources = ["arn:aws:s3:::amazoncloudwatch-agent/*"]
+
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+    }
+  }
 }
 
 resource "aws_vpc" "vpc" {
@@ -237,10 +265,7 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_endpoint_type = "Gateway"
   route_table_ids   = [aws_route_table.private_route_table.id]
 
-  policy = jsonencode({ # nosemgrep
-    Version   = "2012-10-17",
-    Statement = local.s3_vpc_endpoint_statements
-  })
+  policy = data.aws_iam_policy_document.s3_vpc_endpoint.json
 
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-s3-endpoint"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -11,18 +11,27 @@ locals {
     "ec2messages" : "com.amazonaws.${data.aws_region.current.region}.ec2messages",
   }
 
-  s3_vpc_endpoint_restrict_by_org     = length(var.s3_vpc_endpoint_resource_org_ids) > 0
-  s3_vpc_endpoint_restrict_by_account = !local.s3_vpc_endpoint_restrict_by_org && length(var.s3_vpc_endpoint_resource_account_ids) > 0
-  s3_vpc_endpoint_restricted          = local.s3_vpc_endpoint_restrict_by_org || local.s3_vpc_endpoint_restrict_by_account
+  s3_vpc_endpoint_has_org_ids     = length(var.s3_vpc_endpoint_resource_org_ids) > 0
+  s3_vpc_endpoint_has_account_ids = length(var.s3_vpc_endpoint_resource_account_ids) > 0
+  s3_vpc_endpoint_restricted      = local.s3_vpc_endpoint_has_org_ids || local.s3_vpc_endpoint_has_account_ids
 
-  # Always include this account so module-owned buckets keep working.
+  # Always include this account so module-owned buckets keep working (org and/or account mode).
   s3_vpc_endpoint_account_ids = distinct(concat(
     var.s3_vpc_endpoint_resource_account_ids,
     [data.aws_caller_identity.current.account_id]
   ))
 
-  s3_vpc_endpoint_customer_statements = (
-    local.s3_vpc_endpoint_restrict_by_org ? [
+  # Org and account allowlists compose (union of Allows), so cross-org export destinations
+  # can be allowlisted by account even when org IDs are also set.
+  s3_vpc_endpoint_customer_statements = !local.s3_vpc_endpoint_restricted ? [
+    {
+      Effect    = "Allow"
+      Action    = ["s3:*"]
+      Principal = "*"
+      Resource  = ["*"]
+    }
+    ] : concat(
+    local.s3_vpc_endpoint_has_org_ids ? [
       {
         Sid       = "AllowS3InAllowedOrganizations"
         Effect    = "Allow"
@@ -34,21 +43,9 @@ locals {
             "aws:ResourceOrgID" = var.s3_vpc_endpoint_resource_org_ids
           }
         }
-      },
-      # Safety net: module buckets live in this account even if org list is wrong.
-      {
-        Sid       = "AllowS3InCurrentAccount"
-        Effect    = "Allow"
-        Action    = ["s3:*"]
-        Principal = "*"
-        Resource  = ["*"]
-        Condition = {
-          StringEquals = {
-            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
-          }
-        }
       }
-      ] : local.s3_vpc_endpoint_restrict_by_account ? [
+    ] : [],
+    [
       {
         Sid       = "AllowS3InAllowedAccounts"
         Effect    = "Allow"
@@ -61,16 +58,13 @@ locals {
           }
         }
       }
-      ] : [
-      {
-        Effect    = "Allow"
-        Action    = ["s3:*"]
-        Principal = "*"
-        Resource  = ["*"]
-      }
-  ])
+    ]
+  )
 
-  # Amazon-owned buckets required when the endpoint is restricted (ECR layers + CW agent .deb).
+  # Amazon-owned buckets needed when restricted:
+  # - ECR starport: private ECR layer pulls (defaults use public.ecr.aws over NAT/CloudFront;
+  #   this covers private ECR / custom container_image overrides).
+  # - CloudWatch agent: Brainstore user-data .deb from s3.amazonaws.com/amazoncloudwatch-agent/...
   s3_vpc_endpoint_aws_service_statements = local.s3_vpc_endpoint_restricted ? [
     {
       Sid       = "AllowECRStarportLayerBucket"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,4 +1,5 @@
 data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
 
 locals {
   common_tags = merge({
@@ -9,6 +10,88 @@ locals {
     "ssmmessages" : "com.amazonaws.${data.aws_region.current.region}.ssmmessages",
     "ec2messages" : "com.amazonaws.${data.aws_region.current.region}.ec2messages",
   }
+
+  s3_vpc_endpoint_restrict_by_org     = length(var.s3_vpc_endpoint_resource_org_ids) > 0
+  s3_vpc_endpoint_restrict_by_account = !local.s3_vpc_endpoint_restrict_by_org && length(var.s3_vpc_endpoint_resource_account_ids) > 0
+  s3_vpc_endpoint_restricted          = local.s3_vpc_endpoint_restrict_by_org || local.s3_vpc_endpoint_restrict_by_account
+
+  # Always include this account so module-owned buckets keep working.
+  s3_vpc_endpoint_account_ids = distinct(concat(
+    var.s3_vpc_endpoint_resource_account_ids,
+    [data.aws_caller_identity.current.account_id]
+  ))
+
+  s3_vpc_endpoint_customer_statements = (
+    local.s3_vpc_endpoint_restrict_by_org ? [
+      {
+        Sid       = "AllowS3InAllowedOrganizations"
+        Effect    = "Allow"
+        Action    = ["s3:*"]
+        Principal = "*"
+        Resource  = ["*"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceOrgID" = var.s3_vpc_endpoint_resource_org_ids
+          }
+        }
+      },
+      # Safety net: module buckets live in this account even if org list is wrong.
+      {
+        Sid       = "AllowS3InCurrentAccount"
+        Effect    = "Allow"
+        Action    = ["s3:*"]
+        Principal = "*"
+        Resource  = ["*"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+      ] : local.s3_vpc_endpoint_restrict_by_account ? [
+      {
+        Sid       = "AllowS3InAllowedAccounts"
+        Effect    = "Allow"
+        Action    = ["s3:*"]
+        Principal = "*"
+        Resource  = ["*"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = local.s3_vpc_endpoint_account_ids
+          }
+        }
+      }
+      ] : [
+      {
+        Effect    = "Allow"
+        Action    = ["s3:*"]
+        Principal = "*"
+        Resource  = ["*"]
+      }
+  ])
+
+  # Amazon-owned buckets required when the endpoint is restricted (ECR layers + CW agent .deb).
+  s3_vpc_endpoint_aws_service_statements = local.s3_vpc_endpoint_restricted ? [
+    {
+      Sid       = "AllowECRStarportLayerBucket"
+      Effect    = "Allow"
+      Action    = ["s3:GetObject"]
+      Principal = "*"
+      Resource  = ["arn:aws:s3:::prod-${data.aws_region.current.region}-starport-layer-bucket/*"]
+    },
+    {
+      Sid       = "AllowCloudWatchAgentBucket"
+      Effect    = "Allow"
+      Action    = ["s3:GetObject"]
+      Principal = "*"
+      Resource  = ["arn:aws:s3:::amazoncloudwatch-agent/*"]
+    }
+  ] : []
+
+  s3_vpc_endpoint_statements = concat(
+    local.s3_vpc_endpoint_customer_statements,
+    local.s3_vpc_endpoint_aws_service_statements
+  )
 }
 
 resource "aws_vpc" "vpc" {
@@ -161,15 +244,8 @@ resource "aws_vpc_endpoint" "s3" {
   route_table_ids   = [aws_route_table.private_route_table.id]
 
   policy = jsonencode({ # nosemgrep
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect    = "Allow",
-        Action    = ["s3:*"],
-        Principal = "*",
-        Resource  = ["*"]
-      }
-    ]
+    Version   = "2012-10-17",
+    Statement = local.s3_vpc_endpoint_statements
   })
 
   tags = merge({

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -69,7 +69,7 @@ variable "s3_vpc_endpoint_resource_org_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
-    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    Composes with s3_vpc_endpoint_resource_account_ids (union of Allow statements).
     When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
   EOT
   default     = []
@@ -87,9 +87,9 @@ variable "s3_vpc_endpoint_resource_account_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
-    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    Composes with s3_vpc_endpoint_resource_org_ids (union of Allow statements).
     When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
-    The current AWS account is always included automatically when this restriction is active.
+    The current AWS account is always included automatically when either restriction list is non-empty.
   EOT
   default     = []
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -64,3 +64,40 @@ variable "enable_brainstore_ec2_ssm" {
   type        = bool
   default     = false
 }
+
+variable "s3_vpc_endpoint_resource_org_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
+    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for org_id in var.s3_vpc_endpoint_resource_org_ids :
+      can(regex("^o-[a-z0-9]{10,32}$", org_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_org_ids entries must be AWS Organization IDs of the form o-<10-32 lowercase alphanumeric characters>."
+  }
+}
+
+variable "s3_vpc_endpoint_resource_account_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
+    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
+    The current AWS account is always included automatically when this restriction is active.
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for account_id in var.s3_vpc_endpoint_resource_account_ids :
+      can(regex("^[0-9]{12}$", account_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_account_ids entries must be 12-digit AWS account IDs."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1237,7 +1237,7 @@ variable "s3_export_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.s3_export_assume_role_arns :
-      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "s3_export_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
   }
@@ -1257,7 +1257,7 @@ variable "ai_gateway_bedrock_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.ai_gateway_bedrock_assume_role_arns :
-      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "ai_gateway_bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1267,14 +1267,16 @@ variable "s3_vpc_endpoint_resource_org_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
-    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    Composes with s3_vpc_endpoint_resource_account_ids (union of Allow statements) so you can allow an
+    org and also specific accounts (e.g. cross-org export destinations).
     When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
 
     Restricting the endpoint applies to all S3 access via the gateway (Brainstore, code bundles, lambda responses, and export).
-    Listed orgs should include this dataplane account's organization. Terraform also always allows
-    aws:ResourceAccount for the current account so module-owned buckets keep working.
-    When restricted, the policy also allows GetObject to the regional ECR starport layer bucket and
-    the amazoncloudwatch-agent bucket (required for image pulls and Brainstore user-data).
+    The current AWS account is always allowed via aws:ResourceAccount when either list is non-empty.
+    When restricted, the policy also allows GetObject to:
+      - the regional ECR starport layer bucket (private ECR image layers; defaults use public.ecr.aws)
+      - the amazoncloudwatch-agent bucket (Brainstore user-data .deb install)
+    Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
     Only applies when create_vpc is true (module-managed VPC endpoints).
   EOT
@@ -1293,13 +1295,14 @@ variable "s3_vpc_endpoint_resource_account_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
-    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    Composes with s3_vpc_endpoint_resource_org_ids (union of Allow statements).
     When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
 
     Restricting the endpoint applies to all S3 access via the gateway. List additional accounts that
     should be reachable (e.g. export destinations); the current AWS account is always included
-    automatically. When restricted, the policy also allows GetObject to the regional ECR starport
-    layer bucket and the amazoncloudwatch-agent bucket.
+    automatically when either restriction list is non-empty. When restricted, the policy also allows
+    GetObject to the regional ECR starport layer bucket and the amazoncloudwatch-agent bucket.
+    Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
     Only applies when create_vpc is true (module-managed VPC endpoints).
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -1217,14 +1217,16 @@ variable "s3_vpc_endpoint_resource_org_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
-    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    Composes with s3_vpc_endpoint_resource_account_ids (union of Allow statements) so you can allow an
+    org and also specific accounts (e.g. cross-org export destinations).
     When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
 
     Restricting the endpoint applies to all S3 access via the gateway (Brainstore, code bundles, lambda responses, and export).
-    Listed orgs should include this dataplane account's organization. Terraform also always allows
-    aws:ResourceAccount for the current account so module-owned buckets keep working.
-    When restricted, the policy also allows GetObject to the regional ECR starport layer bucket and
-    the amazoncloudwatch-agent bucket (required for image pulls and Brainstore user-data).
+    The current AWS account is always allowed via aws:ResourceAccount when either list is non-empty.
+    When restricted, the policy also allows GetObject to:
+      - the regional ECR starport layer bucket (private ECR image layers; defaults use public.ecr.aws)
+      - the amazoncloudwatch-agent bucket (Brainstore user-data .deb install)
+    Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
     Only applies when create_vpc is true (module-managed VPC endpoints).
   EOT
@@ -1243,13 +1245,14 @@ variable "s3_vpc_endpoint_resource_account_ids" {
   type        = list(string)
   description = <<-EOT
     Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
-    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    Composes with s3_vpc_endpoint_resource_org_ids (union of Allow statements).
     When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
 
     Restricting the endpoint applies to all S3 access via the gateway. List additional accounts that
     should be reachable (e.g. export destinations); the current AWS account is always included
-    automatically. When restricted, the policy also allows GetObject to the regional ECR starport
-    layer bucket and the amazoncloudwatch-agent bucket.
+    automatically when either restriction list is non-empty. When restricted, the policy also allows
+    GetObject to the regional ECR starport layer bucket and the amazoncloudwatch-agent bucket.
+    Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
     Only applies when create_vpc is true (module-managed VPC endpoints).
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -1187,7 +1187,7 @@ variable "s3_export_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.s3_export_assume_role_arns :
-      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "s3_export_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
   }
@@ -1207,9 +1207,60 @@ variable "ai_gateway_bedrock_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.ai_gateway_bedrock_assume_role_arns :
-      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "ai_gateway_bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}
+
+variable "s3_vpc_endpoint_resource_org_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
+    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
+
+    Restricting the endpoint applies to all S3 access via the gateway (Brainstore, code bundles, lambda responses, and export).
+    Listed orgs should include this dataplane account's organization. Terraform also always allows
+    aws:ResourceAccount for the current account so module-owned buckets keep working.
+    When restricted, the policy also allows GetObject to the regional ECR starport layer bucket and
+    the amazoncloudwatch-agent bucket (required for image pulls and Brainstore user-data).
+
+    Only applies when create_vpc is true (module-managed VPC endpoints).
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for org_id in var.s3_vpc_endpoint_resource_org_ids :
+      can(regex("^o-[a-z0-9]{10,32}$", org_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_org_ids entries must be AWS Organization IDs of the form o-<10-32 lowercase alphanumeric characters>."
+  }
+}
+
+variable "s3_vpc_endpoint_resource_account_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
+    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
+
+    Restricting the endpoint applies to all S3 access via the gateway. List additional accounts that
+    should be reachable (e.g. export destinations); the current AWS account is always included
+    automatically. When restricted, the policy also allows GetObject to the regional ECR starport
+    layer bucket and the amazoncloudwatch-agent bucket.
+
+    Only applies when create_vpc is true (module-managed VPC endpoints).
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for account_id in var.s3_vpc_endpoint_resource_account_ids :
+      can(regex("^[0-9]{12}$", account_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_account_ids entries must be 12-digit AWS account IDs."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1237,7 +1237,7 @@ variable "s3_export_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.s3_export_assume_role_arns :
-      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "s3_export_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
   }
@@ -1257,9 +1257,60 @@ variable "ai_gateway_bedrock_assume_role_arns" {
   validation {
     condition = alltrue([
       for arn in var.ai_gateway_bedrock_assume_role_arns :
-      can(regex("^arn:aws:iam::(\\*|[0-9]{12}):role/.+$", arn))
+      can(regex("^arn:aws:iam::(\*|[0-9]{12}):role/.+$", arn))
     ])
     error_message = "ai_gateway_bedrock_assume_role_arns entries must be IAM role ARNs or ARN patterns of the form arn:aws:iam::<account-id|*>:role/<role-name-or-pattern>."
+  }
+}
+
+variable "s3_vpc_endpoint_resource_org_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS Organization IDs for the S3 VPC gateway endpoint policy (aws:ResourceOrgID).
+    When non-empty, takes precedence over s3_vpc_endpoint_resource_account_ids.
+    When both this and s3_vpc_endpoint_resource_account_ids are empty (default), the endpoint allows all S3 traffic.
+
+    Restricting the endpoint applies to all S3 access via the gateway (Brainstore, code bundles, lambda responses, and export).
+    Listed orgs should include this dataplane account's organization. Terraform also always allows
+    aws:ResourceAccount for the current account so module-owned buckets keep working.
+    When restricted, the policy also allows GetObject to the regional ECR starport layer bucket and
+    the amazoncloudwatch-agent bucket (required for image pulls and Brainstore user-data).
+
+    Only applies when create_vpc is true (module-managed VPC endpoints).
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for org_id in var.s3_vpc_endpoint_resource_org_ids :
+      can(regex("^o-[a-z0-9]{10,32}$", org_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_org_ids entries must be AWS Organization IDs of the form o-<10-32 lowercase alphanumeric characters>."
+  }
+}
+
+variable "s3_vpc_endpoint_resource_account_ids" {
+  type        = list(string)
+  description = <<-EOT
+    Optional allowlist of AWS account IDs for the S3 VPC gateway endpoint policy (aws:ResourceAccount).
+    Used only when s3_vpc_endpoint_resource_org_ids is empty; ignored when org IDs are set.
+    When both this and s3_vpc_endpoint_resource_org_ids are empty (default), the endpoint allows all S3 traffic.
+
+    Restricting the endpoint applies to all S3 access via the gateway. List additional accounts that
+    should be reachable (e.g. export destinations); the current AWS account is always included
+    automatically. When restricted, the policy also allows GetObject to the regional ECR starport
+    layer bucket and the amazoncloudwatch-agent bucket.
+
+    Only applies when create_vpc is true (module-managed VPC endpoints).
+  EOT
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for account_id in var.s3_vpc_endpoint_resource_account_ids :
+      can(regex("^[0-9]{12}$", account_id))
+    ])
+    error_message = "s3_vpc_endpoint_resource_account_ids entries must be 12-digit AWS account IDs."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1278,7 +1278,9 @@ variable "s3_vpc_endpoint_resource_org_ids" {
       - the amazoncloudwatch-agent bucket (Brainstore user-data .deb install)
     Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
-    Only applies when create_vpc is true (module-managed VPC endpoints).
+    Applies to any module-managed S3 VPC gateway endpoint (main VPC when create_vpc is true, and
+    quarantine VPC when enable_quarantine_vpc is true and existing_quarantine_vpc_id is unset).
+    Does not modify customer-managed endpoints on existing_* VPC IDs.
   EOT
   default     = []
 
@@ -1304,7 +1306,9 @@ variable "s3_vpc_endpoint_resource_account_ids" {
     GetObject to the regional ECR starport layer bucket and the amazoncloudwatch-agent bucket.
     Adding new same-region AWS-owned S3 dependencies later requires a matching endpoint exception.
 
-    Only applies when create_vpc is true (module-managed VPC endpoints).
+    Applies to any module-managed S3 VPC gateway endpoint (main VPC when create_vpc is true, and
+    quarantine VPC when enable_quarantine_vpc is true and existing_quarantine_vpc_id is unset).
+    Does not modify customer-managed endpoints on existing_* VPC IDs.
   EOT
   default     = []
 


### PR DESCRIPTION
## Summary
- Adds `s3_vpc_endpoint_resource_org_ids` / `s3_vpc_endpoint_resource_account_ids` (compose as a union of Allows; empty both = unrestricted)
- When restricted: allowlisted orgs and/or accounts via `aws:ResourceOrgID` / `aws:ResourceAccount`, with the current account always included
- When restricted: automatic `s3:GetObject` exceptions for regional ECR starport (private ECR / image overrides; defaults use public.ecr.aws) and `amazoncloudwatch-agent` (Brainstore user-data)
- Applied to any module-managed S3 VPC gateway endpoint (main when `create_vpc`, and quarantine when `enable_quarantine_vpc` with no `existing_quarantine_vpc_id`); does not modify customer-managed `existing_*` endpoints
- Builds the endpoint policy via `aws_iam_policy_document` to avoid Terraform inconsistent conditional types between unrestricted and restricted statement shapes

## Test plan
- [x] `mise run lint` / `mise run validate`
- [x] Empty lists → single unrestricted Allow (no policy change)
- [x] Account-only → current account + listed accounts + starport + CW agent
- [x] Org-only → ResourceOrgID + current-account Allow + starport + CW agent
- [x] Org + account → both customer Allows (union) + starport + CW agent
- [x] Sandbox: GetObject to a non-allowlisted same-region account fails at the endpoint (primary security check)
- [x] Sandbox: module bucket R/W and Brainstore CW agent download still work
- [x] Optional: starport GetObject path reachable under restriction (missing-key returns bucket AccessDenied, not a blocked route); full private ECR image pull not exercised (defaults use public.ecr.aws)

### Live verification (`erikdw-sandbox`, Brainstore writer via SSM + instance-profile creds)
Temporarily applied account-only restricted policy to main + quarantine S3 VPC endpoints, then restored unrestricted.

| Check | Result |
|---|---|
| Put/Get module Brainstore bucket | ALLOW |
| Unsigned GetObject `amazoncloudwatch-agent` RPM (~69MB) | ALLOW (HTTP 200) |
| GetObject public object in other account (`us-west-2` temp bucket in 872608195481; laptop HTTP 200) | DENY from VPC (HTTP 403) |
| Endpoints restored to unrestricted | done |

Fixes https://linear.app/braintrustdata/issue/INF-203