### PR TITLE
chore: add scorer parameter validation route

### DIFF
--- a/modules/ingress/api-gateway-openapi-spec.tf
+++ b/modules/ingress/api-gateway-openapi-spec.tf
@@ -268,6 +268,9 @@ locals {
       "/insert-functions" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }
+      "/validate-functions" = {
+        for method in ["options", "post"] : method => local.snippet_api_json_text_method
+      }
       "/logs" = {
         for method in ["options", "post"] : method => local.snippet_api_json_text_method
       }


### PR DESCRIPTION
https://github.com/braintrustdata/braintrust/pull/18155 adds a route to validate the parameters of the scorers.
