### PR TITLE
Restore Loop Runtime AI Proxy Function URL

### DIFF
--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -96,7 +96,7 @@ module "loop_runtime_ecs" {
   code_bundle_bucket_arn    = module.storage.code_bundle_bucket_arn
 
   brainstore_reader_url = local.loop_runtime_brainstore_reader_url
-  ai_proxy_url          = local.api_ecs_ai_proxy_url
+  ai_proxy_url          = local.self_hosted_ai_proxy_url
   braintrust_api_url    = module.ingress[0].api_url
 
   # Shared Brainstore WAL format + lock prefix — must match the API/Brainstore writers.

--- a/main.tf
+++ b/main.tf
@@ -70,11 +70,9 @@ locals {
     : local.brainstore_ai_proxy_url_ssm_parameter_name
   )
 
-  # Quarantine uses the self-hosted AI Proxy Lambda Function URL.
-  quarantine_ai_proxy_url = one(module.services[*].ai_proxy_url)
-
-  # When the ECS API is active, Loop Runtime uses the braintrust-hosted AI gateway.
-  api_ecs_ai_proxy_url = local.enable_ecs_api ? "https://${trimsuffix(replace(var.global_ai_gateway_origin_domain, "/^https?:\\/\\//", ""), "/")}/v1/proxy" : one(module.services[*].ai_proxy_url)
+  # Quarantine and Loop Runtime use the self-hosted AI Proxy Lambda Function URL.
+  # one() keeps this index-safe when services is absent.
+  self_hosted_ai_proxy_url = one(module.services[*].ai_proxy_url)
   gateway_env_vars = local.enable_ai_gateway ? {
     GATEWAY_URL = module.gateway_alb[0].gateway_url
   } : {}
@@ -483,7 +481,7 @@ module "api_ecs" {
   quarantine_invoke_role_arn          = module.services_common.quarantine_invoke_role_arn
   quarantine_function_role_arn        = module.services_common.quarantine_function_role_arn
   quarantine_lambda_security_group_id = module.services_common.quarantine_lambda_security_group_id
-  quarantine_proxy_url                = local.quarantine_ai_proxy_url
+  quarantine_proxy_url                = local.self_hosted_ai_proxy_url
 
   # Networking
   vpc_id             = local.main_vpc_id


### PR DESCRIPTION
## Summary
- Follow-up to #324: restore Loop Runtime (`LOOP_RUNTIME_AI_PROXY_URL`) to the customer AI Proxy Lambda Function URL
- Quarantine and Loop Runtime share `self_hosted_ai_proxy_url` again (same wiring as the first commit in #324 before Loop was flipped back to hosted gateway)
- Removes `api_ecs_ai_proxy_url`; no new gating variable

Internet-mode MicroVMs can reach the public Function URL. AI Proxy already has `GATEWAY_URL` → private gateway when enabled, so Loop still gets Gateway semantics in-account.

## Test plan
- [ ] Diff matches intended Loop Function URL wiring; quarantine still uses Function URL
- [ ] `terraform fmt` / tflint clean
- [ ] Confirm no remaining references to `api_ecs_ai_proxy_url`


Made with [Cursor](https://cursor.com)