### PR TITLE
Use ports.ubuntu.com for package downloads

### DIFF
--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -5,12 +5,10 @@ echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
 # Add retries
 echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99apt-lock-retry
 
-if ! apt-get update; then
-  echo "apt-get update failed; clearing lists and retrying..." >&2
-  rm -rf /var/lib/apt/lists/*
-  apt-get clean
-  apt-get update
-fi
+sed -i "s|http://[a-z0-9-]\+\.ec2\.ports\.ubuntu\.com|http://ports.ubuntu.com|g" /etc/apt/sources.list.d/ubuntu.sources
+rm -rf /var/lib/apt/lists/*
+apt-get clean
+apt-get update
 
 # Mount the local SSD if it exists
 apt-get install -y nvme-cli mdadm

--- a/modules/remote-support/bastion-user-data.sh
+++ b/modules/remote-support/bastion-user-data.sh
@@ -6,7 +6,7 @@ echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
 # Add retries
 echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99apt-lock-retry
 
-sed -i "s|http://[a-z0-9-]\+\.ec2\.ports\.ubuntu\.com|http://ports.ubuntu.com|g" /etc/apt/sources.list.d/ubuntu.sources
+sed -i "s|http://[a-z0-9-]\+\.ec2\.ports\.ubuntu\.com|http://ports.ubuntu.com|g" /etc/apt/sources.list
 rm -rf /var/lib/apt/lists/*
 apt-get clean
 apt-get update

--- a/modules/remote-support/bastion-user-data.sh
+++ b/modules/remote-support/bastion-user-data.sh
@@ -6,12 +6,10 @@ echo 'DPkg::Lock::Timeout "60";' > /etc/apt/apt.conf.d/99apt-lock-retry
 # Add retries
 echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99apt-lock-retry
 
-if ! apt-get update; then
-  echo "apt-get update failed; clearing lists and retrying..." >&2
-  rm -rf /var/lib/apt/lists/*
-  apt-get clean
-  apt-get update
-fi
+sed -i "s|http://[a-z0-9-]\+\.ec2\.ports\.ubuntu\.com|http://ports.ubuntu.com|g" /etc/apt/sources.list.d/ubuntu.sources
+rm -rf /var/lib/apt/lists/*
+apt-get clean
+apt-get update
 
 apt-get install -y jq unzip earlyoom postgresql-client
 snap install aws-cli --classic


### PR DESCRIPTION
## Description 

Use external ports.ubuntu.com for package downloads.

## Context 

The mirrors hosted in AWS are less reliable. https://ports.ubuntu.com is backed by Cloudflare CDN and seems to be more reliable. us-east-1.ec2.ports.ubuntu.com has been having severe stability issues for days.

## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
