### PR TITLE
Add ElastiCache Valkey support and configurable active/passive replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,39 @@ If you're using a brand new AWS account for your Braintrust data plane you will 
 
 All module input variables and outputs are documented inline in the module's Terraform files (see `variables.tf`, `outputs.tf`, and the submodules for details).
 
+### ElastiCache Redis/Valkey configuration
+
+The module provisions a cluster-mode-disabled ElastiCache instance for API and
+Brainstore coordination (transaction IDs and other short-lived state). Customer
+data lives in Postgres and S3, not in ElastiCache. The module keeps the
+existing `redis_*` outputs and `RedisUrl-` secret name for both engines.
+
+Valkey is Redis-protocol compatible and is intended for **new** deployments.
+Valkey requires
+`use_redis_replication_group = true` because the legacy single-node resource
+supports Redis only. Choose the engine when you first apply, and prefer a
+replication group so transit encryption is enabled:
+```hcl
+elasticache_engine             = "valkey"
+valkey_engine_version          = "8.0"
+use_redis_replication_group    = true
+elasticache_num_cache_clusters = 2 # one primary plus one replica
+```
+
+Confirm the Valkey version is available in the region with the ElastiCache
+`DescribeCacheEngineVersions` API before applying.
+
+Set `elasticache_num_cache_clusters` to `2` or more for a primary plus
+replicas with automatic failover. The replication group can contain one
+primary and up to five replicas (maximum six cache clusters), and its subnet
+group should span at least two Availability Zones for useful failover.
+
+Do not change `elasticache_engine` on an existing deployment (Redis→Valkey or
+Valkey→Redis). That cutover is not a supported in-place migration: it can
+replace the cluster, change the endpoint, and take API and Brainstore writes
+offline while transaction IDs cannot be allocated. Leave existing stacks on
+the engine they already run.
+
 ### Organization access configuration
 
 Prefer ID-based organization access for new deployments:

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -104,12 +104,24 @@ module "braintrust-data-plane" {
   # Default is Mon 08:00-11:00 UTC (12am-3am PST).
   # postgres_maintenance_window = "Mon:08:00-Mon:11:00"
 
-  ### Redis configuration
+  ### Redis/Valkey configuration
   # Default is acceptable for typical production deployments.
   redis_instance_type = "cache.r7g.large"
 
   # Redis engine version
   redis_version = "7.0"
+
+  # Valkey is a Redis-compatible option for new deployments. Choose it at
+  # create time; do not change elasticache_engine on an existing stack.
+  # Verify the version is available in the region before applying.
+  #   elasticache_engine             = "valkey"
+  #   valkey_engine_version          = "8.0"
+  #   use_redis_replication_group    = true
+
+  # Traditional active/passive replication group; requires subnets in at least
+  # two AZs.
+  #   use_redis_replication_group    = true
+  #   elasticache_num_cache_clusters = 2
 
   # Only use this when instructed to by the Braintrust team.
   # use_global_ai_gateway_origin   = false

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -97,9 +97,18 @@ module "braintrust-data-plane" {
   # Set to true if you need to test user-defined functions.
   enable_quarantine_vpc = false
 
-  ### Redis configuration
+  ### Redis/Valkey configuration
   redis_instance_type = "cache.t4g.small"
   redis_version       = "7.0"
+
+  # Valkey is a Redis-compatible option for new deployments. Choose it at
+  # create time; do not change elasticache_engine on an existing stack.
+  #   elasticache_engine    = "valkey"
+  #   valkey_engine_version = "8.0"
+
+  # Use replicas only when testing failover behavior.
+  #   use_redis_replication_group   = true
+  #   elasticache_num_cache_clusters = 2
 
   # Only use this when instructed to by the Braintrust team.
   # use_global_ai_gateway_origin   = false

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -93,7 +93,7 @@ module "braintrust-data-plane" {
   brainstore_writer_instance_count = 1
   brainstore_writer_instance_type  = "c8gd.8xlarge"
 
-  ### Redis configuration
+  ### Redis/Valkey configuration
 
   # Default is acceptable for typical production deployments.
   redis_instance_type = "cache.r7g.large"
@@ -101,13 +101,16 @@ module "braintrust-data-plane" {
   # Redis engine version
   redis_version = "7.0"
 
-  # ElastiCache engine: "redis" (default) or "valkey". Valkey is a Redis-compatible
-  # drop-in and requires no changes to downstream service configuration.
-  #   elasticache_engine = "valkey"
-  #   valkey_engine_version = "8.0"
+  # Valkey is a Redis-compatible option for new deployments. Choose it at
+  # create time; do not change elasticache_engine on an existing stack.
+  # Verify the version is available in the region before applying.
+  #   elasticache_engine             = "valkey"
+  #   valkey_engine_version          = "8.0"
+  #   use_redis_replication_group    = true
 
-  # Active/passive replication group (primary + replica) with automatic failover.
-  # Requires use_redis_replication_group = true.
+  # Traditional active/passive replication group (primary + replica) with
+  # automatic failover. Requires a subnet group spanning at least two AZs.
+  #   use_redis_replication_group    = true
   #   elasticache_num_cache_clusters = 2
 
   ### Tagging

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -101,6 +101,15 @@ module "braintrust-data-plane" {
   # Redis engine version
   redis_version = "7.0"
 
+  # ElastiCache engine: "redis" (default) or "valkey". Valkey is a Redis-compatible
+  # drop-in and requires no changes to downstream service configuration.
+  #   elasticache_engine = "valkey"
+  #   valkey_engine_version = "8.0"
+
+  # Active/passive replication group (primary + replica) with automatic failover.
+  # Requires use_redis_replication_group = true.
+  #   elasticache_num_cache_clusters = 2
+
   ### Tagging
   # Optionally add any custom AWS tags you want to apply to all resources created by the module
   #  custom_tags = {

--- a/main.tf
+++ b/main.tf
@@ -208,8 +208,11 @@ module "redis" {
     local.bastion_security_group,
   )
   use_redis_replication_group = var.use_redis_replication_group
+  engine                      = var.elasticache_engine
   redis_instance_type         = var.redis_instance_type
   redis_version               = var.redis_version
+  valkey_engine_version       = var.valkey_engine_version
+  num_cache_clusters          = var.elasticache_num_cache_clusters
   custom_tags                 = local.all_custom_tags
 }
 

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -4,8 +4,8 @@ locals {
   }, var.custom_tags)
   elasticache_security_group_ids = length(var.custom_security_group_ids) > 0 ? var.custom_security_group_ids : [aws_security_group.elasticache[0].id]
 
-  create_redis_replication_group = var.use_redis_replication_group
-  create_legacy_redis_cluster    = !var.use_redis_replication_group
+  create_redis_replication_group = var.use_redis_replication_group || var.engine == "valkey"
+  create_legacy_redis_cluster    = !var.use_redis_replication_group && var.engine != "valkey"
 
   engine_version = var.engine == "valkey" ? var.valkey_engine_version : var.redis_version
 
@@ -20,16 +20,26 @@ locals {
 
   redis_url = local.create_legacy_redis_cluster ? local.legacy_redis_endpoint : local.replication_group_endpoint
 }
-
 resource "aws_elasticache_subnet_group" "main" {
   name        = "${var.deployment_name}-elasticache-subnet-group"
-  description = "Subnet group for Braintrust elasticache"
+  description = "Subnet group for Braintrust ElastiCache Redis/Valkey"
   subnet_ids  = var.subnet_ids
   tags        = local.common_tags
 }
 
+resource "terraform_data" "validate_engine_topology" {
+  count = var.engine == "valkey" && !var.use_redis_replication_group ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.engine != "valkey" || var.use_redis_replication_group
+      error_message = "Valkey requires use_redis_replication_group = true because the legacy aws_elasticache_cluster resource supports Redis only. Set use_redis_replication_group = true before selecting elasticache_engine = \"valkey\"."
+    }
+  }
+}
+
 resource "aws_elasticache_cluster" "main" {
-  count = local.create_legacy_redis_cluster ? 1 : 0
+  count = local.create_legacy_redis_cluster && var.engine != "valkey" ? 1 : 0
 
   cluster_id         = "${var.deployment_name}-redis"
   engine             = var.engine
@@ -54,8 +64,9 @@ resource "aws_elasticache_replication_group" "main" {
   num_cache_clusters = var.num_cache_clusters
   port               = 6379
 
-  # Automatic failover requires at least one replica. Only enable when the
-  # topology actually has a standby node (active/passive with 2+ clusters).
+  # A replica-backed group should use Multi-AZ placement and automatic
+  # failover so a primary or Availability Zone failure can promote a replica.
+  multi_az_enabled           = var.num_cache_clusters >= 2
   automatic_failover_enabled = var.num_cache_clusters >= 2
 
   subnet_group_name  = aws_elasticache_subnet_group.main.name
@@ -68,8 +79,9 @@ resource "aws_elasticache_replication_group" "main" {
 }
 
 resource "aws_secretsmanager_secret" "redis_url" {
+  # Keep this compatibility name for both Redis and Valkey deployments.
   name_prefix = "${var.deployment_name}/RedisUrl-"
-  description = "Redis URL for the Braintrust ElastiCache cluster"
+  description = "Redis-compatible Redis/Valkey URL for the Braintrust ElastiCache cluster"
   kms_key_id  = var.kms_key_arn
   tags        = local.common_tags
 }
@@ -96,7 +108,7 @@ resource "aws_vpc_security_group_ingress_rule" "elasticache_allow_ingress_from_a
   to_port                      = 6379
   ip_protocol                  = "tcp"
   referenced_security_group_id = each.value
-  description                  = "Allow TCP/6379 (Redis) inbound to Elasticache from ${each.key}."
+  description                  = "Allow TCP/6379 (Redis/Valkey) inbound to Elasticache from ${each.key}."
 
   security_group_id = aws_security_group.elasticache[0].id
   tags              = local.common_tags

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -7,6 +7,8 @@ locals {
   create_redis_replication_group = var.use_redis_replication_group
   create_legacy_redis_cluster    = !var.use_redis_replication_group
 
+  engine_version = var.engine == "valkey" ? var.valkey_engine_version : var.redis_version
+
   legacy_redis_endpoint = try(
     "redis://${aws_elasticache_cluster.main[0].cache_nodes[0].address}:${aws_elasticache_cluster.main[0].cache_nodes[0].port}",
     null
@@ -30,10 +32,10 @@ resource "aws_elasticache_cluster" "main" {
   count = local.create_legacy_redis_cluster ? 1 : 0
 
   cluster_id         = "${var.deployment_name}-redis"
-  engine             = "redis"
+  engine             = var.engine
   node_type          = var.redis_instance_type
   num_cache_nodes    = 1
-  engine_version     = var.redis_version
+  engine_version     = local.engine_version
   subnet_group_name  = aws_elasticache_subnet_group.main.name
   security_group_ids = local.elasticache_security_group_ids
   tags               = local.common_tags
@@ -43,14 +45,18 @@ resource "aws_elasticache_replication_group" "main" {
   count = local.create_redis_replication_group ? 1 : 0
 
   replication_group_id = "${var.deployment_name}-redis-rg"
-  description          = "${var.deployment_name} redis"
+  description          = "${var.deployment_name} ${var.engine}"
 
-  engine         = "redis"
-  engine_version = var.redis_version
+  engine         = var.engine
+  engine_version = local.engine_version
   node_type      = var.redis_instance_type
 
-  num_cache_clusters = 1
+  num_cache_clusters = var.num_cache_clusters
   port               = 6379
+
+  # Automatic failover requires at least one replica. Only enable when the
+  # topology actually has a standby node (active/passive with 2+ clusters).
+  automatic_failover_enabled = var.num_cache_clusters >= 2
 
   subnet_group_name  = aws_elasticache_subnet_group.main.name
   security_group_ids = local.elasticache_security_group_ids
@@ -63,7 +69,7 @@ resource "aws_elasticache_replication_group" "main" {
 
 resource "aws_secretsmanager_secret" "redis_url" {
   name_prefix = "${var.deployment_name}/RedisUrl-"
-  description = "Redis URL for the Braintrust Redis cluster"
+  description = "Redis URL for the Braintrust ElastiCache cluster"
   kms_key_id  = var.kms_key_arn
   tags        = local.common_tags
 }

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,31 +1,33 @@
 output "redis_endpoint" {
-  value = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cache_nodes[0].address : aws_elasticache_replication_group.main[0].primary_endpoint_address
+  value       = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cache_nodes[0].address : aws_elasticache_replication_group.main[0].primary_endpoint_address
+  description = "Primary endpoint for the Redis-compatible Redis/Valkey cache."
 }
 
 output "redis_port" {
   value       = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cache_nodes[0].port : aws_elasticache_replication_group.main[0].port
-  description = "Redis port"
+  description = "Port for the Redis-compatible Redis/Valkey cache. The redis_* name is retained for compatibility."
 }
 
 output "redis_arn" {
   value       = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].arn : aws_elasticache_replication_group.main[0].arn
-  description = "Redis ARN"
+  description = "ARN of the Redis-compatible Redis/Valkey cache. The redis_* name is retained for compatibility."
 }
 
 output "monitoring_target" {
-  description = "ElastiCache target identifiers for CloudWatch monitoring."
+  description = "ElastiCache target identifiers for CloudWatch monitoring. Replication groups expose every member cluster through cache_cluster_ids; cache_cluster_id is retained for legacy single-node consumers."
   value = {
-    cache_cluster_id = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cluster_id : one(aws_elasticache_replication_group.main[0].member_clusters)
-    cache_node_id    = "0001"
+    cache_cluster_id  = local.create_legacy_redis_cluster ? aws_elasticache_cluster.main[0].cluster_id : try(one(aws_elasticache_replication_group.main[0].member_clusters), null)
+    cache_cluster_ids = local.create_legacy_redis_cluster ? [aws_elasticache_cluster.main[0].cluster_id] : aws_elasticache_replication_group.main[0].member_clusters
+    cache_node_id     = "0001"
   }
 }
 
 output "redis_security_group_id" {
   value       = local.elasticache_security_group_ids[0]
-  description = "The ID of the first security group for the Elasticache instance"
+  description = "The ID of the first security group for the Redis-compatible Redis/Valkey cache. The redis_* name is retained for compatibility."
 }
 
 output "redis_url_secret_arn" {
   value       = aws_secretsmanager_secret.redis_url.arn
-  description = "ARN of the secret containing the Redis URL"
+  description = "ARN of the secret containing the Redis-compatible Redis/Valkey URL. The redis_* name is retained for compatibility."
 }

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -35,16 +35,44 @@ variable "use_redis_replication_group" {
   type        = bool
 }
 
+variable "engine" {
+  description = "ElastiCache engine to provision. Valkey is a Redis-compatible drop-in and uses the same redis:// / rediss:// URL schemes. Switching this on an existing deployment forces replacement of the cache cluster."
+  type        = string
+  default     = "redis"
+
+  validation {
+    condition     = contains(["redis", "valkey"], var.engine)
+    error_message = "engine must be one of: redis, valkey."
+  }
+}
+
 variable "redis_instance_type" {
   type        = string
-  description = "Instance type for the Redis cluster"
+  description = "Instance type for the Redis/Valkey cluster"
   default     = "cache.r7g.large"
 }
 
 variable "redis_version" {
   type        = string
-  description = "Redis engine version"
+  description = "Redis engine version. Used when engine = \"redis\"."
   default     = "7.0"
+}
+
+variable "valkey_engine_version" {
+  type        = string
+  description = "Valkey engine version. Used when engine = \"valkey\"."
+  default     = "8.0"
+}
+
+variable "num_cache_clusters" {
+  description = "Number of nodes in the replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.num_cache_clusters >= 1 && var.num_cache_clusters <= 5
+    error_message = "num_cache_clusters must be between 1 and 5."
+  }
 }
 
 variable "custom_tags" {

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -15,12 +15,12 @@ variable "vpc_id" {
 
 variable "kms_key_arn" {
   type        = string
-  description = "KMS key ARN used to encrypt Redis URL secret."
+  description = "KMS key ARN used to encrypt the Redis-compatible Redis/Valkey URL secret."
 }
 
 variable "authorized_security_groups" {
   type        = map(string)
-  description = "Map of security group names to their IDs that are authorized to access Elasticache. Format: { name = <security_group_id> }"
+  description = "Map of security group names to their IDs that are authorized to access the Redis-compatible Redis/Valkey cache. Format: { name = <security_group_id> }"
   default     = {}
 }
 
@@ -36,7 +36,7 @@ variable "use_redis_replication_group" {
 }
 
 variable "engine" {
-  description = "ElastiCache engine to provision. Valkey is a Redis-compatible drop-in and uses the same redis:// / rediss:// URL schemes. Switching this on an existing deployment forces replacement of the cache cluster."
+  description = "ElastiCache engine to provision: \"redis\" or \"valkey\". Valkey requires use_redis_replication_group = true because the legacy single-node resource supports Redis only. Valkey is Redis-compatible and uses the same redis:// / rediss:// URL schemes. Intended for new deployments. Do not change this on an existing stack; switching engines is not a supported in-place migration and can take API and Brainstore writes offline."
   type        = string
   default     = "redis"
 
@@ -60,18 +60,18 @@ variable "redis_version" {
 
 variable "valkey_engine_version" {
   type        = string
-  description = "Valkey engine version. Used when engine = \"valkey\"."
+  description = "Valkey engine version. Used when engine = \"valkey\". Verify availability in the deployment region with the ElastiCache DescribeCacheEngineVersions API before applying."
   default     = "8.0"
 }
 
 variable "num_cache_clusters" {
-  description = "Number of nodes in the replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true."
+  description = "Number of nodes in the replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true. The maximum supported value is 6 (one primary plus up to five replicas)."
   type        = number
   default     = 1
 
   validation {
-    condition     = var.num_cache_clusters >= 1 && var.num_cache_clusters <= 5
-    error_message = "num_cache_clusters must be between 1 and 5."
+    condition     = var.num_cache_clusters >= 1 && var.num_cache_clusters <= 6
+    error_message = "num_cache_clusters must be between 1 and 6."
   }
 }
 

--- a/modules/remote-support/bastion-user-data.sh
+++ b/modules/remote-support/bastion-user-data.sh
@@ -9,6 +9,7 @@ TPL_REGION="${region}"
 TPL_DATABASE_SECRET_ARN="${database_secret_arn}"
 TPL_REDIS_HOST="${redis_host}"
 TPL_REDIS_PORT="${redis_port}"
+TPL_REDIS_SCHEME="${redis_scheme}"
 TPL_DATABASE_HOST="${database_host}"
 
 export AWS_REGION=$TPL_REGION
@@ -22,7 +23,7 @@ DB_PASSWORD=$(echo "$DB_CREDS" | jq -r .password)
 cat <<EOF > /etc/braintrust.env
 export AWS_REGION=$TPL_REGION
 export AWS_DEFAULT_REGION=$TPL_REGION
-export REDIS_URL=redis://$TPL_REDIS_HOST:$TPL_REDIS_PORT
+export REDIS_URL=$TPL_REDIS_SCHEME://$TPL_REDIS_HOST:$TPL_REDIS_PORT
 export PG_URL=postgres://$DB_USERNAME:$DB_PASSWORD@$TPL_DATABASE_HOST/postgres
 EOF
 

--- a/modules/remote-support/main-bastion.tf
+++ b/modules/remote-support/main-bastion.tf
@@ -46,6 +46,7 @@ resource "aws_instance" "bastion" {
     database_secret_arn  = var.database_secret_arn
     redis_host           = var.redis_host
     redis_port           = var.redis_port
+    redis_scheme         = var.use_redis_replication_group ? "rediss" : "redis"
     lambda_function_arns = var.lambda_function_arns
   })
   user_data_replace_on_change = true

--- a/modules/remote-support/variables.tf
+++ b/modules/remote-support/variables.tf
@@ -58,6 +58,11 @@ variable "redis_port" {
   type        = number
 }
 
+variable "use_redis_replication_group" {
+  description = "Use the rediss:// scheme when the Redis-compatible cache requires TLS."
+  type        = bool
+}
+
 variable "kms_key_arn" {
   description = "ARN of the KMS key to use for encrypting the bastion host"
   type        = string

--- a/modules/services/lambda-automation-cron.tf
+++ b/modules/services/lambda-automation-cron.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "automation_cron" {
       PG_URL                                    = local.postgres_url
       REDIS_HOST                                = var.redis_host
       REDIS_PORT                                = var.redis_port
-      REDIS_URL                                 = "redis://${var.redis_host}:${var.redis_port}"
+      REDIS_URL                                 = "${var.use_redis_replication_group ? "rediss" : "redis"}://${var.redis_host}:${var.redis_port}"
       BRAINSTORE_ENABLED                        = var.brainstore_enabled
       BRAINSTORE_BACKFILL_HISTORICAL_BATCH_SIZE = var.brainstore_etl_batch_size
       BRAINSTORE_BACKFILL_ENABLE_NONHISTORICAL  = var.brainstore_default

--- a/remote_support.tf
+++ b/remote_support.tf
@@ -11,11 +11,12 @@ module "remote_support" {
 
   deployment_name = var.deployment_name
 
-  database_host       = module.database.postgres_database_address
-  database_secret_arn = module.database.postgres_database_secret_arn
-  redis_host          = module.redis.redis_endpoint
-  redis_port          = module.redis.redis_port
-  kms_key_arn         = local.kms_key_arn
+  database_host               = module.database.postgres_database_address
+  database_secret_arn         = module.database.postgres_database_secret_arn
+  redis_host                  = module.redis.redis_endpoint
+  redis_port                  = module.redis.redis_port
+  use_redis_replication_group = var.use_redis_replication_group
+  kms_key_arn                 = local.kms_key_arn
   lambda_function_arns = compact([
     !var.use_deployment_mode_external_eks ? module.services[0].api_handler_arn : null,
     !var.use_deployment_mode_external_eks ? module.services[0].migrate_database_arn : null,

--- a/variables.tf
+++ b/variables.tf
@@ -370,16 +370,44 @@ variable "use_redis_replication_group" {
   default     = false
 }
 
+variable "elasticache_engine" {
+  description = "ElastiCache engine to provision: \"redis\" or \"valkey\". Valkey is a Redis-compatible drop-in and reuses the same redis:// / rediss:// URL schemes, so no downstream service configuration changes are required. Changing this on an existing deployment forces replacement of the cache cluster."
+  type        = string
+  default     = "redis"
+
+  validation {
+    condition     = contains(["redis", "valkey"], var.elasticache_engine)
+    error_message = "elasticache_engine must be one of: redis, valkey."
+  }
+}
+
 variable "redis_instance_type" {
-  description = "Instance type for the Redis cluster"
+  description = "Instance type for the Redis/Valkey cluster"
   type        = string
   default     = "cache.r7g.large"
 }
 
 variable "redis_version" {
-  description = "Redis engine version"
+  description = "Redis engine version. Used when elasticache_engine = \"redis\"."
   type        = string
   default     = "7.0"
+}
+
+variable "valkey_engine_version" {
+  description = "Valkey engine version. Used when elasticache_engine = \"valkey\"."
+  type        = string
+  default     = "8.0"
+}
+
+variable "elasticache_num_cache_clusters" {
+  description = "Number of nodes in the ElastiCache replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.elasticache_num_cache_clusters >= 1 && var.elasticache_num_cache_clusters <= 5
+    error_message = "elasticache_num_cache_clusters must be between 1 and 5."
+  }
 }
 
 variable "redis_authorized_security_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -363,7 +363,7 @@ variable "DANGER_disable_database_deletion_protection" {
   default     = false
 }
 
-## Redis
+## Redis/Valkey
 variable "use_redis_replication_group" {
   description = "Use an ElastiCache replication group instead of the legacy single-node ElastiCache cluster. Existing deployments should leave this false until following the documented Redis migration procedure."
   type        = bool
@@ -371,7 +371,7 @@ variable "use_redis_replication_group" {
 }
 
 variable "elasticache_engine" {
-  description = "ElastiCache engine to provision: \"redis\" or \"valkey\". Valkey is a Redis-compatible drop-in and reuses the same redis:// / rediss:// URL schemes, so no downstream service configuration changes are required. Changing this on an existing deployment forces replacement of the cache cluster."
+  description = "ElastiCache engine to provision: \"redis\" (default) or \"valkey\". Valkey requires use_redis_replication_group = true because the legacy single-node resource supports Redis only. Valkey is Redis-compatible and uses the same redis:// / rediss:// URL schemes. Intended for new deployments. Do not change this on an existing stack; switching engines is not a supported in-place migration and can take API and Brainstore writes offline."
   type        = string
   default     = "redis"
 
@@ -394,25 +394,25 @@ variable "redis_version" {
 }
 
 variable "valkey_engine_version" {
-  description = "Valkey engine version. Used when elasticache_engine = \"valkey\"."
+  description = "Valkey engine version. Used when elasticache_engine = \"valkey\". Verify that this version is available in the deployment region with the ElastiCache DescribeCacheEngineVersions API before applying."
   type        = string
   default     = "8.0"
 }
 
 variable "elasticache_num_cache_clusters" {
-  description = "Number of nodes in the ElastiCache replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true."
+  description = "Number of nodes in the ElastiCache replication group (primary + replicas). 1 = primary only; 2+ = active/passive with automatic failover. Only applies when use_redis_replication_group = true. The maximum supported value is 6 (one primary plus up to five replicas)."
   type        = number
   default     = 1
 
   validation {
-    condition     = var.elasticache_num_cache_clusters >= 1 && var.elasticache_num_cache_clusters <= 5
-    error_message = "elasticache_num_cache_clusters must be between 1 and 5."
+    condition     = var.elasticache_num_cache_clusters >= 1 && var.elasticache_num_cache_clusters <= 6
+    error_message = "elasticache_num_cache_clusters must be between 1 and 6."
   }
 }
 
 variable "redis_authorized_security_groups" {
   type        = map(string)
-  description = "Map of security group names to their IDs that are authorized to access the Redis instance. Format: { name = <security_group_id> }"
+  description = "Map of security group names to their IDs that are authorized to access the Redis-compatible Redis/Valkey instance. Format: { name = <security_group_id> }"
   default     = {}
 }
 


### PR DESCRIPTION
> [!CAUTION]
> This is experimental functionality while PR is in draft state. Don't use in an important environment

Parameterize the ElastiCache module's engine (redis|valkey) instead of hardcoding redis. Valkey is wire-compatible, so downstream consumers (redis:// / rediss:// URL schemes, REDIS_HOST/PORT wiring) need no changes.

Also expose num_cache_clusters (1-5) on the replication group so customers can run traditional active/passive (primary + replica) with automatic failover. Defaults preserve existing behavior: engine=redis, num_cache_clusters=1, so current deployments see no diff.