### PR TITLE
Remove enable_brainstore

### DIFF
--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -2,7 +2,7 @@ locals {
   # Loop runtime requires the ECS API data plane and Brainstore (it reads
   # module.brainstore[0] for the reader URL / SG). It is fronted by the shared
   # CloudFront distribution at /loop/runtime*.
-  create_loop_runtime = local.create_ecs_api && var.enable_brainstore && var.enable_loop_runtime
+  create_loop_runtime = local.create_ecs_api && var.enable_loop_runtime
 
   loop_runtime_version = (
     var.loop_runtime_version_override != null

--- a/main.tf
+++ b/main.tf
@@ -246,13 +246,13 @@ module "services" {
   redis_host                  = module.redis.redis_endpoint
   redis_port                  = module.redis.redis_port
 
-  brainstore_enabled              = var.enable_brainstore
+  brainstore_enabled              = true
   brainstore_default              = var.brainstore_default
-  brainstore_hostname             = var.enable_brainstore ? module.brainstore[0].dns_name : null
-  brainstore_writer_hostname      = var.enable_brainstore && var.brainstore_writer_instance_count > 0 ? module.brainstore[0].writer_dns_name : null
-  brainstore_fast_reader_hostname = var.enable_brainstore && var.brainstore_fast_reader_instance_count > 0 ? module.brainstore[0].fast_reader_dns_name : null
-  brainstore_s3_bucket_name       = var.enable_brainstore ? module.storage.brainstore_bucket_id : null
-  brainstore_port                 = var.enable_brainstore ? module.brainstore[0].port : null
+  brainstore_hostname             = module.brainstore[0].dns_name
+  brainstore_writer_hostname      = var.brainstore_writer_instance_count > 0 ? module.brainstore[0].writer_dns_name : null
+  brainstore_fast_reader_hostname = var.brainstore_fast_reader_instance_count > 0 ? module.brainstore[0].fast_reader_dns_name : null
+  brainstore_s3_bucket_name       = module.storage.brainstore_bucket_id
+  brainstore_port                 = module.brainstore[0].port
   brainstore_etl_batch_size       = var.brainstore_etl_batch_size
   brainstore_wal_footer_version   = var.brainstore_wal_footer_version
   skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects
@@ -575,7 +575,7 @@ module "services_common" {
 
 module "brainstore" {
   source = "./modules/brainstore-ec2"
-  count  = var.enable_brainstore && !var.use_deployment_mode_external_eks ? 1 : 0
+  count  = !var.use_deployment_mode_external_eks ? 1 : 0
 
   deployment_name                       = var.deployment_name
   instance_count                        = var.brainstore_instance_count

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,12 +44,12 @@ output "main_vpc_private_route_table_id" {
 }
 
 output "brainstore_security_group_id" {
-  value       = var.enable_brainstore ? module.services_common.brainstore_instance_security_group_id : null
+  value       = module.services_common.brainstore_instance_security_group_id
   description = "ID of the security group for the Brainstore instances"
 }
 
 output "brainstore_s3_bucket_name" {
-  value       = var.enable_brainstore ? module.storage.brainstore_bucket_id : null
+  value       = module.storage.brainstore_bucket_id
   description = "Name of the Brainstore S3 bucket"
 }
 
@@ -229,9 +229,9 @@ output "monitoring_contract" {
     }
 
     brainstore = {
-      enabled        = var.enable_brainstore && !var.use_deployment_mode_external_eks
-      s3_bucket_name = var.enable_brainstore ? module.storage.brainstore_bucket_id : null
-      targets        = var.enable_brainstore && !var.use_deployment_mode_external_eks ? module.brainstore[0].monitoring_targets : {}
+      enabled        = !var.use_deployment_mode_external_eks
+      s3_bucket_name = module.storage.brainstore_bucket_id
+      targets        = !var.use_deployment_mode_external_eks ? module.brainstore[0].monitoring_targets : {}
     }
 
     cloudfront = {

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -4,11 +4,6 @@ variable "enable_loop_runtime" {
   default     = false
 
   validation {
-    condition     = !var.enable_loop_runtime || var.enable_brainstore
-    error_message = "enable_loop_runtime requires enable_brainstore = true (the Loop runtime reads from Brainstore)."
-  }
-
-  validation {
     condition     = !var.enable_loop_runtime || !var.use_deployment_mode_external_eks
     error_message = "enable_loop_runtime is not supported with use_deployment_mode_external_eks = true (the Loop runtime requires the in-VPC ECS API data plane)."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1115,11 +1115,6 @@ variable "lambda_version_tag_override" {
 }
 
 ## Brainstore
-variable "enable_brainstore" {
-  type        = bool
-  description = "Enable Brainstore for faster analytics"
-  default     = true
-}
 
 variable "brainstore_default" {
   type        = string


### PR DESCRIPTION
Brainstore has been required since version 2.x of the data plane so it's long overdue to be removed.

re: https://github.com/braintrustdata/terraform-aws-braintrust-data-plane/pull/294#discussion_r3830956147