### PR TITLE
Add optional Rust ingest ECS with ALB weighted % canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ The gateway internal ALB lives in `modules/gateway-alb` so callers can reference
 
 Whether an EKS gateway would reuse this ALB via Terraform is TBD — do not assume it.
 
+### Optional Rust ingest canary: `create_rust_api_ingest`
+
+When `create_rust_api_ingest = true`, the api-ecs module creates a parallel Rust ingest ECS service + target group and adds it to weighted ALB forwards for `/logs3`, `/otel/v1/*`, `/attachment*`, and `/logs3/overflow`. Dial traffic with `rust_api_ingest_traffic_weight` (0–100; TypeScript gets the remainder). Default weight is `0` so you can stand up Rust with no traffic. Rollback = set weight back to `0`. Cutover = weight `100` (or later point paths at Rust only).
+
+Requires `rust_api_ingest_container_image_repository` and either `rust_api_ingest_version_override` or `modules/api-ecs/VERSIONS.json` key `api_rust_ingest`.
+
 ### Private gateway: `create_ai_gateway` vs `enable_ai_gateway`
 
 Similar two-step pattern to API ECS (`enable_ecs_api`), but gateway infra itself is still optional:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,8 @@ Similar two-step pattern to the private gateway:
 
 - **`create_rust_api_ingest`**: parallel Rust ingest ECS service + target group.
 - **`enable_rust_api_ingest`**: point ingest ALB paths (`/logs3`, `/otel/v1/*`, `/attachment*`, `/logs3/overflow`) at Rust only. Requires `create_rust_api_ingest`.
-- **`rust_api_ingest_traffic_weight`**: optional % canary while `create=true` and `enable=false` (TypeScript gets the remainder). Ignored when `enable=true`. Default `0` (stand up with no traffic).
 
-Customer cutover: `create=true, enable=false` → apply → `enable=true` → apply. Greenfield can set both true in one apply. Braintrust soak can dial weight before enable.
+Use `create_rust_api_ingest = true` with `enable_rust_api_ingest = false` for a two-step prod cutover (stand up Rust while ingest stays on TypeScript). Set both true for single-apply wiring on greenfield deployments.
 
 Requires `rust_api_ingest_container_image_repository` and either `rust_api_ingest_version_override` or `modules/api-ecs/VERSIONS.json` key `api_rust_ingest`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,15 @@ The gateway internal ALB lives in `modules/gateway-alb` so callers can reference
 
 Whether an EKS gateway would reuse this ALB via Terraform is TBD — do not assume it.
 
-### Optional Rust ingest canary: `create_rust_api_ingest`
+### Optional Rust ingest: `create_rust_api_ingest` vs `enable_rust_api_ingest`
 
