### PR TITLE
Remove Brainstore writer restart cron

### DIFF
--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -199,11 +199,6 @@ else
   exit 1
 fi
 
-if [ "${is_dedicated_writer_node}" = "true" ]; then
-  # Until we are comfortable with stability, restart the writer node hourly with a random delay up to 30 minutes
-  echo '0 * * * * root sleep $(shuf -i 0-1800 -n 1) && /usr/bin/docker restart brainstore >> /var/log/brainstore-restart.log 2>&1' > /etc/cron.d/restart-brainstore
-fi
-
 if [ -n "${internal_observability_api_key}" ]; then
   if [ -n "${internal_observability_env_name}" ]; then
     export DD_ENV="${internal_observability_env_name}"


### PR DESCRIPTION
## Description 

Remove the brainstore restart cron from writers, it hasn't been necessary for a while. 

## Context 
<!-- Help the reviewer understand the background on why you are doing this -->

Brainstore used to have resource contention issues that were solved by restarting.

## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->

We've been running several deployments without this for months.
