### PR TITLE
feat: add data plane monitoring contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ If you're using a brand new AWS account for your Braintrust data plane you will 
 
 All module input variables and outputs are documented inline in the module's Terraform files (see `variables.tf`, `outputs.tf`, and the submodules for details).
 
-The `monitoring_contract` output is the versioned interface for
-`terraform-aws-braintrust-data-plane-cloudwatch`. Passing it directly to that
-module allows Terraform to order AWS-native monitoring resources after their
-data-plane dependencies without separately discovering newly-created customer
-resources.
-
 ### Organization access configuration
 
 Prefer ID-based organization access for new deployments:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ If you're using a brand new AWS account for your Braintrust data plane you will 
 
 All module input variables and outputs are documented inline in the module's Terraform files (see `variables.tf`, `outputs.tf`, and the submodules for details).
 
+The `monitoring_contract` output is the versioned interface for
+`terraform-aws-braintrust-data-plane-cloudwatch`. Passing it directly to that
+module allows Terraform to order AWS-native monitoring resources after their
+data-plane dependencies without separately discovering newly-created customer
+resources.
+
 ### Organization access configuration
 
 Prefer ID-based organization access for new deployments:

--- a/modules/api-ecs/outputs.tf
+++ b/modules/api-ecs/outputs.tf
@@ -17,6 +17,11 @@ output "alb_arn" {
   value       = aws_lb.api_ecs.arn
 }
 
