### PR TITLE
feat: expose per-service ECS monitoring targets

### DIFF
--- a/modules/api-ecs/outputs.tf
+++ b/modules/api-ecs/outputs.tf
@@ -12,6 +12,27 @@ output "service_names" {
   }
 }
 
+output "monitoring_targets" {
+  description = "API ECS service and target group identifiers keyed by stable role for monitoring integrations."
+  value = {
+    api = {
+      alarm_group   = "api-ecs"
+      service_name  = aws_ecs_service.braintrust_api.name
+      tg_arn_suffix = aws_lb_target_group.braintrust_api.arn_suffix
+    }
+    api-ingest = {
+      alarm_group   = "api-ecs"
+      service_name  = aws_ecs_service.braintrust_api_ingest.name
+      tg_arn_suffix = aws_lb_target_group.braintrust_api_ingest.arn_suffix
+    }
+    api-background = {
+      alarm_group   = "api-ecs"
+      service_name  = aws_ecs_service.braintrust_api_background.name
+      tg_arn_suffix = aws_lb_target_group.braintrust_api_background.arn_suffix
+    }
+  }
+}
+
 output "alb_arn" {
   description = "ARN of the API ECS ALB."
   value       = aws_lb.api_ecs.arn

--- a/modules/api-ecs/outputs.tf
+++ b/modules/api-ecs/outputs.tf
@@ -15,7 +15,7 @@ output "service_names" {
 output "monitoring_targets" {
   description = "API ECS service and target group identifiers keyed by stable role for monitoring integrations."
   value = {
-    api = {
+    api-ecs = {
       alarm_group   = "api-ecs"
       service_name  = aws_ecs_service.braintrust_api.name
       tg_arn_suffix = aws_lb_target_group.braintrust_api.arn_suffix

--- a/outputs.tf
+++ b/outputs.tf
@@ -234,14 +234,14 @@ output "monitoring_contract" {
       cluster_name = length(module.ecs) > 0 ? module.ecs[0].cluster_name : null
       services = merge(
         local.create_ecs_api ? {
-          api-ecs = {
-            service_name  = module.api_ecs[0].service_name
-            lb_arn_suffix = module.api_ecs[0].alb_arn_suffix
-            tg_arn_suffix = module.api_ecs[0].target_group_arn_suffix
-          }
+          for role, target in module.api_ecs[0].monitoring_targets : role => merge(
+            target,
+            { lb_arn_suffix = module.api_ecs[0].alb_arn_suffix },
+          )
         } : {},
         local.create_ai_gateway ? {
           gateway = {
+            alarm_group   = "gateway"
             service_name  = module.gateway_ecs[0].service_name
             lb_arn_suffix = module.gateway_alb[0].gateway_alb_arn_suffix
             tg_arn_suffix = module.gateway_alb[0].gateway_target_group_arn_suffix


### PR DESCRIPTION
## Summary

- Export the API, API ingest, and API background ECS services as separate stable entries in `monitoring_contract.ecs.services`.
- Add `alarm_group = "api-ecs"` to preserve the fact that all three services share one API ECS ALB.

## Customer impact and adoption

This is additive and does not create, modify, replace, or remove data-plane resources.

Existing deployments are unaffected by upgrading to a release containing this output. No action is required.

## Validation

- `mise run validate`
- `mise run lint`
