### PR TITLE
Harden apt against transient mirror outages in user_data

### DIFF
--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -2,6 +2,15 @@
 
 # Help prevent immediate failure of apt commands if another background process is holding the lock
 echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
+# Add retries
+echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99apt-lock-retry
+
+if ! apt-get update; then
+  echo "apt-get update failed; clearing lists and retrying..." >&2
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+  apt-get update
+fi
 
 # Mount the local SSD if it exists
 apt-get install -y nvme-cli mdadm
@@ -57,7 +66,6 @@ cat <<EOF > /etc/docker/daemon.json
   }
 }
 EOF
-apt-get update
 apt-get install -y docker.io jq earlyoom dstat
 systemctl start docker
 systemctl enable docker

--- a/modules/remote-support/bastion-user-data.sh
+++ b/modules/remote-support/bastion-user-data.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 sudo hostnamectl set-hostname bastion
 
-apt-get update
+# Help prevent immediate failure of apt commands if another background process is holding the lock
+echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
+# Add retries
+echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99apt-lock-retry
+
+if ! apt-get update; then
+  echo "apt-get update failed; clearing lists and retrying..." >&2
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+  apt-get update
+fi
+
 apt-get install -y jq unzip earlyoom postgresql-client
 snap install aws-cli --classic
 


### PR DESCRIPTION
- Set Acquire::Retries "5" so apt retries failed .deb downloads instead of failing on the first hiccup (default is 0).
- On apt-get update failure, clear /var/lib/apt/lists/* and retry to recover from corrupt/partial index state left by a flapping mirror.