### PR TITLE
Opt-in s3 access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ See the [`examples/cloudfront-logging`](examples/cloudfront-logging) directory f
 S3 server access logging is disabled by default. Enable it to deliver access logs from the brainstore, code-bundle, and lambda-responses buckets to an S3 bucket you own. This is commonly used for audit and compliance requirements.
 
 ```hcl
-s3_server_access_logging_bucket = "your-audit-logs-bucket"
-# Optional. Defaults to "<deployment_name>/". Per-bucket suffixes are appended.
-# s3_server_access_logging_prefix = "braintrust/"
+s3_server_access_logging = {
+  bucket = "your-audit-logs-bucket"
+  # Optional. Defaults to "<deployment_name>/". Per-bucket suffixes are appended.
+  # prefix = "braintrust/"
+}
 ```
 
 The destination bucket must:
@@ -133,7 +135,7 @@ The destination bucket must:
 
 Restrict access to the destination bucket. Access logs can include object keys and requester information.
 
-Attach a bucket policy like the following to the destination bucket. Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names. The `Resource` prefix must match `s3_server_access_logging_prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
+Attach a bucket policy like the following to the destination bucket. Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names. The `Resource` prefix must match `s3_server_access_logging.prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
 
 ```hcl
 data "aws_caller_identity" "current" {}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ See the [`examples/cloudfront-logging`](examples/cloudfront-logging) directory f
 
 S3 server access logging is disabled by default. Enable it to deliver access logs from the brainstore, code-bundle, and lambda-responses buckets to an S3 bucket you own. This is commonly used for audit and compliance requirements.
 
+Enable logging in this order. The destination policy must already be in place before you set `s3_server_access_logging`; this module only configures the source buckets and cannot depend on a policy you manage outside it.
+
+1. Create the destination bucket (same AWS account and region as the data plane). It must not have Object Lock or Requester Pays enabled, and default encryption must be SSE-S3 (AES256). SSE-KMS prevents Amazon S3 from delivering logs you can decrypt.
+2. Deploy the data plane (or use an existing deployment) so the source bucket name outputs are available.
+3. Attach a bucket policy on the destination bucket that grants `s3:PutObject` to `logging.s3.amazonaws.com` (see below). Restrict access to the destination bucket; access logs can include object keys and requester information.
+4. Only after that policy is applied, set `s3_server_access_logging` and apply again:
+
 ```hcl
 s3_server_access_logging = {
   bucket = "your-audit-logs-bucket"
@@ -126,16 +133,7 @@ s3_server_access_logging = {
 }
 ```
 
-The destination bucket must:
-
-- Be in the same AWS account and region as the data plane
-- Not have Object Lock or Requester Pays enabled
-- Use SSE-S3 (AES256) default encryption. SSE-KMS prevents Amazon S3 from delivering logs you can decrypt
-- Grant `s3:PutObject` to the `logging.s3.amazonaws.com` service principal
-
-Restrict access to the destination bucket. Access logs can include object keys and requester information.
-
-Attach a bucket policy like the following to the destination bucket. Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names. The `Resource` prefix must match `s3_server_access_logging.prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
+Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names in the destination policy. The `Resource` prefix must match `s3_server_access_logging.prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
 
 ```hcl
 data "aws_caller_identity" "current" {}
@@ -169,6 +167,11 @@ data "aws_iam_policy_document" "s3_server_access_logs" {
       values   = [data.aws_caller_identity.current.account_id]
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "s3_server_access_logs" {
+  bucket = "your-audit-logs-bucket"
+  policy = data.aws_iam_policy_document.s3_server_access_logs.json
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,16 @@ Enable logging in this order. The destination policy must already be in place be
 1. Create the destination bucket (same AWS account and region as the data plane). It must not have Object Lock or Requester Pays enabled, and default encryption must be SSE-S3 (AES256). SSE-KMS prevents Amazon S3 from delivering logs you can decrypt.
 2. Deploy the data plane (or use an existing deployment) so the source bucket name outputs are available.
 3. Attach a bucket policy on the destination bucket that grants `s3:PutObject` to `logging.s3.amazonaws.com` (see below). Restrict access to the destination bucket; access logs can include object keys and requester information.
-4. Only after that policy is applied, set `s3_server_access_logging` and apply again:
+4. Only after that policy is applied, set `s3_server_access_logging` and apply again. Use the same prefix as the destination policy `Resource` path (`braintrust/` in the example below). If you omit `prefix`, the module defaults to `<deployment_name>/`, and the policy path must match that instead. Per-bucket suffixes (`brainstore/`, `code-bundle/`, `lambda-responses/`) are appended under the prefix; `braintrust/*` already covers them, so no extra policy statements are needed.
 
 ```hcl
 s3_server_access_logging = {
   bucket = "your-audit-logs-bucket"
-  # Optional. Defaults to "<deployment_name>/". Per-bucket suffixes are appended.
-  # prefix = "braintrust/"
+  prefix = "braintrust/"
 }
 ```
 
-Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names in the destination policy. The `Resource` prefix must match `s3_server_access_logging.prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
+Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names in the destination policy. The `Resource` prefix must match `s3_server_access_logging.prefix` (default `<deployment_name>/` when omitted). Any `Deny` statements on the destination bucket must not block log delivery.
 
 ```hcl
 data "aws_caller_identity" "current" {}

--- a/README.md
+++ b/README.md
@@ -114,6 +114,68 @@ If you need to enable CloudFront standard access logging, you can configure it i
 
 See the [`examples/cloudfront-logging`](examples/cloudfront-logging) directory for a complete example showing how to set up V2 logging to S3.
 
+### S3 Server Access Logging
+
+S3 server access logging is disabled by default. Enable it to deliver access logs from the brainstore, code-bundle, and lambda-responses buckets to an S3 bucket you own. This is commonly used for audit and compliance requirements.
+
+```hcl
+s3_server_access_logging_bucket = "your-audit-logs-bucket"
+# Optional. Defaults to "<deployment_name>/". Per-bucket suffixes are appended.
+# s3_server_access_logging_prefix = "braintrust/"
+```
+
+The destination bucket must:
+
+- Be in the same AWS account and region as the data plane
+- Not have Object Lock or Requester Pays enabled
+- Use SSE-S3 (AES256) default encryption. SSE-KMS prevents Amazon S3 from delivering logs you can decrypt
+- Grant `s3:PutObject` to the `logging.s3.amazonaws.com` service principal
+
+Restrict access to the destination bucket. Access logs can include object keys and requester information.
+
+Attach a bucket policy like the following to the destination bucket. Use the `brainstore_s3_bucket_name`, `code_bundle_s3_bucket_name`, and `lambda_responses_s3_bucket_name` outputs for the source bucket names. The `Resource` prefix must match `s3_server_access_logging_prefix` (default `<deployment_name>/`). Any `Deny` statements on the destination bucket must not block log delivery.
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "s3_server_access_logs" {
+  statement {
+    sid    = "S3ServerAccessLogsPolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::your-audit-logs-bucket/braintrust/*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:s3:::${module.braintrust-data-plane.brainstore_s3_bucket_name}",
+        "arn:aws:s3:::${module.braintrust-data-plane.code_bundle_s3_bucket_name}",
+        "arn:aws:s3:::${module.braintrust-data-plane.lambda_responses_s3_bucket_name}",
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+```
+
+Logs are written with a date-partitioned key format:
+
+`<prefix><bucket-role>/<SourceAccountId>/<SourceRegion>/<SourceBucket>/<YYYY>/<MM>/<DD>/...`
+
+For example, `braintrust/brainstore/<account>/<region>/<bucket>/2026/08/12/...`. First log delivery can take a few hours after you enable logging.
+
 ### Using an Existing VPC
 
 The module supports using an existing VPC instead of creating a new dedicated one for the Braintrust services. This is useful when you want to integrate Braintrust into your existing network infrastructure.

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -146,8 +146,10 @@ module "braintrust-data-plane" {
   # account and region. The destination bucket must grant s3:PutObject to
   # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
   # See the module README "S3 Server Access Logging" section for the required bucket policy.
-  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
-  # s3_server_access_logging_prefix = "braintrust/"
+  # s3_server_access_logging = {
+  #   bucket = "your-audit-logs-bucket"
+  #   prefix = "braintrust/"
+  # }
 
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -142,10 +142,10 @@ module "braintrust-data-plane" {
   # s3_lambda_responses_additional_allowed_origins = []
 
   # Opt-in: S3 server access logging for the brainstore, code-bundle, and
-  # lambda-responses buckets. Logs are written to a bucket you own in the same
-  # account and region. The destination bucket must grant s3:PutObject to
-  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
-  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # lambda-responses buckets. Attach the destination bucket policy (grant
+  # s3:PutObject to logging.s3.amazonaws.com) before enabling this. Destination
+  # must use SSE-S3 (AES256), not SSE-KMS. See the module README "S3 Server
+  # Access Logging" section for the required order and policy.
   # s3_server_access_logging = {
   #   bucket = "your-audit-logs-bucket"
   #   prefix = "braintrust/"

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -141,6 +141,14 @@ module "braintrust-data-plane" {
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
 
+  # Opt-in: S3 server access logging for the brainstore, code-bundle, and
+  # lambda-responses buckets. Logs are written to a bucket you own in the same
+  # account and region. The destination bucket must grant s3:PutObject to
+  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
+  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
+  # s3_server_access_logging_prefix = "braintrust/"
+
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [
   #   "arn:aws:iam::123456789012:role/customer-export-role",

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -124,10 +124,10 @@ module "braintrust-data-plane" {
   # s3_lambda_responses_additional_allowed_origins = []
 
   # Opt-in: S3 server access logging for the brainstore, code-bundle, and
-  # lambda-responses buckets. Logs are written to a bucket you own in the same
-  # account and region. The destination bucket must grant s3:PutObject to
-  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
-  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # lambda-responses buckets. Attach the destination bucket policy (grant
+  # s3:PutObject to logging.s3.amazonaws.com) before enabling this. Destination
+  # must use SSE-S3 (AES256), not SSE-KMS. See the module README "S3 Server
+  # Access Logging" section for the required order and policy.
   # s3_server_access_logging = {
   #   bucket = "your-audit-logs-bucket"
   #   prefix = "braintrust/"

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -123,6 +123,14 @@ module "braintrust-data-plane" {
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
 
+  # Opt-in: S3 server access logging for the brainstore, code-bundle, and
+  # lambda-responses buckets. Logs are written to a bucket you own in the same
+  # account and region. The destination bucket must grant s3:PutObject to
+  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
+  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
+  # s3_server_access_logging_prefix = "braintrust/"
+
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [
   #   "arn:aws:iam::123456789012:role/customer-export-role",

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -128,8 +128,10 @@ module "braintrust-data-plane" {
   # account and region. The destination bucket must grant s3:PutObject to
   # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
   # See the module README "S3 Server Access Logging" section for the required bucket policy.
-  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
-  # s3_server_access_logging_prefix = "braintrust/"
+  # s3_server_access_logging = {
+  #   bucket = "your-audit-logs-bucket"
+  #   prefix = "braintrust/"
+  # }
 
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -171,8 +171,10 @@ module "braintrust-data-plane" {
   # account and region. The destination bucket must grant s3:PutObject to
   # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
   # See the module README "S3 Server Access Logging" section for the required bucket policy.
-  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
-  # s3_server_access_logging_prefix = "braintrust/"
+  # s3_server_access_logging = {
+  #   bucket = "your-audit-logs-bucket"
+  #   prefix = "braintrust/"
+  # }
 
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -167,10 +167,10 @@ module "braintrust-data-plane" {
   # s3_lambda_responses_additional_allowed_origins = []
 
   # Opt-in: S3 server access logging for the brainstore, code-bundle, and
-  # lambda-responses buckets. Logs are written to a bucket you own in the same
-  # account and region. The destination bucket must grant s3:PutObject to
-  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
-  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # lambda-responses buckets. Attach the destination bucket policy (grant
+  # s3:PutObject to logging.s3.amazonaws.com) before enabling this. Destination
+  # must use SSE-S3 (AES256), not SSE-KMS. See the module README "S3 Server
+  # Access Logging" section for the required order and policy.
   # s3_server_access_logging = {
   #   bucket = "your-audit-logs-bucket"
   #   prefix = "braintrust/"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -166,6 +166,14 @@ module "braintrust-data-plane" {
   # s3_code_bundle_additional_allowed_origins      = []
   # s3_lambda_responses_additional_allowed_origins = []
 
+  # Opt-in: S3 server access logging for the brainstore, code-bundle, and
+  # lambda-responses buckets. Logs are written to a bucket you own in the same
+  # account and region. The destination bucket must grant s3:PutObject to
+  # logging.s3.amazonaws.com and use SSE-S3 (AES256) default encryption, not SSE-KMS.
+  # See the module README "S3 Server Access Logging" section for the required bucket policy.
+  # s3_server_access_logging_bucket = "your-audit-logs-bucket"
+  # s3_server_access_logging_prefix = "braintrust/"
+
   # Opt-in: bound S3 export AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # s3_export_assume_role_arns = [
   #   "arn:aws:iam::123456789012:role/customer-export-role",

--- a/main.tf
+++ b/main.tf
@@ -223,8 +223,7 @@ module "storage" {
   s3_code_bundle_additional_allowed_origins      = var.s3_code_bundle_additional_allowed_origins
   s3_lambda_responses_additional_allowed_origins = var.s3_lambda_responses_additional_allowed_origins
   enable_s3_bucket_abac                          = var.enable_s3_bucket_abac
-  s3_server_access_logging_bucket                = var.s3_server_access_logging_bucket
-  s3_server_access_logging_prefix                = var.s3_server_access_logging_prefix
+  s3_server_access_logging                       = var.s3_server_access_logging
   custom_tags                                    = local.all_custom_tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,8 @@ module "storage" {
   s3_code_bundle_additional_allowed_origins      = var.s3_code_bundle_additional_allowed_origins
   s3_lambda_responses_additional_allowed_origins = var.s3_lambda_responses_additional_allowed_origins
   enable_s3_bucket_abac                          = var.enable_s3_bucket_abac
+  s3_server_access_logging_bucket                = var.s3_server_access_logging_bucket
+  s3_server_access_logging_prefix                = var.s3_server_access_logging_prefix
   custom_tags                                    = local.all_custom_tags
 }
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -21,4 +21,13 @@ locals {
   common_tags = merge({
     BraintrustDeploymentName = var.deployment_name
   }, var.custom_tags)
+
+  s3_server_access_logging_enabled = var.s3_server_access_logging_bucket != null && var.s3_server_access_logging_bucket != ""
+  s3_server_access_logging_prefix  = var.s3_server_access_logging_prefix != null ? var.s3_server_access_logging_prefix : "${var.deployment_name}/"
+
+  s3_server_access_logging_buckets = {
+    brainstore       = aws_s3_bucket.brainstore.id
+    code-bundle      = aws_s3_bucket.code_bundle_bucket.id
+    lambda-responses = aws_s3_bucket.lambda_responses_bucket.id
+  }
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -22,8 +22,14 @@ locals {
     BraintrustDeploymentName = var.deployment_name
   }, var.custom_tags)
 
-  s3_server_access_logging_enabled = var.s3_server_access_logging_bucket != null && var.s3_server_access_logging_bucket != ""
-  s3_server_access_logging_prefix  = var.s3_server_access_logging_prefix != null ? var.s3_server_access_logging_prefix : "${var.deployment_name}/"
+  # Object presence is known at plan time even when .bucket is unknown until apply
+  # (e.g. destination bucket created in the same configuration).
+  s3_server_access_logging_enabled = var.s3_server_access_logging != null
+  s3_server_access_logging_prefix = (
+    var.s3_server_access_logging != null && var.s3_server_access_logging.prefix != null
+    ? var.s3_server_access_logging.prefix
+    : "${var.deployment_name}/"
+  )
 
   s3_server_access_logging_buckets = {
     brainstore       = aws_s3_bucket.brainstore.id

--- a/modules/storage/s3-logging.tf
+++ b/modules/storage/s3-logging.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket_logging" "access_logs" {
+  for_each = local.s3_server_access_logging_enabled ? local.s3_server_access_logging_buckets : {}
+
+  bucket        = each.value
+  target_bucket = var.s3_server_access_logging_bucket
+  target_prefix = "${local.s3_server_access_logging_prefix}${each.key}/"
+
+  target_object_key_format {
+    partitioned_prefix {
+      partition_date_source = "EventTime"
+    }
+  }
+}

--- a/modules/storage/s3-logging.tf
+++ b/modules/storage/s3-logging.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket_logging" "access_logs" {
   for_each = local.s3_server_access_logging_enabled ? local.s3_server_access_logging_buckets : {}
 
   bucket        = each.value
-  target_bucket = var.s3_server_access_logging_bucket
+  target_bucket = var.s3_server_access_logging.bucket
   target_prefix = "${local.s3_server_access_logging_prefix}${each.key}/"
 
   target_object_key_format {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -40,7 +40,7 @@ variable "enable_s3_bucket_abac" {
 }
 
 variable "s3_server_access_logging" {
-  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable. The destination bucket must be in the same AWS account and region, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS."
+  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable. Attach the destination bucket policy that grants s3:PutObject to logging.s3.amazonaws.com before setting this variable. The destination bucket must be in the same AWS account and region, must not have Object Lock, and must use SSE-S3 (AES256) default encryption, not SSE-KMS."
   type = object({
     bucket = string
     prefix = optional(string)

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -39,6 +39,23 @@ variable "enable_s3_bucket_abac" {
   default     = false
 }
 
+variable "s3_server_access_logging_bucket" {
+  description = "Name of an existing S3 bucket that receives server access logs from the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable logging. The destination bucket must be in the same AWS account and region, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS."
+  type        = string
+  default     = null
+}
+
+variable "s3_server_access_logging_prefix" {
+  description = "Key prefix for S3 server access logs. Defaults to '<deployment_name>/' when logging is enabled. Per-bucket suffixes (brainstore/, code-bundle/, lambda-responses/) are appended. Must be empty or end with '/'."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.s3_server_access_logging_prefix == null ? true : (var.s3_server_access_logging_prefix == "" || endswith(var.s3_server_access_logging_prefix, "/"))
+    error_message = "s3_server_access_logging_prefix must be empty or end with '/'."
+  }
+}
+
 variable "custom_tags" {
   description = "Custom tags to apply to all created resources"
   type        = map(string)

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -39,20 +39,23 @@ variable "enable_s3_bucket_abac" {
   default     = false
 }
 
-variable "s3_server_access_logging_bucket" {
-  description = "Name of an existing S3 bucket that receives server access logs from the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable logging. The destination bucket must be in the same AWS account and region, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS."
-  type        = string
-  default     = null
-}
-
-variable "s3_server_access_logging_prefix" {
-  description = "Key prefix for S3 server access logs. Defaults to '<deployment_name>/' when logging is enabled. Per-bucket suffixes (brainstore/, code-bundle/, lambda-responses/) are appended. Must be empty or end with '/'."
-  type        = string
-  default     = null
+variable "s3_server_access_logging" {
+  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable. The destination bucket must be in the same AWS account and region, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS."
+  type = object({
+    bucket = string
+    prefix = optional(string)
+  })
+  default = null
 
   validation {
-    condition     = var.s3_server_access_logging_prefix == null ? true : (var.s3_server_access_logging_prefix == "" || endswith(var.s3_server_access_logging_prefix, "/"))
-    error_message = "s3_server_access_logging_prefix must be empty or end with '/'."
+    condition = var.s3_server_access_logging == null ? true : (
+      length(var.s3_server_access_logging.bucket) > 0 && (
+        var.s3_server_access_logging.prefix == null ||
+        var.s3_server_access_logging.prefix == "" ||
+        endswith(var.s3_server_access_logging.prefix, "/")
+      )
+    )
+    error_message = "s3_server_access_logging.bucket must be non-empty; prefix must be null, empty, or end with '/'."
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,16 @@ output "brainstore_s3_bucket_name" {
   description = "Name of the Brainstore S3 bucket"
 }
 
+output "code_bundle_s3_bucket_name" {
+  value       = module.storage.code_bundle_bucket_id
+  description = "Name of the code bundle S3 bucket"
+}
+
+output "lambda_responses_s3_bucket_name" {
+  value       = module.storage.lambda_responses_bucket_id
+  description = "Name of the lambda responses S3 bucket"
+}
+
 output "rds_security_group_id" {
   value       = module.database.rds_security_group_id
   description = "ID of the security group for the RDS instance"

--- a/variables.tf
+++ b/variables.tf
@@ -996,7 +996,7 @@ variable "enable_s3_bucket_abac" {
 }
 
 variable "s3_server_access_logging" {
-  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable (default). The destination bucket must be in the same AWS account and region as this deployment, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS. Useful for audit and compliance requirements."
+  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable (default). Attach the destination bucket policy that grants s3:PutObject to logging.s3.amazonaws.com before setting this variable. The destination bucket must be in the same AWS account and region as this deployment, must not have Object Lock, and must use SSE-S3 (AES256) default encryption, not SSE-KMS. Useful for audit and compliance requirements."
   type = object({
     bucket = string
     prefix = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -995,6 +995,23 @@ variable "enable_s3_bucket_abac" {
   default     = false
 }
 
+variable "s3_server_access_logging_bucket" {
+  description = "Opt-in. Name of an existing S3 bucket that receives server access logs from the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable logging (default). The destination bucket must be in the same AWS account and region as this deployment, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS. Useful for audit and compliance requirements."
+  type        = string
+  default     = null
+}
+
+variable "s3_server_access_logging_prefix" {
+  description = "Key prefix for S3 server access logs. Defaults to '<deployment_name>/' when logging is enabled. Per-bucket suffixes (brainstore/, code-bundle/, lambda-responses/) are appended. Must be empty or end with '/'."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.s3_server_access_logging_prefix == null ? true : (var.s3_server_access_logging_prefix == "" || endswith(var.s3_server_access_logging_prefix, "/"))
+    error_message = "s3_server_access_logging_prefix must be empty or end with '/'."
+  }
+}
+
 variable "outbound_rate_limit_max_requests" {
   description = "The maximum number of requests per user allowed in the time frame specified by OutboundRateLimitMaxRequests. Setting to 0 will disable rate limits"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -995,20 +995,23 @@ variable "enable_s3_bucket_abac" {
   default     = false
 }
 
-variable "s3_server_access_logging_bucket" {
-  description = "Opt-in. Name of an existing S3 bucket that receives server access logs from the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable logging (default). The destination bucket must be in the same AWS account and region as this deployment, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS. Useful for audit and compliance requirements."
-  type        = string
-  default     = null
-}
-
-variable "s3_server_access_logging_prefix" {
-  description = "Key prefix for S3 server access logs. Defaults to '<deployment_name>/' when logging is enabled. Per-bucket suffixes (brainstore/, code-bundle/, lambda-responses/) are appended. Must be empty or end with '/'."
-  type        = string
-  default     = null
+variable "s3_server_access_logging" {
+  description = "Opt-in. Configure S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Leave null to disable (default). The destination bucket must be in the same AWS account and region as this deployment, must not have Object Lock, and must grant s3:PutObject to logging.s3.amazonaws.com. Default encryption must be SSE-S3 (AES256), not SSE-KMS. Useful for audit and compliance requirements."
+  type = object({
+    bucket = string
+    prefix = optional(string)
+  })
+  default = null
 
   validation {
-    condition     = var.s3_server_access_logging_prefix == null ? true : (var.s3_server_access_logging_prefix == "" || endswith(var.s3_server_access_logging_prefix, "/"))
-    error_message = "s3_server_access_logging_prefix must be empty or end with '/'."
+    condition = var.s3_server_access_logging == null ? true : (
+      length(var.s3_server_access_logging.bucket) > 0 && (
+        var.s3_server_access_logging.prefix == null ||
+        var.s3_server_access_logging.prefix == "" ||
+        endswith(var.s3_server_access_logging.prefix, "/")
+      )
+    )
+    error_message = "s3_server_access_logging.bucket must be non-empty; prefix must be null, empty, or end with '/'."
   }
 }
 


### PR DESCRIPTION
## Description

Opt-in S3 server access logging for the brainstore, code-bundle, and lambda-responses buckets. Disabled by default. When enabled, logs are written to a customer-owned bucket in the same account and region.

Operators can enable it with:

```hcl
s3_server_access_logging_bucket = "your-audit-logs-bucket"
# optional; defaults to "<deployment_name>/"
# s3_server_access_logging_prefix = "braintrust/"
```

The destination bucket must grant `s3:PutObject` to `logging.s3.amazonaws.com`, use SSE-S3 (not SSE-KMS), and must not have Object Lock. See the README for the required bucket policy. New outputs `code_bundle_s3_bucket_name` and `lambda_responses_s3_bucket_name` are available for that policy.

Existing deployments are unchanged unless the new variable is set.

> [!WARNING]
> Brainstore in a busy environment can generate a significant amount of s3 access logs

## Context

A Vanilla Hybrid customer needs server access logs from these buckets delivered to a bucket they own, for audit/compliance. This keeps logging optional so other customers are not affected.

## Testing

- [x] `terraform fmt` and `terraform validate` on the root module
- [x] `tflint` on the root and storage modules
- [x] Exercise an example configuration in sandbox environment 