### PR TITLE
Fix null prefix evaluation for S3 server access logging.

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -26,9 +26,13 @@ locals {
   # (e.g. destination bucket created in the same configuration).
   s3_server_access_logging_enabled = var.s3_server_access_logging != null
   s3_server_access_logging_prefix = (
-    var.s3_server_access_logging != null && var.s3_server_access_logging.prefix != null
-    ? var.s3_server_access_logging.prefix
-    : "${var.deployment_name}/"
+    var.s3_server_access_logging == null
+    ? "${var.deployment_name}/"
+    : (
+      var.s3_server_access_logging.prefix != null
+      ? var.s3_server_access_logging.prefix
+      : "${var.deployment_name}/"
+    )
   )
 
   s3_server_access_logging_buckets = {


### PR DESCRIPTION
Fix a latent issue from #328

```
│ Error: Attempt to get attribute from null value
│ 
│   on modules/storage/main.tf line 29, in locals:
│   29:     var.s3_server_access_logging != null && var.s3_server_access_logging.prefix != null
│     ├────────────────
│     │ var.s3_server_access_logging is null
│ 
│ This value is null, so it does not have any attributes.
```

Noticed this because of the tests in #294 so might be time to revisit that PR and get CI running it pre-merge