### PR TITLE
chore: add apply_immediately flag and cloudwatch_log_group outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,7 @@ module "redis" {
   use_redis_replication_group = var.use_redis_replication_group
   redis_instance_type         = var.redis_instance_type
   redis_version               = var.redis_version
+  apply_immediately           = var.redis_apply_immediately
   custom_tags                 = local.all_custom_tags
 }
 

--- a/modules/api-ecs/outputs.tf
+++ b/modules/api-ecs/outputs.tf
@@ -80,3 +80,12 @@ output "url_ssm_parameter_version" {
   description = "Version of the SSM parameter containing the API ECS URL. Increments whenever the URL changes (e.g. HTTP -> HTTPS), so consumers can pin to it and force a refresh."
   value       = aws_ssm_parameter.api_url.version
 }
+
+output "cloudwatch_log_groups" {
+  description = "Names of the cloudwatch log groups created for ECS."
+  value = {
+    braintrust_api            = aws_cloudwatch_log_group.braintrust_api.name
+    braintrust_api_ingest     = aws_cloudwatch_log_group.braintrust_api_ingest.name
+    braintrust_api_background = aws_cloudwatch_log_group.braintrust_api_background.name
+  }
+}

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -36,6 +36,7 @@ resource "aws_elasticache_cluster" "main" {
   engine_version     = var.redis_version
   subnet_group_name  = aws_elasticache_subnet_group.main.name
   security_group_ids = local.elasticache_security_group_ids
+  apply_immediately  = var.apply_immediately
   tags               = local.common_tags
 }
 
@@ -45,9 +46,10 @@ resource "aws_elasticache_replication_group" "main" {
   replication_group_id = "${var.deployment_name}-redis-rg"
   description          = "${var.deployment_name} redis"
 
-  engine         = "redis"
-  engine_version = var.redis_version
-  node_type      = var.redis_instance_type
+  engine            = "redis"
+  engine_version    = var.redis_version
+  node_type         = var.redis_instance_type
+  apply_immediately = var.apply_immediately
 
   num_cache_clusters = 1
   port               = 6379

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -47,6 +47,11 @@ variable "redis_version" {
   default     = "7.0"
 }
 
+variable "apply_immediately" {
+  type        = bool
+  description = "Apply Redis changes immediately instead of during the maintenance window"
+  default     = false
+}
 variable "custom_tags" {
   description = "Custom tags to apply to all created resources"
   type        = map(string)

--- a/modules/gateway-ecs/outputs.tf
+++ b/modules/gateway-ecs/outputs.tf
@@ -7,3 +7,10 @@ output "task_security_group_id" {
   description = "Security group ID attached to gateway ECS tasks"
   value       = aws_security_group.task.id
 }
+
+output "cloudwatch_log_groups" {
+  description = "Names of the cloudwatch log groups created for the ECS gateway."
+  value = {
+    service = aws_cloudwatch_log_group.service.name
+  }
+}

--- a/modules/loop-runtime-ecs/outputs.tf
+++ b/modules/loop-runtime-ecs/outputs.tf
@@ -12,3 +12,10 @@ output "task_role_arn" {
   description = "ARN of the Loop runtime ECS task role"
   value       = aws_iam_role.task.arn
 }
+
+output "cloudwatch_log_groups" {
+  description = "Names of the cloudwatch log groups created for the Loop runtime ECS tasks."
+  value = {
+    service = aws_cloudwatch_log_group.service.name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -206,7 +206,7 @@ output "cloudfront_distribution_hosted_zone_id" {
 output "monitoring_contract" {
   description = "Versioned resource identifiers and capabilities consumed by terraform-aws-braintrust-data-plane-cloudwatch."
   value = {
-    version = 1
+    version = 2
 
     rds = {
       identifier               = module.database.postgres_database_identifier
@@ -257,6 +257,15 @@ output "monitoring_contract" {
             tg_arn_suffix = module.gateway_alb[0].gateway_target_group_arn_suffix
           }
         } : {},
+      )
+    }
+
+    cloudwatch = {
+      log_groups = merge(
+        local.create_ecs_api ? { api-ecs = module.api_ecs[0].cloudwatch_log_groups } : {},
+        local.create_ai_gateway ? { gateway = module.gateway_ecs[0].cloudwatch_log_groups } : {},
+        local.create_loop_runtime ? { loop-runtime = module.loop_runtime_alb[0].cloudwatch_log_groups } : {},
+        local.create_loop_runtime ? { loop-runtime-sandbox = { group = module.loop_runtime_sandbox_aws_microvm[0].microvm_log_group_name } } : {},
       )
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -388,6 +388,11 @@ variable "redis_authorized_security_groups" {
   default     = {}
 }
 
+variable "redis_apply_immediately" {
+  description = "Apply Redis changes immediately instead of during the maintenance window"
+  type        = bool
+  default     = false
+}
 ## Services
 
 variable "create_ai_gateway" {


### PR DESCRIPTION
## Description 
<!-- Help the reviewer understand what you changed and what the expected behavior is now -->
<!-- Include exact details of what customers need to do, or what they should expect, if anything -->
* Add a flag to skip the maintenance window for Elasticache and apply changes immediately
* Add outputs for all cloudwatch log groups

## Context 
<!-- Help the reviewer understand the background on why you are doing this -->
* Tried to increase the instance size and there was no TF native way to apply it immediately
* Needed a list of log groups to forward to external monitoring


## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
* TFLint