### PR TITLE
Require a Gateway when enabling Loop runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,17 @@ Similar two-step pattern to API ECS (`enable_ecs_api`), but gateway infra itself
 
 Use `create_ai_gateway = true` with `enable_ai_gateway = false` for a two-step prod cutover (stand up infra while keeping caller-supplied `GATEWAY_URL`, e.g. hosted gateway). Set both true for single-apply wiring on greenfield deployments.
 
+### Loop runtime requires a Gateway
+
+Loop v2 (the Loop runtime ECS + MicroVM sandbox) needs Gateway semantics. It cannot use the AI Proxy Lambda as the LLM router.
+
+`enable_loop_runtime` is invalid unless one of:
+
+- **Public Gateway:** `use_global_ai_gateway_origin = true` (CloudFront `/v1/proxy` → hosted `gateway.braintrust.dev`)
+- **Private Gateway:** `enable_ai_gateway = true` (wires `GATEWAY_URL` on AIProxy; Loop still uses the Function URL hop from #329)
+
+`create_ai_gateway = true` with `enable_ai_gateway = false` and `use_global_ai_gateway_origin = false` fails plan — that is AI Proxy with no Gateway. Keep `use_global_ai_gateway_origin = true` during the two-step private-gateway cutover if Loop is already on.
+
 ### Upgrade Sequencing (for customers upgrading from pre-2.0)
 
 These constraints apply to customers migrating from Data Plane 1.x to 2.0. New deployments on 2.0+ ship with WAL v3 and no-PG defaults baked in.

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -31,7 +31,8 @@ module "braintrust-data-plane" {
   # btql_audit_logs_strict_org_ids      = []
   # btql_audit_logs_best_effort_org_ids = []
 
-  # The optional Loop runtime is disabled by default.
+  # The optional Loop runtime is disabled by default. Enabling it requires a
+  # Gateway: use_global_ai_gateway_origin or enable_ai_gateway.
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
 

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -30,7 +30,8 @@ module "braintrust-data-plane" {
   # btql_audit_logs_strict_org_ids      = []
   # btql_audit_logs_best_effort_org_ids = []
 
-  # The optional Loop runtime is disabled by default.
+  # The optional Loop runtime is disabled by default. Enabling it requires a
+  # Gateway: use_global_ai_gateway_origin or enable_ai_gateway.
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
 

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -10,7 +10,8 @@ module "braintrust-data-plane" {
   # use_global_ai_gateway_origin   = false
   # global_ai_gateway_origin_domain = "gateway.braintrust.dev"
 
-  # The optional Loop runtime is disabled by default.
+  # The optional Loop runtime is disabled by default. Enabling it requires a
+  # Gateway: use_global_ai_gateway_origin or enable_ai_gateway.
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
 

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -1,6 +1,6 @@
 variable "enable_loop_runtime" {
   type        = bool
-  description = "Deploy the dedicated Loop runtime ECS/Fargate service (hosted Loop) and its MicroVM sandbox. Requires the ECS API data plane and Brainstore."
+  description = "Deploy the dedicated Loop runtime ECS/Fargate service (hosted Loop) and its MicroVM sandbox. Requires the ECS API data plane, Brainstore, and a Gateway (use_global_ai_gateway_origin or enable_ai_gateway). Loop v2 cannot use the AI Proxy Lambda alone."
   default     = false
 
   validation {
@@ -11,6 +11,11 @@ variable "enable_loop_runtime" {
   validation {
     condition     = !var.enable_loop_runtime || !var.use_deployment_mode_external_eks
     error_message = "enable_loop_runtime is not supported with use_deployment_mode_external_eks = true (the Loop runtime requires the in-VPC ECS API data plane)."
+  }
+
+  validation {
+    condition     = !var.enable_loop_runtime || var.use_global_ai_gateway_origin || var.enable_ai_gateway
+    error_message = "enable_loop_runtime requires a Gateway: set use_global_ai_gateway_origin (public hosted Gateway) or enable_ai_gateway (private Gateway). create_ai_gateway alone is not enough — Loop v2 cannot use the AI Proxy Lambda without GATEWAY_URL."
   }
 }
 


### PR DESCRIPTION
## Summary
- Loop v2 needs Gateway semantics and cannot use the AI Proxy Lambda as the LLM router.
- `enable_loop_runtime` now fails plan unless `use_global_ai_gateway_origin` (public hosted Gateway) or `enable_ai_gateway` (private Gateway, `GATEWAY_URL` on AIProxy) is set.
- `create_ai_gateway` alone is not enough — that is the two-step cutover with AI Proxy and no Gateway. Keep `use_global_ai_gateway_origin = true` during that cutover if Loop is already on.

## Test plan
- [ ] `terraform validate` / `mise run lint` on this branch
- [ ] Confirm plan fails: `enable_loop_runtime = true`, `enable_ai_gateway = false`, `use_global_ai_gateway_origin = false` (even with `create_ai_gateway = true`)
- [ ] Confirm plan succeeds: `enable_loop_runtime = true` + `enable_ai_gateway = true`
- [ ] Confirm plan succeeds: `enable_loop_runtime = true` + `use_global_ai_gateway_origin = true`
- [ ] Examples still have Loop off and are unchanged in behavior


Made with [Cursor](https://cursor.com)