### PR TITLE
Fix loop-runtime monitoring contract log group source

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -264,7 +264,7 @@ output "monitoring_contract" {
       log_groups = merge(
         local.create_ecs_api ? { api-ecs = module.api_ecs[0].cloudwatch_log_groups } : {},
         local.create_ai_gateway ? { gateway = module.gateway_ecs[0].cloudwatch_log_groups } : {},
-        local.create_loop_runtime ? { loop-runtime = module.loop_runtime_alb[0].cloudwatch_log_groups } : {},
+        local.create_loop_runtime ? { loop-runtime = module.loop_runtime_ecs[0].cloudwatch_log_groups } : {},
         local.create_loop_runtime ? { loop-runtime-sandbox = { group = module.loop_runtime_sandbox_aws_microvm[0].microvm_log_group_name } } : {},
       )
     }


### PR DESCRIPTION
## Summary
- Fixes a plan-time `Unsupported attribute` error on `monitoring_contract`: `module.loop_runtime_alb[0]` has no `cloudwatch_log_groups` output.
- Reads Loop runtime log groups from `module.loop_runtime_ecs` instead, matching the gateway/API ECS pattern.
- Regression from #341.

## Test plan
- [ ] `terraform plan` with `enable_loop_runtime = true` no longer errors on `monitoring_contract`
- [ ] Confirm `monitoring_contract.cloudwatch.log_groups.loop-runtime` is populated from the ECS service log group


Made with [Cursor](https://cursor.com)