### PR TITLE
feat: Add otel logs and /logs3/overflow endpoint

### DIFF
--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -9,7 +9,7 @@ v6 moves the primary APIHandler and AIProxy workloads from Lambda onto ECS. This
 APIHandler and AIProxy now run as ECS services alongside the existing Lambdas. The ECS API is split into three services for different workload types:
 
 - `braintrust-api` — general API traffic
-- `braintrust-api-ingest` — ingestion paths (`/logs3`, `/otel/v1/traces`, `/otel/v1/logs`)
+- `braintrust-api-ingest` — ingestion paths (`/logs3`, `/logs3/overflow`, `/otel/v1/traces`, `/otel/v1/logs`)
 - `braintrust-api-background` — background paths (evals, function invoke, proxy)
 
 These services have new variables that require consideration:

--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -9,7 +9,7 @@ v6 moves the primary APIHandler and AIProxy workloads from Lambda onto ECS. This
 APIHandler and AIProxy now run as ECS services alongside the existing Lambdas. The ECS API is split into three services for different workload types:
 
 - `braintrust-api` — general API traffic
-- `braintrust-api-ingest` — ingestion paths (`/logs3`, `/logs3/overflow`, `/otel/v1/traces`, `/otel/v1/logs`)
+- `braintrust-api-ingest` — ingestion paths
 - `braintrust-api-background` — background paths (evals, function invoke, proxy)
 
 These services have new variables that require consideration:

--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -9,7 +9,7 @@ v6 moves the primary APIHandler and AIProxy workloads from Lambda onto ECS. This
 APIHandler and AIProxy now run as ECS services alongside the existing Lambdas. The ECS API is split into three services for different workload types:
 
 - `braintrust-api` — general API traffic
-- `braintrust-api-ingest` — ingestion paths (`/logs3`, `/otel/v1/traces`)
+- `braintrust-api-ingest` — ingestion paths (`/logs3`, `/otel/v1/traces`, `/otel/v1/logs`)
 - `braintrust-api-background` — background paths (evals, function invoke, proxy)
 
 These services have new variables that require consideration:

--- a/modules/api-ecs/alb-path-routes.tf
+++ b/modules/api-ecs/alb-path-routes.tf
@@ -13,6 +13,7 @@ locals {
     # braintrust-api-ingest
     { path = "/logs3", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/otel/v1/traces", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
+    { path = "/otel/v1/logs", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/attachment", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/attachment/status", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
 

--- a/modules/api-ecs/alb-path-routes.tf
+++ b/modules/api-ecs/alb-path-routes.tf
@@ -12,6 +12,7 @@ locals {
   alb_path_routes = [
     # braintrust-api-ingest
     { path = "/logs3", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
+    { path = "/logs3/overflow", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/otel/v1/traces", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/otel/v1/logs", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/attachment", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },

--- a/modules/api-ecs/alb-path-routes.tf
+++ b/modules/api-ecs/alb-path-routes.tf
@@ -12,9 +12,7 @@ locals {
   alb_path_routes = [
     # braintrust-api-ingest
     { path = "/logs3", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/logs3/overflow", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/otel/v1/traces", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/otel/v1/logs", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
+    { path = "/otel/v1/*", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/attachment", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
     { path = "/attachment/status", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
 
@@ -29,6 +27,7 @@ locals {
     { path = "/automation/logs/trigger", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
     { path = "/v1/proxy/chat/completions", target_group = aws_lb_target_group.braintrust_api_background.arn },
     { path = "/v1/proxy/responses", target_group = aws_lb_target_group.braintrust_api_background.arn },
+    { path = "/logs3/overflow", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
   ]
 
   alb_path_listener_rules = {

--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -327,6 +327,11 @@ locals {
           consumes = ["application/json", "application/x-protobuf"]
         })
       }
+      "/otel/v1/logs" = {
+        for method in ["options", "post"] : method => merge(local.snippet_api_json_method, {
+          consumes = ["application/json", "application/x-protobuf"]
+        })
+      }
       "/ping" = {
         for method in ["get", "options"] : method => local.snippet_api_json_text_method
       }


### PR DESCRIPTION
companion PR to https://github.com/braintrustdata/braintrust/pull/18792. Adds the relevant OTEL logs endpoints to terraform. Generally `/otel/v1/logs` behaves exactly like `/otel/v1/traces` for our purposes, so they can exist in the same places.

Also adds `/logs3/overflow`, this was not there before, but definitely should be considered an ingest endpoint.