-When `create_rust_api_ingest = true`, the api-ecs module creates a parallel Rust ingest ECS service + target group and adds it to weighted ALB forwards for `/logs3`, `/otel/v1/*`, `/attachment*`, and `/logs3/overflow`. Dial traffic with `rust_api_ingest_traffic_weight` (0–100; TypeScript gets the remainder). Default weight is `0` so you can stand up Rust with no traffic. Rollback = set weight back to `0`. Cutover = weight `100` (or later point paths at Rust only).
+Similar two-step pattern to the private gateway:
+
+- **`create_rust_api_ingest`**: parallel Rust ingest ECS service + target group.
+- **`enable_rust_api_ingest`**: point ingest ALB paths (`/logs3`, `/otel/v1/*`, `/attachment*`, `/logs3/overflow`) at Rust only. Requires `create_rust_api_ingest`.
+- **`rust_api_ingest_traffic_weight`**: optional % canary while `create=true` and `enable=false` (TypeScript gets the remainder). Ignored when `enable=true`. Default `0` (stand up with no traffic).
+
+Customer cutover: `create=true, enable=false` → apply → `enable=true` → apply. Greenfield can set both true in one apply. Braintrust soak can dial weight before enable.
 
 Requires `rust_api_ingest_container_image_repository` and either `rust_api_ingest_version_override` or `modules/api-ecs/VERSIONS.json` key `api_rust_ingest`.
 

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -151,8 +151,10 @@ module "braintrust-data-plane" {
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
+  ### Optional Rust ingest (ECS API only; default off)
+  # Two-step: create=true, enable=false, apply; then enable=true.
   # create_rust_api_ingest                     = false
+  # enable_rust_api_ingest                     = false
   # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -155,7 +155,6 @@ module "braintrust-data-plane" {
   # Two-step: create=true, enable=false, apply; then enable=true.
   # create_rust_api_ingest                     = false
   # enable_rust_api_ingest                     = false
-  # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"
   # rust_api_ingest_health_check_path          = "/"

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -157,5 +157,5 @@ module "braintrust-data-plane" {
   # enable_rust_api_ingest                     = false
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"
-  # rust_api_ingest_health_check_path          = "/"
+  # rust_api_ingest_health_check_path          = "/health/liveness"
 }

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -150,4 +150,11 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # Only applies when create_ai_gateway is true.
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
+  # create_rust_api_ingest                     = false
+  # rust_api_ingest_traffic_weight             = 0
+  # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
+  # rust_api_ingest_version_override           = "vX.Y.Z"
+  # rust_api_ingest_health_check_path          = "/"
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -132,8 +132,10 @@ module "braintrust-data-plane" {
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
 
-  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
+  ### Optional Rust ingest (ECS API only; default off)
+  # Two-step: create=true, enable=false, apply; then enable=true.
   # create_rust_api_ingest                     = false
+  # enable_rust_api_ingest                     = false
   # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -131,4 +131,11 @@ module "braintrust-data-plane" {
 
   # Opt-in: bound AI Gateway Bedrock AssumeRole to approved role ARNs or IAM patterns (default: unrestricted).
   # ai_gateway_bedrock_assume_role_arns = ["arn:aws:iam::123456789012:role/braintrust-bedrock-role"]
+
+  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
+  # create_rust_api_ingest                     = false
+  # rust_api_ingest_traffic_weight             = 0
+  # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
+  # rust_api_ingest_version_override           = "vX.Y.Z"
+  # rust_api_ingest_health_check_path          = "/"
 }

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -136,7 +136,6 @@ module "braintrust-data-plane" {
   # Two-step: create=true, enable=false, apply; then enable=true.
   # create_rust_api_ingest                     = false
   # enable_rust_api_ingest                     = false
-  # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"
   # rust_api_ingest_health_check_path          = "/"

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -138,5 +138,5 @@ module "braintrust-data-plane" {
   # enable_rust_api_ingest                     = false
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"
-  # rust_api_ingest_health_check_path          = "/"
+  # rust_api_ingest_health_check_path          = "/health/liveness"
 }

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -121,10 +121,12 @@ module "braintrust-data-plane" {
   # quarantine_vpc_cidr                   = "10.175.8.0/21"
 
 
-  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
-  # Stand up a parallel Rust ingest service and dial traffic with
-  # rust_api_ingest_traffic_weight (0-100; TypeScript gets the remainder).
+  ### Optional Rust ingest (ECS API only; default off)
+  # Two-step cutover: create=true, enable=false, apply; then enable=true.
+  # Greenfield can set both true in one apply. Optional % canary while create
+  # is true and enable is false via rust_api_ingest_traffic_weight.
   # create_rust_api_ingest                     = false
+  # enable_rust_api_ingest                     = false
   # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -121,6 +121,19 @@ module "braintrust-data-plane" {
   # quarantine_vpc_cidr                   = "10.175.8.0/21"
 
 
+  ### Optional Rust ingest ALB weighted canary (ECS API only; default off)
+  # Stand up a parallel Rust ingest service and dial traffic with
+  # rust_api_ingest_traffic_weight (0-100; TypeScript gets the remainder).
+  # create_rust_api_ingest                     = false
+  # rust_api_ingest_traffic_weight             = 0
+  # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
+  # rust_api_ingest_version_override           = "vX.Y.Z"
+  # rust_api_ingest_cpu                        = 1024
+  # rust_api_ingest_memory                     = 8192
+  # rust_api_ingest_min_count                  = 2
+  # rust_api_ingest_max_count                  = 50
+  # rust_api_ingest_health_check_path          = "/"
+
   ### Advanced configuration
 
   # The maximum number of concurrent executions to reserve and constrain Braintrust lambdas to.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -132,7 +132,7 @@ module "braintrust-data-plane" {
   # rust_api_ingest_memory                     = 8192
   # rust_api_ingest_min_count                  = 2
   # rust_api_ingest_max_count                  = 50
-  # rust_api_ingest_health_check_path          = "/"
+  # rust_api_ingest_health_check_path          = "/health/liveness"
 
   ### Advanced configuration
 

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -123,11 +123,9 @@ module "braintrust-data-plane" {
 
   ### Optional Rust ingest (ECS API only; default off)
   # Two-step cutover: create=true, enable=false, apply; then enable=true.
-  # Greenfield can set both true in one apply. Optional % canary while create
-  # is true and enable is false via rust_api_ingest_traffic_weight.
+  # Greenfield can set both true in one apply.
   # create_rust_api_ingest                     = false
   # enable_rust_api_ingest                     = false
-  # rust_api_ingest_traffic_weight             = 0
   # rust_api_ingest_container_image_repository = "ACCOUNT.dkr.ecr.REGION.amazonaws.com/braintrust-api-rust-ingest"
   # rust_api_ingest_version_override           = "vX.Y.Z"
   # rust_api_ingest_cpu                        = 1024

--- a/main.tf
+++ b/main.tf
@@ -458,6 +458,7 @@ module "api_ecs" {
   braintrust_api_ingest_event_loop_utilization_autoscaling     = var.braintrust_api_ingest_event_loop_utilization_autoscaling
   braintrust_api_ingest_event_loop_delay_autoscaling           = var.braintrust_api_ingest_event_loop_delay_autoscaling
   create_rust_api_ingest                                       = var.create_rust_api_ingest
+  enable_rust_api_ingest                                       = var.enable_rust_api_ingest
   rust_api_ingest_traffic_weight                               = var.rust_api_ingest_traffic_weight
   rust_api_ingest_container_image_repository                   = var.rust_api_ingest_container_image_repository
   rust_api_ingest_version_override                             = var.rust_api_ingest_version_override

--- a/main.tf
+++ b/main.tf
@@ -424,6 +424,7 @@ module "api_ecs" {
   brainstore_writer_hostname      = var.brainstore_writer_instance_count > 0 ? module.brainstore[0].writer_dns_name : null
   brainstore_fast_reader_hostname = var.brainstore_fast_reader_instance_count > 0 ? module.brainstore[0].fast_reader_dns_name : null
   brainstore_s3_bucket_name       = module.storage.brainstore_bucket_id
+  brainstore_locks_s3_path        = var.brainstore_locks_s3_path
   brainstore_port                 = module.brainstore[0].port
   brainstore_etl_batch_size       = var.brainstore_etl_batch_size
   brainstore_wal_footer_version   = var.brainstore_wal_footer_version

--- a/main.tf
+++ b/main.tf
@@ -457,6 +457,16 @@ module "api_ecs" {
   braintrust_api_ingest_cpu_autoscaling                        = var.braintrust_api_ingest_cpu_autoscaling
   braintrust_api_ingest_event_loop_utilization_autoscaling     = var.braintrust_api_ingest_event_loop_utilization_autoscaling
   braintrust_api_ingest_event_loop_delay_autoscaling           = var.braintrust_api_ingest_event_loop_delay_autoscaling
+  create_rust_api_ingest                                       = var.create_rust_api_ingest
+  rust_api_ingest_traffic_weight                               = var.rust_api_ingest_traffic_weight
+  rust_api_ingest_container_image_repository                   = var.rust_api_ingest_container_image_repository
+  rust_api_ingest_version_override                             = var.rust_api_ingest_version_override
+  rust_api_ingest_cpu                                          = var.rust_api_ingest_cpu
+  rust_api_ingest_memory                                       = var.rust_api_ingest_memory
+  rust_api_ingest_min_count                                    = var.rust_api_ingest_min_count
+  rust_api_ingest_max_count                                    = var.rust_api_ingest_max_count
+  rust_api_ingest_cpu_autoscaling                              = var.rust_api_ingest_cpu_autoscaling
+  rust_api_ingest_health_check_path                            = var.rust_api_ingest_health_check_path
   braintrust_api_background_cpu                                = var.braintrust_api_background_cpu
   braintrust_api_background_memory                             = var.braintrust_api_background_memory
   braintrust_api_background_min_count                          = var.braintrust_api_background_min_count

--- a/modules/api-ecs/alb-path-routes.tf
+++ b/modules/api-ecs/alb-path-routes.tf
@@ -1,31 +1,42 @@
 # ALB path routing (evaluated by priority; lower number wins).
 # Unmatched requests fall through to the listener default action → braintrust-api.
 #
-# When create_rust_api_ingest is true, ingest path rules use a weighted forward
-# across the TypeScript and Rust target groups (rust_api_ingest_traffic_weight).
+# Ingest paths (/logs3, /otel/v1/*, /attachment*, /logs3/overflow):
+# - create_rust_api_ingest=false: TypeScript only
+# - create=true, enable=false: weighted TS/Rust (rust_api_ingest_traffic_weight)
+# - create=true, enable=true: Rust only (weight ignored)
 # Non-ingest routes are unchanged.
 
 locals {
-  rust_api_ingest_traffic_weight = var.create_rust_api_ingest ? var.rust_api_ingest_traffic_weight : 0
+  rust_api_ingest_enabled = var.create_rust_api_ingest && var.enable_rust_api_ingest
+  rust_api_ingest_canary  = var.create_rust_api_ingest && !var.enable_rust_api_ingest
+
+  rust_api_ingest_traffic_weight = local.rust_api_ingest_canary ? var.rust_api_ingest_traffic_weight : 0
   ts_api_ingest_traffic_weight   = 100 - local.rust_api_ingest_traffic_weight
 
-  ingest_target_groups = var.create_rust_api_ingest ? [
-    {
-      arn    = aws_lb_target_group.braintrust_api_ingest.arn
-      weight = local.ts_api_ingest_traffic_weight
-    },
-    {
-      arn    = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
-      weight = local.rust_api_ingest_traffic_weight
-    },
-    ] : [
-    {
-      arn = aws_lb_target_group.braintrust_api_ingest.arn
-    },
-  ]
+  ingest_target_groups = (
+    local.rust_api_ingest_enabled ? [
+      {
+        arn = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
+      },
+      ] : local.rust_api_ingest_canary ? [
+      {
+        arn    = aws_lb_target_group.braintrust_api_ingest.arn
+        weight = local.ts_api_ingest_traffic_weight
+      },
+      {
+        arn    = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
+        weight = local.rust_api_ingest_traffic_weight
+      },
+      ] : [
+      {
+        arn = aws_lb_target_group.braintrust_api_ingest.arn
+      },
+    ]
+  )
 
   alb_path_routes = [
-    # braintrust-api-ingest (weighted TS/Rust when create_rust_api_ingest)
+    # braintrust-api-ingest (TS / weighted canary / Rust-only — see locals above)
     { path = "/logs3", method = "POST", target_groups = local.ingest_target_groups },
     { path = "/otel/v1/*", method = "POST", target_groups = local.ingest_target_groups },
     { path = "/attachment", method = "POST", target_groups = local.ingest_target_groups },

--- a/modules/api-ecs/alb-path-routes.tf
+++ b/modules/api-ecs/alb-path-routes.tf
@@ -1,33 +1,48 @@
-# ALB path routing (evaluated top-to-bottom; list order = rule priority).
+# ALB path routing (evaluated by priority; lower number wins).
 # Unmatched requests fall through to the listener default action → braintrust-api.
 #
-# Each route requires:
-#   - path:         path pattern to match
-#   - target_group: target group ARN to forward to
-#
-# Optional:
-#   - method: HTTP method to match (e.g. "POST"); omit to match any method
+# When create_rust_api_ingest is true, ingest path rules use a weighted forward
+# across the TypeScript and Rust target groups (rust_api_ingest_traffic_weight).
+# Non-ingest routes are unchanged.
 
 locals {
+  rust_api_ingest_traffic_weight = var.create_rust_api_ingest ? var.rust_api_ingest_traffic_weight : 0
+  ts_api_ingest_traffic_weight   = 100 - local.rust_api_ingest_traffic_weight
+
+  ingest_target_groups = var.create_rust_api_ingest ? [
+    {
+      arn    = aws_lb_target_group.braintrust_api_ingest.arn
+      weight = local.ts_api_ingest_traffic_weight
+    },
+    {
+      arn    = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
+      weight = local.rust_api_ingest_traffic_weight
+    },
+    ] : [
+    {
+      arn = aws_lb_target_group.braintrust_api_ingest.arn
+    },
+  ]
+
   alb_path_routes = [
-    # braintrust-api-ingest
-    { path = "/logs3", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/otel/v1/*", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/attachment", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
-    { path = "/attachment/status", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
+    # braintrust-api-ingest (weighted TS/Rust when create_rust_api_ingest)
+    { path = "/logs3", method = "POST", target_groups = local.ingest_target_groups },
+    { path = "/otel/v1/*", method = "POST", target_groups = local.ingest_target_groups },
+    { path = "/attachment", method = "POST", target_groups = local.ingest_target_groups },
+    { path = "/attachment/status", method = "POST", target_groups = local.ingest_target_groups },
 
     # braintrust-api-background
-    { path = "/v1/eval", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/v1/eval/*", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/function/eval", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/function/sandbox", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/function/use", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/function/invoke-async-batch", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/function/insert-functions", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/automation/logs/trigger", method = "POST", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/v1/proxy/chat/completions", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/v1/proxy/responses", target_group = aws_lb_target_group.braintrust_api_background.arn },
-    { path = "/logs3/overflow", method = "POST", target_group = aws_lb_target_group.braintrust_api_ingest.arn },
+    { path = "/v1/eval", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/v1/eval/*", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/function/eval", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/function/sandbox", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/function/use", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/function/invoke-async-batch", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/function/insert-functions", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/automation/logs/trigger", method = "POST", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/v1/proxy/chat/completions", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/v1/proxy/responses", target_groups = [{ arn = aws_lb_target_group.braintrust_api_background.arn }] },
+    { path = "/logs3/overflow", method = "POST", target_groups = local.ingest_target_groups },
   ]
 
   alb_path_listener_rules = {
@@ -49,8 +64,13 @@ resource "aws_lb_listener_rule" "alb_path_routes" {
   action {
     type = "forward"
     forward {
-      target_group {
-        arn = each.value.target_group
+      dynamic "target_group" {
+        for_each = each.value.target_groups
+
+        content {
+          arn    = target_group.value.arn
+          weight = try(target_group.value.weight, null)
+        }
       }
     }
   }

--- a/modules/api-ecs/alb.tf
+++ b/modules/api-ecs/alb.tf
@@ -64,6 +64,18 @@ resource "aws_security_group_rule" "task_ingress_from_alb" {
   security_group_id        = var.task_security_group_id
 }
 
+resource "aws_security_group_rule" "task_ingress_from_alb_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 8100
+  to_port                  = 8100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+  description              = "Allow inbound traffic from API ECS ALB to Rust ingest tasks."
+  security_group_id        = var.task_security_group_id
+}
+
 resource "aws_lb" "api_ecs" {
   name               = "${var.deployment_name}-api-ecs"
   internal           = true

--- a/modules/api-ecs/braintrust-api-rust-ingest.tf
+++ b/modules/api-ecs/braintrust-api-rust-ingest.tf
@@ -11,11 +11,51 @@ locals {
     : try(jsondecode(file("${path.module}/VERSIONS.json"))["api_rust_ingest"], null)
   )
 
-  rust_api_ingest_env_vars = merge(local.merged_env_vars, {
+  # api-rs embeds Brainstore storage and needs direct URIs (same pattern as
+  # brainstore EC2 / loop-runtime / dataplane-loadtest api-next). TS merged_env
+  # only has BRAINSTORE_URL + BRAINSTORE_REALTIME_WAL_BUCKET, which is not enough.
+  rust_api_ingest_brainstore_env_vars = merge(
+    {
+      API_RS_HOST        = "0.0.0.0"
+      API_RS_PORT        = "8100"
+      BRAINSTORE_VERBOSE = "1"
+    },
+    var.brainstore_s3_bucket_name != null && var.brainstore_s3_bucket_name != "" ? {
+      BRAINSTORE_INDEX_URI        = "s3://${var.brainstore_s3_bucket_name}/brainstore/index"
+      BRAINSTORE_LOCKS_URI        = "s3://${var.brainstore_s3_bucket_name}/${trimprefix(var.brainstore_locks_s3_path, "/")}"
+      BRAINSTORE_REALTIME_WAL_URI = "s3://${var.brainstore_s3_bucket_name}/brainstore/wal"
+    } : {},
+    {
+      BRAINSTORE_CODE_BUNDLE_URI    = "s3://${var.code_bundle_bucket}"
+      BRAINSTORE_RESPONSE_CACHE_URI = "s3://${var.response_bucket}/brainstore-cache"
+    },
+  )
+
+  rust_api_ingest_env_vars = merge(local.merged_env_vars, local.rust_api_ingest_brainstore_env_vars, {
     CLOUDWATCH_METRICS_SERVICE_NAME    = local.braintrust_api_rust_ingest_name
     CLOUDWATCH_METRICS_DEPLOYMENT_NAME = var.deployment_name
-    API_RS_PORT                        = "8100"
   })
+
+  # Explicit Brainstore storage secrets (PG/Redis). api-rs can also alias PG_URL /
+  # REDIS_URL, but loadtest and brainstore nodes set these names directly.
+  rust_api_ingest_secrets = concat(local.api_container_base.secrets, [
+    {
+      name      = "BRAINSTORE_METADATA_URI"
+      valueFrom = var.database_url_secret_arn
+    },
+    {
+      name      = "BRAINSTORE_WAL_URI"
+      valueFrom = var.database_url_secret_arn
+    },
+    {
+      name      = "BRAINSTORE_XACT_MANAGER_URI"
+      valueFrom = var.redis_url_secret_arn
+    },
+    {
+      name      = "BRAINSTORE_REDIS_URI"
+      valueFrom = var.redis_url_secret_arn
+    },
+  ])
 
   # api-rs (public.ecr.aws/braintrust/api-next) listens on 8100 with /health/liveness.
   # Override portMappings + healthCheck from api_container_base (TS defaults to 8000 /).
@@ -45,6 +85,7 @@ locals {
         startPeriod = 10
         timeout     = 5
       }
+      secrets = local.rust_api_ingest_secrets
       environment = [
         for key in sort(keys(local.rust_api_ingest_env_vars)) : {
           name  = key
@@ -131,6 +172,10 @@ resource "aws_ecs_task_definition" "braintrust_api_rust_ingest" {
     precondition {
       condition     = trimspace(var.rust_api_ingest_container_image_repository) != ""
       error_message = "create_rust_api_ingest requires rust_api_ingest_container_image_repository."
+    }
+    precondition {
+      condition     = try(trimspace(var.brainstore_s3_bucket_name), "") != ""
+      error_message = "create_rust_api_ingest requires brainstore_s3_bucket_name (BRAINSTORE_INDEX_URI)."
     }
   }
 }

--- a/modules/api-ecs/braintrust-api-rust-ingest.tf
+++ b/modules/api-ecs/braintrust-api-rust-ingest.tf
@@ -1,6 +1,7 @@
-# Optional Rust ingest service for ALB weighted % canaries.
-# When create_rust_api_ingest is true, ingest path rules weighted-forward
-# across the TypeScript and Rust target groups (see alb-path-routes.tf).
+# Optional Rust ingest service.
+# create_rust_api_ingest stands up the service + TG.
+# enable_rust_api_ingest (or rust_api_ingest_traffic_weight while canarying)
+# controls ALB ingest path forwarding — see alb-path-routes.tf.
 
 locals {
   braintrust_api_rust_ingest_name = "braintrust-api-rust-ingest"

--- a/modules/api-ecs/braintrust-api-rust-ingest.tf
+++ b/modules/api-ecs/braintrust-api-rust-ingest.tf
@@ -1,0 +1,196 @@
+# Optional Rust ingest service for ALB weighted % canaries.
+# When create_rust_api_ingest is true, ingest path rules weighted-forward
+# across the TypeScript and Rust target groups (see alb-path-routes.tf).
+
+locals {
+  braintrust_api_rust_ingest_name = "braintrust-api-rust-ingest"
+  rust_api_ingest_version_tag = (
+    var.rust_api_ingest_version_override != null
+    ? var.rust_api_ingest_version_override
+    : try(jsondecode(file("${path.module}/VERSIONS.json"))["api_rust_ingest"], null)
+  )
+
+  rust_api_ingest_env_vars = merge(local.merged_env_vars, {
+    CLOUDWATCH_METRICS_SERVICE_NAME    = local.braintrust_api_rust_ingest_name
+    CLOUDWATCH_METRICS_DEPLOYMENT_NAME = var.deployment_name
+  })
+
+  # Canary v1: awslogs only. Datadog sidecars can follow once the image/pipeline is stable.
+  rust_api_ingest_container_definitions = jsonencode([
+    merge(local.api_container_base, {
+      name  = "api"
+      image = "${var.rust_api_ingest_container_image_repository}:${coalesce(local.rust_api_ingest_version_tag, "unset")}"
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = try(aws_cloudwatch_log_group.braintrust_api_rust_ingest[0].name, "/braintrust/${var.deployment_name}/${local.braintrust_api_rust_ingest_name}")
+          awslogs-region        = data.aws_region.current.region
+          awslogs-stream-prefix = local.braintrust_api_rust_ingest_name
+        }
+      }
+      environment = [
+        for key in sort(keys(local.rust_api_ingest_env_vars)) : {
+          name  = key
+          value = local.rust_api_ingest_env_vars[key]
+        }
+      ]
+    })
+  ])
+}
+
+resource "aws_cloudwatch_log_group" "braintrust_api_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  name              = "/braintrust/${var.deployment_name}/${local.braintrust_api_rust_ingest_name}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge({
+    Name = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}-logs"
+  }, local.common_tags)
+}
+
+resource "aws_lb_target_group" "braintrust_api_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  # Max 32 chars: deployment_name <= 18 + "-api-rs-ing".
+  name        = "${var.deployment_name}-api-rs-ing"
+  port        = 8000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  deregistration_delay = var.target_group_deregistration_delay_seconds
+
+  health_check {
+    path                = var.rust_api_ingest_health_check_path
+    matcher             = "200-399"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 10
+  }
+
+  tags = merge({
+    Name = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}"
+  }, local.common_tags)
+}
+
+resource "aws_ecs_task_definition" "braintrust_api_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  family                   = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.rust_api_ingest_cpu)
+  memory                   = tostring(var.rust_api_ingest_memory)
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = var.task_role_arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = local.rust_api_ingest_container_definitions
+
+  tags = merge({
+    Name = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}"
+  }, local.common_tags)
+
+  lifecycle {
+    precondition {
+      condition     = contains(keys(local.valid_fargate_memory_by_cpu), tostring(var.rust_api_ingest_cpu))
+      error_message = "rust_api_ingest_cpu must be a valid Fargate CPU value."
+    }
+    precondition {
+      condition     = contains(local.valid_fargate_memory_by_cpu[tostring(var.rust_api_ingest_cpu)], var.rust_api_ingest_memory)
+      error_message = "rust_api_ingest_memory must be a valid Fargate memory value for the configured cpu."
+    }
+    precondition {
+      condition     = local.rust_api_ingest_version_tag != null && trimspace(local.rust_api_ingest_version_tag) != ""
+      error_message = "create_rust_api_ingest requires rust_api_ingest_version_override or VERSIONS.json api_rust_ingest."
+    }
+    precondition {
+      condition     = trimspace(var.rust_api_ingest_container_image_repository) != ""
+      error_message = "create_rust_api_ingest requires rust_api_ingest_container_image_repository."
+    }
+  }
+}
+
+resource "aws_ecs_service" "braintrust_api_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  name                              = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}"
+  cluster                           = var.ecs_cluster_arn
+  task_definition                   = aws_ecs_task_definition.braintrust_api_rust_ingest[0].arn
+  desired_count                     = var.rust_api_ingest_min_count
+  launch_type                       = "FARGATE"
+  force_new_deployment              = true
+  propagate_tags                    = "SERVICE"
+  enable_ecs_managed_tags           = true
+  enable_execute_command            = var.enable_execute_command
+  health_check_grace_period_seconds = 60
+  wait_for_steady_state             = true
+
+  # This causes instant rollbacks on first deploy. Must be off.
+  sigint_rollback = false
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.task_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
+    container_name   = "api"
+    container_port   = 8000
+  }
+
+  depends_on = [aws_lb_listener_rule.alb_path_routes]
+
+  lifecycle {
+    create_before_destroy = false
+    ignore_changes        = [desired_count]
+  }
+
+  tags = merge({
+    Name = "${var.deployment_name}-${local.braintrust_api_rust_ingest_name}"
+  }, local.common_tags)
+}
+
+resource "aws_appautoscaling_target" "braintrust_api_rust_ingest" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  max_capacity       = var.rust_api_ingest_max_count
+  min_capacity       = var.rust_api_ingest_min_count
+  resource_id        = "service/${var.ecs_cluster_name}/${aws_ecs_service.braintrust_api_rust_ingest[0].name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "braintrust_api_rust_ingest_cpu_target" {
+  count = var.create_rust_api_ingest ? 1 : 0
+
+  name               = "${var.deployment_name}-api-rust-ingest-cpu-target"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.braintrust_api_rust_ingest[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.braintrust_api_rust_ingest[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.braintrust_api_rust_ingest[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value       = var.rust_api_ingest_cpu_autoscaling.target_value
+    scale_in_cooldown  = var.rust_api_ingest_cpu_autoscaling.scale_in_cooldown
+    scale_out_cooldown = var.rust_api_ingest_cpu_autoscaling.scale_out_cooldown
+  }
+}

--- a/modules/api-ecs/braintrust-api-rust-ingest.tf
+++ b/modules/api-ecs/braintrust-api-rust-ingest.tf
@@ -16,6 +16,8 @@ locals {
   })
 
   # Canary v1: awslogs only. Datadog sidecars can follow once the image/pipeline is stable.
+  # Override container healthCheck so it matches rust_api_ingest_health_check_path
+  # (api_container_base always probes /).
   rust_api_ingest_container_definitions = jsonencode([
     merge(local.api_container_base, {
       name  = "api"
@@ -27,6 +29,13 @@ locals {
           awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = local.braintrust_api_rust_ingest_name
         }
+      }
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8000${var.rust_api_ingest_health_check_path} || exit 1"]
+        interval    = 30
+        retries     = 3
+        startPeriod = 10
+        timeout     = 5
       }
       environment = [
         for key in sort(keys(local.rust_api_ingest_env_vars)) : {

--- a/modules/api-ecs/braintrust-api-rust-ingest.tf
+++ b/modules/api-ecs/braintrust-api-rust-ingest.tf
@@ -14,15 +14,22 @@ locals {
   rust_api_ingest_env_vars = merge(local.merged_env_vars, {
     CLOUDWATCH_METRICS_SERVICE_NAME    = local.braintrust_api_rust_ingest_name
     CLOUDWATCH_METRICS_DEPLOYMENT_NAME = var.deployment_name
+    API_RS_PORT                        = "8100"
   })
 
-  # Canary v1: awslogs only. Datadog sidecars can follow once the image/pipeline is stable.
-  # Override container healthCheck so it matches rust_api_ingest_health_check_path
-  # (api_container_base always probes /).
+  # api-rs (public.ecr.aws/braintrust/api-next) listens on 8100 with /health/liveness.
+  # Override portMappings + healthCheck from api_container_base (TS defaults to 8000 /).
   rust_api_ingest_container_definitions = jsonencode([
     merge(local.api_container_base, {
       name  = "api"
       image = "${var.rust_api_ingest_container_image_repository}:${coalesce(local.rust_api_ingest_version_tag, "unset")}"
+      portMappings = [
+        {
+          containerPort = 8100
+          hostPort      = 8100
+          protocol      = "tcp"
+        }
+      ]
       logConfiguration = {
         logDriver = "awslogs"
         options = {
@@ -32,7 +39,7 @@ locals {
         }
       }
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:8000${var.rust_api_ingest_health_check_path} || exit 1"]
+        command     = ["CMD-SHELL", "curl -f http://localhost:8100${var.rust_api_ingest_health_check_path} || exit 1"]
         interval    = 30
         retries     = 3
         startPeriod = 10
@@ -65,7 +72,7 @@ resource "aws_lb_target_group" "braintrust_api_rust_ingest" {
 
   # Max 32 chars: deployment_name <= 18 + "-api-rs-ing".
   name        = "${var.deployment_name}-api-rs-ing"
-  port        = 8000
+  port        = 8100
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = var.vpc_id
@@ -160,7 +167,7 @@ resource "aws_ecs_service" "braintrust_api_rust_ingest" {
   load_balancer {
     target_group_arn = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
     container_name   = "api"
-    container_port   = 8000
+    container_port   = 8100
   }
 
   depends_on = [aws_lb_listener_rule.alb_path_routes]

--- a/modules/api-ecs/outputs.tf
+++ b/modules/api-ecs/outputs.tf
@@ -5,11 +5,16 @@ output "service_name" {
 
 output "service_names" {
   description = "Names of all API ECS services."
-  value = {
-    braintrust_api            = aws_ecs_service.braintrust_api.name
-    braintrust_api_ingest     = aws_ecs_service.braintrust_api_ingest.name
-    braintrust_api_background = aws_ecs_service.braintrust_api_background.name
-  }
+  value = merge(
+    {
+      braintrust_api            = aws_ecs_service.braintrust_api.name
+      braintrust_api_ingest     = aws_ecs_service.braintrust_api_ingest.name
+      braintrust_api_background = aws_ecs_service.braintrust_api_background.name
+    },
+    var.create_rust_api_ingest ? {
+      braintrust_api_rust_ingest = aws_ecs_service.braintrust_api_rust_ingest[0].name
+    } : {},
+  )
 }
 
 output "alb_arn" {
@@ -49,11 +54,16 @@ output "target_group_arn_suffix" {
 
 output "target_group_arns" {
   description = "ARNs of all API ECS ALB target groups."
-  value = {
-    braintrust_api            = aws_lb_target_group.braintrust_api.arn
-    braintrust_api_ingest     = aws_lb_target_group.braintrust_api_ingest.arn
-    braintrust_api_background = aws_lb_target_group.braintrust_api_background.arn
-  }
+  value = merge(
+    {
+      braintrust_api            = aws_lb_target_group.braintrust_api.arn
+      braintrust_api_ingest     = aws_lb_target_group.braintrust_api_ingest.arn
+      braintrust_api_background = aws_lb_target_group.braintrust_api_background.arn
+    },
+    var.create_rust_api_ingest ? {
+      braintrust_api_rust_ingest = aws_lb_target_group.braintrust_api_rust_ingest[0].arn
+    } : {},
+  )
 }
 
 output "alb_security_group_id" {

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -148,13 +148,24 @@ variable "braintrust_api_event_loop_delay_autoscaling" {
 
 variable "create_rust_api_ingest" {
   type        = bool
-  description = "Create the optional Rust ingest ECS service and include it in weighted ALB forwards for ingest paths. Use rust_api_ingest_traffic_weight to dial traffic (0 = stand up with no traffic)."
+  description = "Create the optional Rust ingest ECS service + target group. Ingest paths stay on TypeScript until enable_rust_api_ingest (or a canary weight). Default false."
   default     = false
+}
+
+variable "enable_rust_api_ingest" {
+  type        = bool
+  description = "Point ingest ALB paths at the Rust target group only. Requires create_rust_api_ingest. When true, rust_api_ingest_traffic_weight is ignored."
+  default     = false
+
+  validation {
+    condition     = !var.enable_rust_api_ingest || var.create_rust_api_ingest
+    error_message = "enable_rust_api_ingest requires create_rust_api_ingest."
+  }
 }
 
 variable "rust_api_ingest_traffic_weight" {
   type        = number
-  description = "Percent of ingest ALB traffic (0-100) sent to Rust when create_rust_api_ingest is true. TypeScript receives the remainder. Ignored when create_rust_api_ingest is false."
+  description = "Percent of ingest ALB traffic (0-100) sent to Rust while create_rust_api_ingest is true and enable_rust_api_ingest is false. Ignored when create is false or enable is true."
   default     = 0
 
   validation {

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -568,6 +568,12 @@ variable "brainstore_s3_bucket_name" {
   default     = null
 }
 
+variable "brainstore_locks_s3_path" {
+  type        = string
+  description = "S3 path prefix under the Brainstore bucket for Rust ingest BRAINSTORE_LOCKS_URI. Must match Brainstore nodes (root brainstore_locks_s3_path)."
+  default     = "/locks"
+}
+
 variable "brainstore_port" {
   type        = number
   description = "Brainstore port."

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -246,8 +246,8 @@ variable "rust_api_ingest_cpu_autoscaling" {
 
 variable "rust_api_ingest_health_check_path" {
   type        = string
-  description = "Health check path for the Rust ingest target group."
-  default     = "/"
+  description = "Health check path for the Rust ingest target group and container (api-rs default: /health/liveness)."
+  default     = "/health/liveness"
 }
 
 variable "braintrust_api_ingest_cpu" {

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -146,6 +146,99 @@ variable "braintrust_api_event_loop_delay_autoscaling" {
   }
 }
 
+variable "create_rust_api_ingest" {
+  type        = bool
+  description = "Create the optional Rust ingest ECS service and include it in weighted ALB forwards for ingest paths. Use rust_api_ingest_traffic_weight to dial traffic (0 = stand up with no traffic)."
+  default     = false
+}
+
+variable "rust_api_ingest_traffic_weight" {
+  type        = number
+  description = "Percent of ingest ALB traffic (0-100) sent to Rust when create_rust_api_ingest is true. TypeScript receives the remainder. Ignored when create_rust_api_ingest is false."
+  default     = 0
+
+  validation {
+    condition     = var.rust_api_ingest_traffic_weight >= 0 && var.rust_api_ingest_traffic_weight <= 100
+    error_message = "rust_api_ingest_traffic_weight must be between 0 and 100."
+  }
+}
+
+variable "rust_api_ingest_container_image_repository" {
+  type        = string
+  description = "Container image repository for the Rust ingest ECS service. Required when create_rust_api_ingest is true."
+  default     = ""
+}
+
+variable "rust_api_ingest_version_override" {
+  type        = string
+  description = "Optional Rust ingest image tag. If null, uses modules/api-ecs/VERSIONS.json key api_rust_ingest when present."
+  default     = null
+
+  validation {
+    condition     = var.rust_api_ingest_version_override == null ? true : trimspace(var.rust_api_ingest_version_override) != ""
+    error_message = "rust_api_ingest_version_override must be null or a non-empty string."
+  }
+}
+
+variable "rust_api_ingest_cpu" {
+  type        = number
+  description = "CPU units for the braintrust-api-rust-ingest ECS task definition."
+  default     = 1024
+}
+
+variable "rust_api_ingest_memory" {
+  type        = number
+  description = "Memory (MiB) for the braintrust-api-rust-ingest ECS task definition."
+  default     = 8192
+}
+
+variable "rust_api_ingest_min_count" {
+  type        = number
+  description = "Minimum number of braintrust-api-rust-ingest ECS tasks."
+  default     = 2
+
+  validation {
+    condition     = var.rust_api_ingest_min_count >= 1
+    error_message = "rust_api_ingest_min_count must be at least 1."
+  }
+}
+
+variable "rust_api_ingest_max_count" {
+  type        = number
+  description = "Maximum number of braintrust-api-rust-ingest ECS tasks."
+  default     = 50
+
+  validation {
+    condition     = var.rust_api_ingest_max_count >= var.rust_api_ingest_min_count
+    error_message = "rust_api_ingest_max_count must be greater than or equal to rust_api_ingest_min_count."
+  }
+}
+
+variable "rust_api_ingest_cpu_autoscaling" {
+  type = object({
+    target_value       = number
+    scale_in_cooldown  = number
+    scale_out_cooldown = number
+  })
+  description = "CPU target tracking autoscaling for the braintrust-api-rust-ingest ECS service."
+  default = {
+    target_value       = 50
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+
+  validation {
+    condition     = var.rust_api_ingest_cpu_autoscaling.target_value > 0 && var.rust_api_ingest_cpu_autoscaling.target_value <= 100
+    error_message = "rust_api_ingest_cpu_autoscaling.target_value must be between 1 and 100."
+  }
+}
+
+variable "rust_api_ingest_health_check_path" {
+  type        = string
+  description = "Health check path for the Rust ingest target group."
+  default     = "/"
+}
+
 variable "braintrust_api_ingest_cpu" {
   type        = number
   description = "CPU units for the braintrust-api-ingest ECS task definition."

--- a/outputs.tf
+++ b/outputs.tf
@@ -133,6 +133,11 @@ output "api_ecs_alb_security_group_id" {
   description = "ID of the security group attached to the private API ECS ALB"
 }
 
+output "api_ecs_rust_ingest_service_name" {
+  description = "Name of the optional Rust ingest ECS service, if create_rust_api_ingest is enabled."
+  value       = local.create_ecs_api && var.create_rust_api_ingest ? module.api_ecs[0].service_names.braintrust_api_rust_ingest : null
+}
+
 output "api_ecs_http_url" {
   value       = local.create_ecs_api ? module.api_ecs[0].http_url : null
   description = "URL of the private API ECS ALB (https://<custom domain> when a certificate and custom domain are provided, otherwise http://<ALB DNS name>)"

--- a/variables.tf
+++ b/variables.tf
@@ -740,6 +740,100 @@ variable "braintrust_api_ingest_cpu_autoscaling" {
   default = {}
 }
 
+variable "create_rust_api_ingest" {
+  description = <<-EOT
+    Create the optional Rust ingest ECS service and include it in weighted ALB
+    forwards for ingest paths (/logs3, /otel/v1/*, /attachment*, /logs3/overflow).
+    Dial traffic with rust_api_ingest_traffic_weight (0 = stand up with no traffic).
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "rust_api_ingest_traffic_weight" {
+  description = "Percent of ingest ALB traffic (0-100) sent to Rust when create_rust_api_ingest is true. TypeScript receives the remainder. Default 0."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.rust_api_ingest_traffic_weight >= 0 && var.rust_api_ingest_traffic_weight <= 100
+    error_message = "rust_api_ingest_traffic_weight must be between 0 and 100."
+  }
+}
+
+variable "rust_api_ingest_container_image_repository" {
+  description = "Container image repository for Rust ingest. Required when create_rust_api_ingest is true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = !var.create_rust_api_ingest || trimspace(var.rust_api_ingest_container_image_repository) != ""
+    error_message = "rust_api_ingest_container_image_repository is required when create_rust_api_ingest is true."
+  }
+}
+
+variable "rust_api_ingest_version_override" {
+  description = "Rust ingest image tag. Required when create_rust_api_ingest is true unless VERSIONS.json has api_rust_ingest."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.rust_api_ingest_version_override == null || trimspace(var.rust_api_ingest_version_override) != ""
+    error_message = "rust_api_ingest_version_override must be null or a non-empty string."
+  }
+}
+
+variable "rust_api_ingest_cpu" {
+  description = "CPU units for the braintrust-api-rust-ingest ECS task definition."
+  type        = number
+  default     = 1024
+}
+
+variable "rust_api_ingest_memory" {
+  description = "Memory (MiB) for the braintrust-api-rust-ingest ECS task definition."
+  type        = number
+  default     = 8192
+}
+
+variable "rust_api_ingest_min_count" {
+  description = "Minimum number of braintrust-api-rust-ingest ECS tasks."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.rust_api_ingest_min_count >= 1
+    error_message = "rust_api_ingest_min_count must be at least 1."
+  }
+}
+
+variable "rust_api_ingest_max_count" {
+  description = "Maximum number of braintrust-api-rust-ingest ECS tasks."
+  type        = number
+  default     = 50
+
+  validation {
+    condition     = var.rust_api_ingest_max_count >= var.rust_api_ingest_min_count
+    error_message = "rust_api_ingest_max_count must be greater than or equal to rust_api_ingest_min_count."
+  }
+}
+
+variable "rust_api_ingest_cpu_autoscaling" {
+  description = "CPU target tracking autoscaling for the braintrust-api-rust-ingest ECS service."
+  type = object({
+    target_value       = optional(number, 50)
+    scale_in_cooldown  = optional(number, 300)
+    scale_out_cooldown = optional(number, 60)
+  })
+
+  default = {}
+}
+
+variable "rust_api_ingest_health_check_path" {
+  description = "Health check path for the Rust ingest target group."
+  type        = string
+  default     = "/"
+}
+
 variable "braintrust_api_ingest_event_loop_utilization_autoscaling" {
   description = "EventLoopUtilizationPercent target tracking autoscaling for the braintrust-api-ingest ECS service."
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -742,16 +742,36 @@ variable "braintrust_api_ingest_cpu_autoscaling" {
 
 variable "create_rust_api_ingest" {
   description = <<-EOT
-    Create the optional Rust ingest ECS service and include it in weighted ALB
-    forwards for ingest paths (/logs3, /otel/v1/*, /attachment*, /logs3/overflow).
-    Dial traffic with rust_api_ingest_traffic_weight (0 = stand up with no traffic).
+    Create the optional Rust ingest ECS service + target group. Ingest ALB paths
+    stay on TypeScript until enable_rust_api_ingest is true (or a canary weight
+    is set). For existing dataplanes: create=true, enable=false, apply; then
+    enable=true in a later apply. Greenfield can set both true in one apply.
   EOT
   type        = bool
   default     = false
 }
 
+variable "enable_rust_api_ingest" {
+  description = <<-EOT
+    Point ingest ALB paths (/logs3, /otel/v1/*, /attachment*, /logs3/overflow) at
+    the Rust target group only. Requires create_rust_api_ingest. When true,
+    rust_api_ingest_traffic_weight is ignored.
+  EOT
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.enable_rust_api_ingest || var.create_rust_api_ingest
+    error_message = "enable_rust_api_ingest requires create_rust_api_ingest."
+  }
+}
+
 variable "rust_api_ingest_traffic_weight" {
-  description = "Percent of ingest ALB traffic (0-100) sent to Rust when create_rust_api_ingest is true. TypeScript receives the remainder. Default 0."
+  description = <<-EOT
+    Percent of ingest ALB traffic (0-100) sent to Rust while create_rust_api_ingest
+    is true and enable_rust_api_ingest is false. TypeScript receives the remainder.
+    Ignored when create is false or enable is true. Default 0 (stand up with no traffic).
+  EOT
   type        = number
   default     = 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -849,9 +849,9 @@ variable "rust_api_ingest_cpu_autoscaling" {
 }
 
 variable "rust_api_ingest_health_check_path" {
-  description = "Health check path for the Rust ingest target group."
+  description = "Health check path for the Rust ingest target group and container (api-rs default: /health/liveness)."
   type        = string
-  default     = "/"
+  default     = "/health/liveness"
 }
 
 variable "braintrust_api_ingest_event_loop_utilization_autoscaling" {

--- a/variables.tf
+++ b/variables.tf
@@ -778,7 +778,7 @@ variable "rust_api_ingest_version_override" {
   default     = null
 
   validation {
-    condition     = var.rust_api_ingest_version_override == null || trimspace(var.rust_api_ingest_version_override) != ""
+    condition     = var.rust_api_ingest_version_override == null ? true : trimspace(var.rust_api_ingest_version_override) != ""
     error_message = "rust_api_ingest_version_override must be null or a non-empty string."
   }
 }


### PR DESCRIPTION
## Summary
- Adds optional `braintrust-api-rust-ingest` ECS service + TG behind `create_rust_api_ingest` (default off).
- Two-step cutover: `enable_rust_api_ingest` points ingest ALB paths at Rust only; while create is on and enable is off, `rust_api_ingest_traffic_weight` (0–100, soak-only) can split TS/Rust.
- Ingest paths: `/logs3`, `/otel/v1/*`, `/attachment*`, `/logs3/overflow`.
- Wires Brainstore storage env/secrets for api-rs (`BRAINSTORE_INDEX_URI`, realtime WAL / locks / code-bundle / response-cache URIs, plus METADATA/WAL/REDIS secrets) — matches brainstore nodes / loadtest api-next; fixes `No index URI provided`.
- Aligned with api-rs defaults: port `8100`, health `/health/liveness`.

## Test plan
- [ ] `terraform fmt` / validate on module (+ example init if needed)
- [ ] Plan with `create_rust_api_ingest = false` → no Rust resources, ingest rules unchanged
- [ ] Plan with create true / enable false / weight `0` → Rust service/TG; ingest rules include Rust TG at weight 0
- [ ] Plan weight bump (e.g. 5) → only ALB listener rule weights change
- [ ] Plan `enable_rust_api_ingest = true` → ingest paths forward to Rust only
- [ ] Confirm task env includes `BRAINSTORE_INDEX_URI=s3://…/brainstore/index` and containers pass liveness
- [ ] Confirm image repo + tag / `VERSIONS.json` `api_rust_ingest` validation fails closed when missing