### PR TITLE
Add custom CA bundle support to API ECS

### DIFF
--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -115,6 +115,9 @@ module "braintrust-data-plane" {
   # Allowed values: "off", "proxy", "warn", "reject". Defaults to "warn".
   # unsafe_url_request_mode = "warn"
 
+  # Optional custom CA bundle for outbound HTTPS from API ECS.
+  # custom_ca_bundle_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
+
   ### Network configuration
   # Defaults are fine for most sandbox deployments. Only change if you need to
   # peer with other VPCs and the default CIDRs conflict.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -148,10 +148,8 @@ module "braintrust-data-plane" {
   # url_security_allow_cidrs = "10.0.0.0/8"
 
   # Optional custom CA bundle for outbound HTTPS from API ECS. The secret value
-  # must contain PEM-encoded CA certificates. Set the KMS key ARN only when the
-  # secret uses a customer-managed key instead of the default Secrets Manager key.
-  # custom_ca_bundle_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
-  # custom_ca_bundle_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+  # must contain PEM-encoded CA certificates.
+  # custom_ca_bundle_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
 
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -147,6 +147,12 @@ module "braintrust-data-plane" {
   # url_security_dns_servers = "1.1.1.1,8.8.8.8"
   # url_security_allow_cidrs = "10.0.0.0/8"
 
+  # Optional custom CA bundle for outbound HTTPS from API ECS. The secret value
+  # must contain PEM-encoded CA certificates. Set the KMS key ARN only when the
+  # secret uses a customer-managed key instead of the default Secrets Manager key.
+  # custom_ca_bundle_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
+  # custom_ca_bundle_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.
   # brainstore_extra_env_vars = {}

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -148,8 +148,10 @@ module "braintrust-data-plane" {
   # url_security_allow_cidrs = "10.0.0.0/8"
 
   # Optional custom CA bundle for outbound HTTPS from API ECS. The secret value
-  # must contain PEM-encoded CA certificates.
-  # custom_ca_bundle_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
+  # must contain PEM-encoded CA certificates. Set the KMS key ARN only when the
+  # secret uses a customer-managed key instead of the default Secrets Manager key.
+  # custom_ca_bundle_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
+  # custom_ca_bundle_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
 
   # Uncomment these to set extra environment variables for the services.
   # Only use this when instructed to by the Braintrust team.

--- a/main.tf
+++ b/main.tf
@@ -415,11 +415,10 @@ module "api_ecs" {
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins
 
   # Data stores
-  database_url_secret_arn      = module.database.postgres_database_url_secret_arn
-  redis_url_secret_arn         = module.redis.redis_url_secret_arn
-  function_tools_secret_arn    = module.services_common.function_tools_secret_arn
-  custom_ca_bundle_secret_arn  = var.custom_ca_bundle_secret_arn
-  custom_ca_bundle_kms_key_arn = var.custom_ca_bundle_kms_key_arn
+  database_url_secret_arn     = module.database.postgres_database_url_secret_arn
+  redis_url_secret_arn        = module.redis.redis_url_secret_arn
+  function_tools_secret_arn   = module.services_common.function_tools_secret_arn
+  custom_ca_bundle_secret_arn = var.custom_ca_bundle_secret_arn
 
   # Brainstore
   brainstore_hostname             = module.brainstore[0].dns_name

--- a/main.tf
+++ b/main.tf
@@ -415,9 +415,11 @@ module "api_ecs" {
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins
 
   # Data stores
-  database_url_secret_arn   = module.database.postgres_database_url_secret_arn
-  redis_url_secret_arn      = module.redis.redis_url_secret_arn
-  function_tools_secret_arn = module.services_common.function_tools_secret_arn
+  database_url_secret_arn      = module.database.postgres_database_url_secret_arn
+  redis_url_secret_arn         = module.redis.redis_url_secret_arn
+  function_tools_secret_arn    = module.services_common.function_tools_secret_arn
+  custom_ca_bundle_secret_arn  = var.custom_ca_bundle_secret_arn
+  custom_ca_bundle_kms_key_arn = var.custom_ca_bundle_kms_key_arn
 
   # Brainstore
   brainstore_hostname             = module.brainstore[0].dns_name

--- a/main.tf
+++ b/main.tf
@@ -415,10 +415,11 @@ module "api_ecs" {
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins
 
   # Data stores
-  database_url_secret_arn     = module.database.postgres_database_url_secret_arn
-  redis_url_secret_arn        = module.redis.redis_url_secret_arn
-  function_tools_secret_arn   = module.services_common.function_tools_secret_arn
-  custom_ca_bundle_secret_arn = var.custom_ca_bundle_secret_arn
+  database_url_secret_arn      = module.database.postgres_database_url_secret_arn
+  redis_url_secret_arn         = module.redis.redis_url_secret_arn
+  function_tools_secret_arn    = module.services_common.function_tools_secret_arn
+  custom_ca_bundle_secret_arn  = var.custom_ca_bundle_secret_arn
+  custom_ca_bundle_kms_key_arn = var.custom_ca_bundle_kms_key_arn
 
   # Brainstore
   brainstore_hostname             = module.brainstore[0].dns_name

--- a/modules/api-ecs/iam.tf
+++ b/modules/api-ecs/iam.tf
@@ -50,10 +50,7 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
         Action = [
           "kms:Decrypt",
         ]
-        Resource = concat(
-          [var.kms_key_arn],
-          var.custom_ca_bundle_kms_key_arn == null ? [] : [var.custom_ca_bundle_kms_key_arn],
-        )
+        Resource = var.kms_key_arn
         Condition = {
           StringEquals = {
             "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"

--- a/modules/api-ecs/iam.tf
+++ b/modules/api-ecs/iam.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
             var.function_tools_secret_arn,
             var.redis_url_secret_arn,
           ],
+          var.custom_ca_bundle_secret_arn == null ? [] : [var.custom_ca_bundle_secret_arn],
           local.observability_enabled ? [var.internal_observability_api_key_secret_arn] : [],
         )
       },
@@ -49,7 +50,10 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
         Action = [
           "kms:Decrypt",
         ]
-        Resource = var.kms_key_arn
+        Resource = concat(
+          [var.kms_key_arn],
+          var.custom_ca_bundle_kms_key_arn == null ? [] : [var.custom_ca_bundle_kms_key_arn],
+        )
         Condition = {
           StringEquals = {
             "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"

--- a/modules/api-ecs/iam.tf
+++ b/modules/api-ecs/iam.tf
@@ -50,7 +50,10 @@ resource "aws_iam_role_policy" "task_execution_secrets" {
         Action = [
           "kms:Decrypt",
         ]
-        Resource = var.kms_key_arn
+        Resource = concat(
+          [var.kms_key_arn],
+          var.custom_ca_bundle_kms_key_arn == null ? [] : [var.custom_ca_bundle_kms_key_arn],
+        )
         Condition = {
           StringEquals = {
             "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"

--- a/modules/api-ecs/locals.tf
+++ b/modules/api-ecs/locals.tf
@@ -157,24 +157,32 @@ locals {
         protocol      = "tcp"
       }
     ]
-    secrets = [
-      {
-        name      = "FUNCTION_SECRET_KEY"
-        valueFrom = var.function_tools_secret_arn
-      },
-      {
-        name      = "PG_URL"
-        valueFrom = var.database_url_secret_arn
-      },
-      {
-        name      = "REDIS_URL"
-        valueFrom = var.redis_url_secret_arn
-      },
-      {
-        name      = "SERVICE_TOKEN_SECRET_KEY"
-        valueFrom = var.function_tools_secret_arn
-      }
-    ]
+    secrets = concat(
+      [
+        {
+          name      = "FUNCTION_SECRET_KEY"
+          valueFrom = var.function_tools_secret_arn
+        },
+        {
+          name      = "PG_URL"
+          valueFrom = var.database_url_secret_arn
+        },
+        {
+          name      = "REDIS_URL"
+          valueFrom = var.redis_url_secret_arn
+        },
+        {
+          name      = "SERVICE_TOKEN_SECRET_KEY"
+          valueFrom = var.function_tools_secret_arn
+        }
+      ],
+      var.custom_ca_bundle_secret_arn == null ? [] : [
+        {
+          name      = "BRAINTRUST_CUSTOM_CA_BUNDLE"
+          valueFrom = var.custom_ca_bundle_secret_arn
+        }
+      ],
+    )
     healthCheck = {
       command     = ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
       interval    = 30

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -452,6 +452,12 @@ variable "custom_ca_bundle_secret_arn" {
   default     = null
 }
 
+variable "custom_ca_bundle_kms_key_arn" {
+  type        = string
+  description = "Optional ARN of the customer-managed KMS key encrypting the custom CA bundle secret."
+  default     = null
+}
+
 variable "brainstore_hostname" {
   type        = string
   description = "Brainstore hostname."

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -446,6 +446,18 @@ variable "function_tools_secret_arn" {
   description = "ARN of the function tools encryption key secret."
 }
 
+variable "custom_ca_bundle_secret_arn" {
+  type        = string
+  description = "Optional ARN of the secret containing a PEM-encoded custom CA bundle."
+  default     = null
+}
+
+variable "custom_ca_bundle_kms_key_arn" {
+  type        = string
+  description = "Optional ARN of the customer-managed KMS key encrypting the custom CA bundle secret."
+  default     = null
+}
+
 variable "brainstore_hostname" {
   type        = string
   description = "Brainstore hostname."

--- a/modules/api-ecs/variables.tf
+++ b/modules/api-ecs/variables.tf
@@ -452,12 +452,6 @@ variable "custom_ca_bundle_secret_arn" {
   default     = null
 }
 
-variable "custom_ca_bundle_kms_key_arn" {
-  type        = string
-  description = "Optional ARN of the customer-managed KMS key encrypting the custom CA bundle secret."
-  default     = null
-}
-
 variable "brainstore_hostname" {
   type        = string
   description = "Brainstore hostname."

--- a/variables.tf
+++ b/variables.tf
@@ -867,6 +867,17 @@ variable "custom_ca_bundle_secret_arn" {
   default     = null
 }
 
+variable "custom_ca_bundle_kms_key_arn" {
+  description = "Optional ARN of the customer-managed KMS key encrypting custom_ca_bundle_secret_arn. Leave unset when the secret uses the default Secrets Manager KMS key."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.custom_ca_bundle_kms_key_arn == null || var.custom_ca_bundle_secret_arn != null
+    error_message = "custom_ca_bundle_secret_arn must be set when custom_ca_bundle_kms_key_arn is set."
+  }
+}
+
 variable "braintrust_api_authorized_security_groups" {
   description = "Map of security group names to their IDs that are authorized to access the internal API ECS ALB. Format: { name = <security_group_id> }"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -861,6 +861,23 @@ variable "braintrust_api_extra_env_vars" {
   }
 }
 
+variable "custom_ca_bundle_secret_arn" {
+  description = "Optional ARN of an existing AWS Secrets Manager secret containing a PEM-encoded custom CA bundle for API ECS outbound HTTPS."
+  type        = string
+  default     = null
+}
+
+variable "custom_ca_bundle_kms_key_arn" {
+  description = "Optional ARN of the customer-managed KMS key encrypting custom_ca_bundle_secret_arn. Leave unset when the secret uses the default Secrets Manager KMS key."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.custom_ca_bundle_kms_key_arn == null || var.custom_ca_bundle_secret_arn != null
+    error_message = "custom_ca_bundle_secret_arn must be set when custom_ca_bundle_kms_key_arn is set."
+  }
+}
+
 variable "braintrust_api_authorized_security_groups" {
   description = "Map of security group names to their IDs that are authorized to access the internal API ECS ALB. Format: { name = <security_group_id> }"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -867,17 +867,6 @@ variable "custom_ca_bundle_secret_arn" {
   default     = null
 }
 
-variable "custom_ca_bundle_kms_key_arn" {
-  description = "Optional ARN of the customer-managed KMS key encrypting custom_ca_bundle_secret_arn. Leave unset when the secret uses the default Secrets Manager KMS key."
-  type        = string
-  default     = null
-
-  validation {
-    condition     = var.custom_ca_bundle_kms_key_arn == null || var.custom_ca_bundle_secret_arn != null
-    error_message = "custom_ca_bundle_secret_arn must be set when custom_ca_bundle_kms_key_arn is set."
-  }
-}
-
 variable "braintrust_api_authorized_security_groups" {
   description = "Map of security group names to their IDs that are authorized to access the internal API ECS ALB. Format: { name = <security_group_id> }"
   type        = map(string)


### PR DESCRIPTION
# Add custom CA bundle support to API ECS

## Description

Adds an optional `custom_ca_bundle_secret_arn` input for API ECS.

The referenced AWS Secrets Manager secret must contain one or more PEM-encoded CA certificates:

```hcl
custom_ca_bundle_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
```

When configured, the module:

- Grants the API ECS task execution role permission to read the secret.
- Injects its value into the API handler, ingest, and background containers as `BRAINTRUST_CUSTOM_CA_BUNDLE`.
- Allows the application runtime to append those certificates to the standard Node.js CA trust store.

Existing deployments are unchanged when `custom_ca_bundle_secret_arn` is unset. Supplying the variable to an application image that predates the corresponding application support is also harmless; the environment variable will not be consumed.

## Context

Customers deploying AWS Vanilla Hybrid may use outbound TLS-inspecting proxies or internal AI gateways/proxies whose certificates are signed by private certificate authorities. Without the custom CA bundle, API ECS cannot verify the certificates presented by those endpoints because the private CA is not included in the standard Node.js trust store.

This change is intentionally scoped to outbound HTTPS initiated by the API ECS runtime. In the current architecture, that includes data-plane model requests originating from application features such as:

- Playgrounds
- Saved prompt invocations
- Experiment and evaluation flows where Braintrust executes the model request
- Prompt-based or built-in LLM scorers executed by the API service

This does not add custom CA trust to separate runtimes such as custom-code scorer quarantine functions, the AI Proxy Lambda, or the private Gateway. Those components require their own runtime and deployment integration.

## Testing

- Ran `terraform fmt -check -recursive`.
- Ran `terraform validate`.
- Ran `tflint --recursive`.
- Planned and applied the module to an AWS Vanilla Hybrid sandbox.
- Confirmed the API handler, ingest, and background ECS services deployed successfully.
- Confirmed OpenAI requests succeeded through a TLS-intercepting Squid proxy.
- Confirmed Anthropic requests succeeded through a TLS-intercepting Squid proxy.
- Confirmed requests to a private LiteLLM HTTPS endpoint using a certificate signed by the custom CA succeeded.
- Removed the dedicated custom-CA KMS configuration, reapplied the module, and repeated the OpenAI, Anthropic, and LiteLLM Playground tests successfully.