### PR TITLE
Keep the CloudFront origin request policy when rolling back enable_ecs_api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,15 @@ Module changes must be applyable directly to live customer stacks without tear-d
 - Avoid env-only changes on Lambdas that do not need them — e.g. do not merge shared env into `MigrateDatabaseFunction` or crons, because that publishes a new Lambda version and re-invokes migrations.
 - Prefer state moves and in-place updates over replace; if a resource must be replaced, document why and whether downtime is expected.
 
+### Review the inverse of every `count` / `for_each`
+
+Traffic/cutover flags (`enable_ecs_api`, `enable_ai_gateway`, and similar) are meant to flip in both directions in a single apply. When adding a resource gated on such a flag:
+
+- Mentally apply `true → false`. Terraform will destroy the resource in the same apply that stops referencing it.
+- If AWS requires the parent to finish deploying that detach first, rollback fails. CloudFront origin request policies, cache policies, functions, and VPC origins are in this class — distribution updates are asynchronous, and CloudFront rejects deleting a still-attached child.
+- Do not `count` a resource on a rollback-safe flag just to avoid an unused object. Keep it created (same lifetime as the parent module / sibling origin) and only gate *attachment*.
+- `create_*` flags own resource lifetime; `enable_*` flags own routing.
+
 ### Private gateway ALB relocation
 
 The gateway internal ALB lives in `modules/gateway-alb` so callers can reference `GATEWAY_URL` without depending on `gateway-ecs`. Temporary `moved` blocks in `moved_state.tf` remount state from `services_common` → `gateway_alb` so upgrades do not destroy/recreate the ALB. Remove those moved blocks after all stacks have applied once.
@@ -74,7 +83,6 @@ Similar two-step pattern to API ECS (`enable_ecs_api`), but gateway infra itself
 - **`enable_ai_gateway`**: wire `GATEWAY_URL` on APIHandler, AIProxy, and ECS API. Requires `create_ai_gateway`.
 
 Use `create_ai_gateway = true` with `enable_ai_gateway = false` for a two-step prod cutover (stand up infra while keeping caller-supplied `GATEWAY_URL`, e.g. hosted gateway). Set both true for single-apply wiring on greenfield deployments.
-
 
 ### Upgrade Sequencing (for customers upgrading from pre-2.0)
 

--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -51,6 +51,8 @@ These services have new variables that require consideration:
 
 Set `enable_ecs_api = false` and apply. CloudFront will revert to the Lambda path. This is a fast rollback while the Lambdas are still deployed.
 
+The custom CloudFront origin request policy (`<deployment>-all-viewer-with-forwarded-proto`) is left in place after rollback. CloudFront cannot delete a policy in the same apply that detaches it from the distribution.
+
 ## Cleanup
 
 Lambda resources will continue to exist in your data plane, though they are no longer used. A future release will remove the Lambda resources.

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -30,10 +30,11 @@ locals {
   # the API can recover the viewer protocol. Do not use this policy for HTTPS origins because
   # forwarding the viewer Host header can make CloudFront validate the ALB certificate against
   # the viewer hostname; the ALB already sets X-Forwarded-Proto=https in that case.
+  # The policy resource is always created; this flag only controls whether it is attached.
   cloudfront_use_ecs_forwarded_proto_policy = var.enable_ecs_api && !var.api_ecs_alb_https_enabled
   cloudfront_ecs_origin_request_policy_id = (
     local.cloudfront_use_ecs_forwarded_proto_policy
-    ? aws_cloudfront_origin_request_policy.all_viewer_with_forwarded_proto[0].id
+    ? aws_cloudfront_origin_request_policy.all_viewer_with_forwarded_proto.id
     : local.cloudfront_AllViewerExceptHostHeader
   )
   cloudfront_origin_request_policy_for_origin = {
@@ -49,9 +50,13 @@ locals {
 
 # Forwards all viewer headers/cookies/query strings plus CloudFront-Forwarded-Proto. This is
 # safe only for the HTTP ECS origin; HTTPS origins must not forward the viewer Host header.
+#
+# Always created (not gated on enable_ecs_api or ALB HTTPS). CloudFront rejects deleting an
+# origin request policy while a distribution still references it, and distribution updates
+# deploy asynchronously. Gating this resource caused enable_ecs_api rollback (true → false)
+# to fail: Terraform detached the policy and deleted it in the same apply, before CloudFront
+# finished deploying. Keep the policy and only attach it when routing to the HTTP ECS origin.
 resource "aws_cloudfront_origin_request_policy" "all_viewer_with_forwarded_proto" {
-  count = local.cloudfront_use_ecs_forwarded_proto_policy ? 1 : 0
-
   name    = "${var.deployment_name}-all-viewer-with-forwarded-proto"
   comment = "All viewer headers plus CloudFront-Forwarded-Proto (for HTTP ECS ALB origin)"
 

--- a/modules/ingress/moved_state.tf
+++ b/modules/ingress/moved_state.tf
@@ -1,0 +1,6 @@
+# Origin request policy is always created so enable_ecs_api rollback does not
+# delete it in the same apply that detaches it from the CloudFront distribution.
+moved {
+  from = aws_cloudfront_origin_request_policy.all_viewer_with_forwarded_proto[0]
+  to   = aws_cloudfront_origin_request_policy.all_viewer_with_forwarded_proto
+}


### PR DESCRIPTION
CloudFront rejects deleting a still-attached policy while the distribution update is deploying, so always create the policy and only detach it on rollback.

This resolves a regression that was introduced in #296 which prevented terraform from executing the documented rollback procedure without manual intervention.