### PR TITLE
Stop Loop runtime ECS task replacements on unrelated plans

### DIFF
--- a/modules/loop-runtime-ecs/main.tf
+++ b/modules/loop-runtime-ecs/main.tf
@@ -121,6 +121,10 @@ locals {
     linuxParameters = {
       initProcessEnabled = true
       capabilities = {
+        # AWS stores drop=["ALL"] as {add=[], drop=["ALL"]}. Omitting add makes
+        # container_definitions never match state, so every plan ForceNew-replaces
+        # the task definition (and rolls Loop on unrelated gateway releases).
+        add  = []
         drop = ["ALL"]
       }
     }


### PR DESCRIPTION
## Summary
- Loop runtime ECS task definitions were being ForceNew-replaced on every `prod-lovable-eu` plan, including gateway-only releases, even when the image and env were unchanged.
- AWS persists `linuxParameters.capabilities` as `{add=[], drop=["ALL"]}`. Terraform omitted `add`, so `container_definitions` never matched state.

## Test plan
- [ ] Diff is only `add = []` on the Loop runtime container definition
- [ ] After this is on module `main`, the next EU apply may bounce Loop once; a following gateway-only plan should not replace `aws_ecs_task_definition.loop_runtime`


Made with [Cursor](https://cursor.com)