### PR TITLE
Pass `permissions_boundary_arn` into API ECS module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -503,12 +503,13 @@ module "api_ecs" {
   alb_custom_domain              = var.braintrust_api_alb_custom_domain
   alb_drop_invalid_header_fields = var.braintrust_api_alb_drop_invalid_header_fields
 
-  kms_key_arn            = local.kms_key_arn
-  ecs_cluster_arn        = module.ecs[0].cluster_arn
-  ecs_cluster_name       = module.ecs[0].cluster_name
-  task_role_arn          = module.services_common.api_handler_role_arn
-  task_security_group_id = module.services_common.api_security_group_id
-  custom_tags            = local.all_custom_tags
+  kms_key_arn              = local.kms_key_arn
+  permissions_boundary_arn = var.permissions_boundary_arn
+  ecs_cluster_arn          = module.ecs[0].cluster_arn
+  ecs_cluster_name         = module.ecs[0].cluster_name
+  task_role_arn            = module.services_common.api_handler_role_arn
+  task_security_group_id   = module.services_common.api_security_group_id
+  custom_tags              = local.all_custom_tags
 }
 
 module "ingress" {

--- a/modules/api-ecs/iam.tf
+++ b/modules/api-ecs/iam.tf
@@ -10,8 +10,9 @@ data "aws_iam_policy_document" "ecs_task_assume_role" {
 }
 
 resource "aws_iam_role" "task_execution" {
-  name               = "${var.deployment_name}-api-ecs-task-exec"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  name                 = "${var.deployment_name}-api-ecs-task-exec"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
   tags = merge({
     Name = "${var.deployment_name}-api-ecs-task-exec"
   }, local.common_tags)

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -8,6 +8,12 @@ variable "kms_key_arn" {
   description = "KMS key ARN used to encrypt API ECS resources that support customer-managed KMS keys."
 }
 
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module."
+  default     = null
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID where ECS resources are deployed."

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -232,8 +232,9 @@ resource "aws_vpc_security_group_ingress_rule" "cache_allow_ingress_from_gateway
 }
 
 resource "aws_iam_role" "task_execution" {
-  name               = "${var.deployment_name}-gateway-task-exec"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  name                 = "${var.deployment_name}-gateway-task-exec"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
   tags = merge({
     Name = "${var.deployment_name}-gateway-task-exec"
   }, local.common_tags)

--- a/modules/gateway-ecs/variables.tf
+++ b/modules/gateway-ecs/variables.tf
@@ -10,7 +10,7 @@ variable "kms_key_arn" {
 
 variable "permissions_boundary_arn" {
   type        = string
-  description = "ARN of the IAM permissions boundary to apply to the gateway task role."
+  description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module."
   default     = null
 }
 


### PR DESCRIPTION
## Description

Threads the root module’s existing `permissions_boundary_arn` value into the `api-ecs` submodule and applies it to the API ECS task execution IAM role. It also applies the already-forwarded boundary to the Gateway ECS task execution IAM role.

Customers already setting `permissions_boundary_arn` do not need to change their configuration. The boundary will now be applied automatically to `${deployment_name}-api-ecs-task-exec` and `${deployment_name}-gateway-task-exec`, consistent with the other IAM roles created by the module.

## Context

The API ECS and Gateway ECS task execution roles were added without applying the module-wide permissions boundary. Some customers have SCPs that require a specific permissions boundary on every IAM role; without it, the roles cannot be created.

## Testing

- Ran `terraform fmt -check -recursive`
- Ran `git diff --check`
- Verified the change uses the established submodule pattern:
  - Optional string input with `default = null`
  - Root module forwards the existing value
  - IAM roles set `permissions_boundary = var.permissions_boundary_arn`
- Audited all 17 Terraform-managed IAM roles and confirmed each now applies the module-wide boundary