+output "alb_arn_suffix" {
+  description = "ARN suffix of the API ECS ALB for CloudWatch dimensions."
+  value       = aws_lb.api_ecs.arn_suffix
+}
+
 output "alb_dns_name" {
   description = "DNS name of the API ECS ALB."
   value       = aws_lb.api_ecs.dns_name
@@ -35,6 +40,11 @@ output "alb_domain" {
 output "target_group_arn" {
   description = "ARN of the braintrust-api ALB target group."
   value       = aws_lb_target_group.braintrust_api.arn
+}
+
+output "target_group_arn_suffix" {
+  description = "ARN suffix of the braintrust-api ALB target group for CloudWatch dimensions."
+  value       = aws_lb_target_group.braintrust_api.arn_suffix
 }
 
 output "target_group_arns" {

--- a/modules/brainstore-ec2/outputs.tf
+++ b/modules/brainstore-ec2/outputs.tf
@@ -22,3 +22,30 @@ output "brainstore_elb_security_group_id" {
   description = "The ID of the security group for the Brainstore ELB"
   value       = aws_security_group.brainstore_elb.id
 }
+
+output "monitoring_targets" {
+  description = "Brainstore targets keyed by stable role for monitoring integrations."
+  value = merge(
+    {
+      reader = {
+        asg_name      = aws_autoscaling_group.brainstore.name
+        lb_arn_suffix = aws_lb.brainstore.arn_suffix
+        tg_arn_suffix = aws_lb_target_group.brainstore.arn_suffix
+      }
+    },
+    local.has_writer_nodes ? {
+      writer = {
+        asg_name      = aws_autoscaling_group.brainstore_writer[0].name
+        lb_arn_suffix = aws_lb.brainstore_writer[0].arn_suffix
+        tg_arn_suffix = aws_lb_target_group.brainstore_writer[0].arn_suffix
+      }
+    } : {},
+    local.has_fast_reader_nodes ? {
+      fast-reader = {
+        asg_name      = aws_autoscaling_group.brainstore_fast_reader[0].name
+        lb_arn_suffix = aws_lb.brainstore_fast_reader[0].arn_suffix
+        tg_arn_suffix = aws_lb_target_group.brainstore_fast_reader[0].arn_suffix
+      }
+    } : {},
+  )
+}

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -18,6 +18,16 @@ output "postgres_database_arn" {
   description = "The ARN of the main Postgres database"
 }
 
+output "postgres_allocated_storage_gib" {
+  value       = aws_db_instance.main.allocated_storage
+  description = "Allocated storage for the main Postgres database in GiB"
+}
+
+output "postgres_provisioned_iops" {
+  value       = aws_db_instance.main.iops
+  description = "Provisioned IOPS for the main Postgres database, or null when not configured"
+}
+
 output "postgres_database_username" {
   value       = local.postgres_username
   description = "The username for the main Postgres database"

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -12,6 +12,14 @@ output "redis_arn" {
   description = "Redis ARN"
 }
 
+output "monitoring_target" {
+  description = "ElastiCache target identifiers for CloudWatch monitoring."
+  value = {
+    cache_cluster_id = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cluster_id : one(aws_elasticache_replication_group.main[0].member_clusters)
+    cache_node_id    = "0001"
+  }
+}
+
 output "redis_security_group_id" {
   value       = local.elasticache_security_group_ids[0]
   description = "The ID of the first security group for the Elasticache instance"

--- a/modules/gateway-alb/outputs.tf
+++ b/modules/gateway-alb/outputs.tf
@@ -8,6 +8,11 @@ output "gateway_alb_arn" {
   value       = aws_lb.gateway.arn
 }
 
+output "gateway_alb_arn_suffix" {
+  description = "ARN suffix of the private gateway ALB for CloudWatch dimensions"
+  value       = aws_lb.gateway.arn_suffix
+}
+
 output "gateway_alb_security_group_id" {
   description = "Security group ID attached to the private gateway ALB"
   value       = aws_security_group.gateway_alb.id
@@ -16,6 +21,11 @@ output "gateway_alb_security_group_id" {
 output "gateway_target_group_arn" {
   description = "ARN of the gateway ALB target group"
   value       = aws_lb_target_group.gateway.arn
+}
+
+output "gateway_target_group_arn_suffix" {
+  description = "ARN suffix of the gateway ALB target group for CloudWatch dimensions"
+  value       = aws_lb_target_group.gateway.arn_suffix
 }
 
 output "gateway_http_listener_arn" {

--- a/modules/ingress/outputs.tf
+++ b/modules/ingress/outputs.tf
@@ -27,3 +27,13 @@ output "api_gateway_rest_api_arn" {
   description = "The ARN of the API gateway rest api"
   value       = aws_api_gateway_rest_api.api.arn
 }
+
+output "api_gateway_name" {
+  description = "The name of the API Gateway REST API."
+  value       = aws_api_gateway_rest_api.api.name
+}
+
+output "api_gateway_stage_name" {
+  description = "The deployed API Gateway stage name."
+  value       = aws_api_gateway_stage.api.stage_name
+}

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -8,6 +8,32 @@ output "api_handler_arn" {
   value       = aws_lambda_function.api_handler.arn
 }
 
+output "monitoring_functions" {
+  description = "Core Lambda functions keyed by stable logical role for monitoring integrations."
+  value = {
+    api-handler = {
+      function_name   = aws_lambda_function.api_handler.function_name
+      timeout_seconds = aws_lambda_function.api_handler.timeout
+    }
+    ai-proxy = {
+      function_name   = aws_lambda_function.ai_proxy.function_name
+      timeout_seconds = aws_lambda_function.ai_proxy.timeout
+    }
+    billing-cron = {
+      function_name   = aws_lambda_function.billing_cron.function_name
+      timeout_seconds = aws_lambda_function.billing_cron.timeout
+    }
+    automation-cron = {
+      function_name   = aws_lambda_function.automation_cron.function_name
+      timeout_seconds = aws_lambda_function.automation_cron.timeout
+    }
+    catchup-etl = {
+      function_name   = aws_lambda_function.catchup_etl.function_name
+      timeout_seconds = aws_lambda_function.catchup_etl.timeout
+    }
+  }
+}
+
 output "ai_proxy_arn" {
   description = "The ARN of the AI proxy lambda function"
   value       = aws_lambda_function.ai_proxy.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -193,6 +193,65 @@ output "cloudfront_distribution_hosted_zone_id" {
   description = "The hosted zone ID of the cloudfront distribution"
 }
 
+output "monitoring_contract" {
+  description = "Versioned resource identifiers and capabilities consumed by terraform-aws-braintrust-data-plane-cloudwatch."
+  value = {
+    version = 1
+
+    rds = {
+      identifier               = module.database.postgres_database_identifier
+      allocated_storage_gib    = module.database.postgres_allocated_storage_gib
+      provisioned_iops         = module.database.postgres_provisioned_iops
+      provisioned_iops_enabled = var.postgres_storage_iops > 0
+    }
+
+    elasticache = module.redis.monitoring_target
+
+    lambda = {
+      enabled   = !var.use_deployment_mode_external_eks
+      functions = !var.use_deployment_mode_external_eks ? module.services[0].monitoring_functions : {}
+    }
+
+    api_gateway = {
+      enabled = !var.use_deployment_mode_external_eks
+      name    = !var.use_deployment_mode_external_eks ? module.ingress[0].api_gateway_name : null
+      stage   = !var.use_deployment_mode_external_eks ? module.ingress[0].api_gateway_stage_name : null
+    }
+
+    brainstore = {
+      enabled        = var.enable_brainstore && !var.use_deployment_mode_external_eks
+      s3_bucket_name = var.enable_brainstore ? module.storage.brainstore_bucket_id : null
+      targets        = var.enable_brainstore && !var.use_deployment_mode_external_eks ? module.brainstore[0].monitoring_targets : {}
+    }
+
+    cloudfront = {
+      enabled         = !var.use_deployment_mode_external_eks
+      distribution_id = !var.use_deployment_mode_external_eks ? module.ingress[0].cloudfront_distribution_id : null
+    }
+
+    ecs = {
+      enabled      = length(module.ecs) > 0
+      cluster_name = length(module.ecs) > 0 ? module.ecs[0].cluster_name : null
+      services = merge(
+        local.create_ecs_api ? {
+          api-ecs = {
+            service_name  = module.api_ecs[0].service_name
+            lb_arn_suffix = module.api_ecs[0].alb_arn_suffix
+            tg_arn_suffix = module.api_ecs[0].target_group_arn_suffix
+          }
+        } : {},
+        local.create_ai_gateway ? {
+          gateway = {
+            service_name  = module.gateway_ecs[0].service_name
+            lb_arn_suffix = module.gateway_alb[0].gateway_alb_arn_suffix
+            tg_arn_suffix = module.gateway_alb[0].gateway_target_group_arn_suffix
+          }
+        } : {},
+      )
+    }
+  }
+}
+
 output "kms_key_arn" {
   value       = local.kms_key_arn
   description = "ARN of the KMS key used to encrypt Braintrust resources"

--- a/outputs.tf
+++ b/outputs.tf
@@ -202,7 +202,7 @@ output "monitoring_contract" {
       identifier               = module.database.postgres_database_identifier
       allocated_storage_gib    = module.database.postgres_allocated_storage_gib
       provisioned_iops         = module.database.postgres_provisioned_iops
-      provisioned_iops_enabled = var.postgres_storage_iops > 0
+      provisioned_iops_enabled = var.postgres_storage_iops == null ? false : var.postgres_storage_iops > 0
     }
 
     elasticache = module.redis.monitoring_target


### PR DESCRIPTION
## Summary

- export an additive, versioned `monitoring_contract` for compatible monitoring integrations
- expose stable identifiers for RDS, ElastiCache, Lambda, Brainstore, API Gateway, CloudFront, and ECS targets

## Customer impact and adoption

This is additive and does not create, modify, replace, or remove data-plane resources.

Existing deployments are unaffected by upgrading to a release containing this output. No action is required.

## Validation

- `mise run lint`
- `mise run validate`
- `terraform fmt -check -recursive`
- `terraform validate`