### PR TITLE
use lambda ai proxy instead of braintrust hosted gateway

### DIFF
--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -96,7 +96,7 @@ module "loop_runtime_ecs" {
   code_bundle_bucket_arn    = module.storage.code_bundle_bucket_arn
 
   brainstore_reader_url = local.loop_runtime_brainstore_reader_url
-  ai_proxy_url          = local.self_hosted_ai_proxy_url
+  ai_proxy_url          = local.api_ecs_ai_proxy_url
   braintrust_api_url    = module.ingress[0].api_url
 
   # Shared Brainstore WAL format + lock prefix — must match the API/Brainstore writers.

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -96,7 +96,7 @@ module "loop_runtime_ecs" {
   code_bundle_bucket_arn    = module.storage.code_bundle_bucket_arn
 
   brainstore_reader_url = local.loop_runtime_brainstore_reader_url
-  ai_proxy_url          = local.api_ecs_ai_proxy_url
+  ai_proxy_url          = local.self_hosted_ai_proxy_url
   braintrust_api_url    = module.ingress[0].api_url
 
   # Shared Brainstore WAL format + lock prefix — must match the API/Brainstore writers.

--- a/main.tf
+++ b/main.tf
@@ -70,9 +70,11 @@ locals {
     : local.brainstore_ai_proxy_url_ssm_parameter_name
   )
 
-  # Quarantine and Loop Runtime use the self-hosted AI Proxy Lambda Function URL.
-  # one() keeps this index-safe when services is absent.
-  self_hosted_ai_proxy_url = one(module.services[*].ai_proxy_url)
+  # Quarantine uses the self-hosted AI Proxy Lambda Function URL.
+  quarantine_ai_proxy_url = one(module.services[*].ai_proxy_url)
+
+  # When the ECS API is active, Loop Runtime uses the braintrust-hosted AI gateway.
+  api_ecs_ai_proxy_url = local.enable_ecs_api ? "https://${trimsuffix(replace(var.global_ai_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")}/v1/proxy" : one(module.services[*].ai_proxy_url)
   gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.gateway_alb[0].gateway_url
   } : {}
@@ -475,7 +477,7 @@ module "api_ecs" {
   quarantine_invoke_role_arn          = module.services_common.quarantine_invoke_role_arn
   quarantine_function_role_arn        = module.services_common.quarantine_function_role_arn
   quarantine_lambda_security_group_id = module.services_common.quarantine_lambda_security_group_id
-  quarantine_proxy_url                = local.self_hosted_ai_proxy_url
+  quarantine_proxy_url                = local.quarantine_ai_proxy_url
 
   # Networking
   vpc_id             = local.main_vpc_id

--- a/main.tf
+++ b/main.tf
@@ -70,10 +70,9 @@ locals {
     : local.brainstore_ai_proxy_url_ssm_parameter_name
   )
 
-  # When the ECS API is active, quarantine / in-VPC callers use the global AI
-  # gateway origin for proxy traffic instead of the AI Proxy Lambda. one() keeps
-  # this index-safe when services is absent (use_deployment_mode_external_eks).
-  api_ecs_ai_proxy_url = local.enable_ecs_api ? "https://${trimsuffix(replace(var.global_ai_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")}/v1/proxy" : one(module.services[*].ai_proxy_url)
+  # Quarantine and Loop Runtime use the self-hosted AI Proxy Lambda Function URL.
+  # one() keeps this index-safe when services is absent.
+  self_hosted_ai_proxy_url = one(module.services[*].ai_proxy_url)
   gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.gateway_alb[0].gateway_url
   } : {}
@@ -476,7 +475,7 @@ module "api_ecs" {
   quarantine_invoke_role_arn          = module.services_common.quarantine_invoke_role_arn
   quarantine_function_role_arn        = module.services_common.quarantine_function_role_arn
   quarantine_lambda_security_group_id = module.services_common.quarantine_lambda_security_group_id
-  quarantine_proxy_url                = local.api_ecs_ai_proxy_url
+  quarantine_proxy_url                = local.self_hosted_ai_proxy_url
 
   # Networking
   vpc_id             = local.main_vpc_id


### PR DESCRIPTION
## Description 
Routes quarantine llm traffic through the customer-hosted AI Proxy Lambda instead of the Braintrust-hosted gateway. This keeps traffic within the customer AWS account.

## Context 
Flipping `enable_ecs_api = true` today will start sending the quarantine LLM traffic to the Braintrust hosted gateway as the AI proxy running on ECS is not accessible from the quarantine VPC. This will be fixed in the future with the AI Gateway being mandatory and additional networking. 

## Testing 
Deployed in lab and testing quarantine functions. 
