### PR TITLE
Add external EKS Loop Runtime support

### DIFF
--- a/examples/braintrust-data-plane-external-eks-quarantine/README.md
+++ b/examples/braintrust-data-plane-external-eks-quarantine/README.md
@@ -94,6 +94,15 @@ Use the Terraform outputs to configure the Helm chart:
 ```yaml
 cloud: aws
 
+objectStorage:
+  aws:
+    brainstoreBucket: "<terraform output brainstore_s3_bucket_name>"
+    codeBundleBucket: "<terraform output code_bundle_s3_bucket_name>"
+
+# Keep this prefix aligned with Terraform when using object-storage locks.
+brainstore:
+  locksS3Path: "<terraform output loop_runtime_locks_s3_path>"
+
 loopRuntime:
   enabled: true
   image:
@@ -101,7 +110,7 @@ loopRuntime:
   # Use the role ARN here with IRSA. With Pod Identity, associate this role
   # with the service account instead and leave awsRoleArn empty.
   serviceAccount:
-    name: braintrust-loop-runtime
+    name: braintrust-loop-runtime # Must match loop_runtime_eks_service_account_name.
     awsRoleArn: "<terraform output loop_runtime_eks_role_arn>"
   sandbox:
     imageIdentifier: "<terraform output loop_runtime_microvm_image_arn>"
@@ -140,9 +149,12 @@ Key outputs:
 **Other Resources:**
 
 - `main_vpc_id` - The main VPC ID
+- `brainstore_s3_bucket_name` - Name of the Brainstore S3 bucket
+- `code_bundle_s3_bucket_name` - Name of the code bundle S3 bucket
 - `loop_runtime_eks_role_arn` - IAM role for the Helm-managed Loop Runtime service account
 - `loop_runtime_microvm_image_arn` - AWS MicroVM image used by Loop Runtime
 - `loop_runtime_version` - Loop Runtime container image and sandbox artifact version
+- `loop_runtime_locks_s3_path` - Normalized object-storage lock prefix for Helm
 - `loop_runtime_sandbox_env_vars` - Non-secret sandbox settings for Helm
 
 ## Network Configuration

--- a/examples/braintrust-data-plane-external-eks-quarantine/README.md
+++ b/examples/braintrust-data-plane-external-eks-quarantine/README.md
@@ -83,6 +83,40 @@ These resources are available for use by your EKS-deployed services via EKS Pod 
    - Deploy your Braintrust services to the EKS cluster
    - Ensure services can access the Quarantine VPC
 
+### Deploying Loop Runtime with Helm
+
+Set `enable_loop_runtime = true` after EKS identity configuration. In external
+EKS mode Terraform creates the AWS MicroVM image, network connectors, and a
+dedicated IAM role; it does not create an ECS service or ALB.
+
+Use the Terraform outputs to configure the Helm chart:
+
+```yaml
+cloud: aws
+
+loopRuntime:
+  enabled: true
+  image:
+    tag: "<terraform output loop_runtime_version>"
+  # Use the role ARN here with IRSA. With Pod Identity, associate this role
+  # with the service account instead and leave awsRoleArn empty.
+  serviceAccount:
+    name: braintrust-loop-runtime
+    awsRoleArn: "<terraform output loop_runtime_eks_role_arn>"
+  sandbox:
+    imageIdentifier: "<terraform output loop_runtime_microvm_image_arn>"
+    region: "<AWS region>"
+    ingressNetworkConnectorArns: "<AWS_LAMBDA_MICROVM_INGRESS_NETWORK_CONNECTOR_ARNS>"
+    egressNetworkConnectorArns: "<AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARNS>"
+```
+
+The connector values are included in
+`terraform output -json loop_runtime_sandbox_env_vars`. The chart reads the
+existing `braintrust-secrets` keys (`PG_URL`, `REDIS_URL`,
+`FUNCTION_SECRET_KEY`, and `BRAINSTORE_LICENSE_KEY`) and automatically wires
+the API's `LOOP_RUNTIME_URL`. Enable `virtualService` if the runtime should be
+reachable through the chart-managed Istio ingress.
+
 ## Outputs
 
 After deployment, you can get important values using:
@@ -106,6 +140,10 @@ Key outputs:
 **Other Resources:**
 
 - `main_vpc_id` - The main VPC ID
+- `loop_runtime_eks_role_arn` - IAM role for the Helm-managed Loop Runtime service account
+- `loop_runtime_microvm_image_arn` - AWS MicroVM image used by Loop Runtime
+- `loop_runtime_version` - Loop Runtime container image and sandbox artifact version
+- `loop_runtime_sandbox_env_vars` - Non-secret sandbox settings for Helm
 
 ## Network Configuration
 

--- a/examples/braintrust-data-plane-external-eks-quarantine/README.md
+++ b/examples/braintrust-data-plane-external-eks-quarantine/README.md
@@ -99,10 +99,6 @@ objectStorage:
     brainstoreBucket: "<terraform output brainstore_s3_bucket_name>"
     codeBundleBucket: "<terraform output code_bundle_s3_bucket_name>"
 
-# Keep this prefix aligned with Terraform when using object-storage locks.
-brainstore:
-  locksS3Path: "<terraform output loop_runtime_locks_s3_path>"
-
 loopRuntime:
   enabled: true
   image:
@@ -154,7 +150,6 @@ Key outputs:
 - `loop_runtime_eks_role_arn` - IAM role for the Helm-managed Loop Runtime service account
 - `loop_runtime_microvm_image_arn` - AWS MicroVM image used by Loop Runtime
 - `loop_runtime_version` - Loop Runtime container image and sandbox artifact version
-- `loop_runtime_locks_s3_path` - Normalized object-storage lock prefix for Helm
 - `loop_runtime_sandbox_env_vars` - Non-secret sandbox settings for Helm
 
 ## Network Configuration

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -44,6 +44,8 @@ module "braintrust-data-plane" {
   # Loop Runtime process; enable this after configuring EKS Pod Identity or IRSA below.
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
+  # Must match loopRuntime.serviceAccount.name in the Helm deployment.
+  loop_runtime_eks_service_account_name = "braintrust-loop-runtime"
 
   # With external EKS, there are additional configurations that must be applied after the EKS cluster has been created outside of this module.
   # Enable EKS Pod Identity for the Braintrust IAM roles

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -40,7 +40,8 @@ module "braintrust-data-plane" {
   # It assumes an EKS deployment is being done outside of terraform.
   use_deployment_mode_external_eks = true
 
-  # Loop runtime is not supported with external EKS deployments.
+  # Terraform creates the AWS MicroVM sandbox and EKS IAM role. Helm runs the
+  # Loop Runtime process; enable this after configuring EKS Pod Identity or IRSA below.
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
 

--- a/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
@@ -78,8 +78,3 @@ output "loop_runtime_sandbox_env_vars" {
   description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
   value       = module.braintrust-data-plane.loop_runtime_sandbox_env_vars
 }
-
-output "loop_runtime_locks_s3_path" {
-  description = "Normalized S3 path prefix used for Loop Runtime object-store locks"
-  value       = module.braintrust-data-plane.loop_runtime_locks_s3_path
-}

--- a/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
@@ -49,6 +49,16 @@ output "kms_key_arn" {
   value       = module.braintrust-data-plane.kms_key_arn
 }
 
+output "brainstore_s3_bucket_name" {
+  description = "Name of the Brainstore S3 bucket"
+  value       = module.braintrust-data-plane.brainstore_s3_bucket_name
+}
+
+output "code_bundle_s3_bucket_name" {
+  description = "Name of the code bundle S3 bucket"
+  value       = module.braintrust-data-plane.code_bundle_s3_bucket_name
+}
+
 output "loop_runtime_version" {
   description = "Loop Runtime container and sandbox artifact version"
   value       = module.braintrust-data-plane.loop_runtime_version
@@ -67,4 +77,9 @@ output "loop_runtime_microvm_image_arn" {
 output "loop_runtime_sandbox_env_vars" {
   description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
   value       = module.braintrust-data-plane.loop_runtime_sandbox_env_vars
+}
+
+output "loop_runtime_locks_s3_path" {
+  description = "Normalized S3 path prefix used for Loop Runtime object-store locks"
+  value       = module.braintrust-data-plane.loop_runtime_locks_s3_path
 }

--- a/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/outputs.tf
@@ -48,3 +48,23 @@ output "kms_key_arn" {
   description = "ARN of the KMS key used to encrypt Braintrust resources"
   value       = module.braintrust-data-plane.kms_key_arn
 }
+
+output "loop_runtime_version" {
+  description = "Loop Runtime container and sandbox artifact version"
+  value       = module.braintrust-data-plane.loop_runtime_version
+}
+
+output "loop_runtime_eks_role_arn" {
+  description = "ARN of the IAM role to associate with the Loop Runtime EKS service account"
+  value       = module.braintrust-data-plane.loop_runtime_eks_role_arn
+}
+
+output "loop_runtime_microvm_image_arn" {
+  description = "ARN of the Loop Runtime sandbox MicroVM image"
+  value       = module.braintrust-data-plane.loop_runtime_microvm_image_arn
+}
+
+output "loop_runtime_sandbox_env_vars" {
+  description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
+  value       = module.braintrust-data-plane.loop_runtime_sandbox_env_vars
+}

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -138,6 +138,7 @@ module "loop_runtime_eks" {
   permissions_boundary_arn  = var.permissions_boundary_arn
   eks_cluster_arn           = var.existing_eks_cluster_arn
   eks_namespace             = var.eks_namespace
+  eks_service_account_name  = var.loop_runtime_eks_service_account_name
   enable_eks_pod_identity   = var.enable_eks_pod_identity
   enable_eks_irsa           = var.enable_eks_irsa
   kms_key_arn               = local.kms_key_arn

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -143,6 +143,7 @@ module "loop_runtime_eks" {
   kms_key_arn               = local.kms_key_arn
   brainstore_s3_bucket_arn  = module.storage.brainstore_bucket_arn
   code_bundle_s3_bucket_arn = module.storage.code_bundle_bucket_arn
+  brainstore_locks_s3_path  = var.brainstore_locks_s3_path
   sandbox_policy_json       = module.loop_runtime_sandbox_aws_microvm[0].task_role_policy_json
   custom_tags               = local.all_custom_tags
 }

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -144,7 +144,6 @@ module "loop_runtime_eks" {
   kms_key_arn               = local.kms_key_arn
   brainstore_s3_bucket_arn  = module.storage.brainstore_bucket_arn
   code_bundle_s3_bucket_arn = module.storage.code_bundle_bucket_arn
-  brainstore_locks_s3_path  = var.brainstore_locks_s3_path
   sandbox_policy_json       = module.loop_runtime_sandbox_aws_microvm[0].task_role_policy_json
   custom_tags               = local.all_custom_tags
 }

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -1,8 +1,9 @@
 locals {
-  # Loop runtime requires the ECS API data plane and Brainstore (it reads
-  # module.brainstore[0] for the reader URL / SG). It is fronted by the shared
-  # CloudFront distribution at /loop/runtime*.
-  create_loop_runtime = local.create_ecs_api && var.enable_loop_runtime
+  # Standard deployments run Loop Runtime on ECS. External EKS deployments
+  # create the AWS sandbox substrate and IAM here, while Helm runs the
+  # Loop Runtime process in Kubernetes.
+  create_loop_runtime     = var.enable_loop_runtime
+  create_loop_runtime_ecs = local.create_ecs_api && var.enable_loop_runtime
 
   loop_runtime_version = (
     var.loop_runtime_version_override != null
@@ -10,7 +11,7 @@ locals {
     : jsondecode(file("${path.module}/modules/loop-runtime-ecs/VERSIONS.json"))["loop-runtime"]
   )
 
-  loop_runtime_brainstore_reader_url = local.create_loop_runtime ? format(
+  loop_runtime_brainstore_reader_url = local.create_loop_runtime_ecs ? format(
     "http://%s:%s",
     var.brainstore_fast_reader_instance_count > 0 ? module.brainstore[0].fast_reader_dns_name : module.brainstore[0].dns_name,
     module.brainstore[0].port,
@@ -19,7 +20,7 @@ locals {
 
 module "loop_runtime_alb" {
   source = "./modules/loop-runtime-alb"
-  count  = local.create_loop_runtime ? 1 : 0
+  count  = local.create_loop_runtime_ecs ? 1 : 0
 
   deployment_name                      = var.deployment_name
   vpc_id                               = local.main_vpc_id
@@ -54,7 +55,7 @@ module "loop_runtime_sandbox_aws_microvm" {
 
 module "loop_runtime_ecs" {
   source = "./modules/loop-runtime-ecs"
-  count  = local.create_loop_runtime ? 1 : 0
+  count  = local.create_loop_runtime_ecs ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -127,4 +128,21 @@ module "loop_runtime_ecs" {
   internal_observability_region             = var.internal_observability_region
 
   custom_tags = local.all_custom_tags
+}
+
+module "loop_runtime_eks" {
+  source = "./modules/loop-runtime-eks"
+  count  = var.use_deployment_mode_external_eks && var.enable_loop_runtime ? 1 : 0
+
+  deployment_name           = var.deployment_name
+  permissions_boundary_arn  = var.permissions_boundary_arn
+  eks_cluster_arn           = var.existing_eks_cluster_arn
+  eks_namespace             = var.eks_namespace
+  enable_eks_pod_identity   = var.enable_eks_pod_identity
+  enable_eks_irsa           = var.enable_eks_irsa
+  kms_key_arn               = local.kms_key_arn
+  brainstore_s3_bucket_arn  = module.storage.brainstore_bucket_arn
+  code_bundle_s3_bucket_arn = module.storage.code_bundle_bucket_arn
+  sandbox_policy_json       = module.loop_runtime_sandbox_aws_microvm[0].task_role_policy_json
+  custom_tags               = local.all_custom_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ locals {
   # in-process automation cron, so windowed Loop automations run in that Lambda.
   lambda_env_services              = toset(["APIHandler", "AIProxy"])
   loop_runtime_lambda_env_services = toset(["AutomationCron"])
-  loop_runtime_lambda_env_vars = local.create_loop_runtime ? {
+  loop_runtime_lambda_env_vars = local.create_loop_runtime_ecs ? {
     LOOP_RUNTIME_URL = module.loop_runtime_alb[0].loop_runtime_url
   } : {}
   main_vpc_private_subnet_ids = [
@@ -325,7 +325,7 @@ module "services" {
 
 module "ecs" {
   source = "./modules/ecs"
-  count  = local.create_ai_gateway || local.create_ecs_api || local.create_loop_runtime ? 1 : 0
+  count  = local.create_ai_gateway || local.create_ecs_api || local.create_loop_runtime_ecs ? 1 : 0
 
   deployment_name    = var.deployment_name
   kms_key_arn        = local.kms_key_arn
@@ -541,10 +541,10 @@ module "ingress" {
   api_ecs_alb_domain                  = module.api_ecs[0].alb_domain
   api_ecs_alb_https_enabled           = module.api_ecs[0].alb_https_enabled
 
-  enable_loop_runtime                     = local.create_loop_runtime
-  loop_runtime_alb_arn                    = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_alb_arn : null
-  loop_runtime_alb_dns_name               = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_alb_dns_name : null
-  loop_runtime_cloudfront_ingress_rule_id = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_cloudfront_vpc_origin_ingress_rule_id : null
+  enable_loop_runtime                     = local.create_loop_runtime_ecs
+  loop_runtime_alb_arn                    = local.create_loop_runtime_ecs ? module.loop_runtime_alb[0].loop_runtime_alb_arn : null
+  loop_runtime_alb_dns_name               = local.create_loop_runtime_ecs ? module.loop_runtime_alb[0].loop_runtime_alb_dns_name : null
+  loop_runtime_cloudfront_ingress_rule_id = local.create_loop_runtime_ecs ? module.loop_runtime_alb[0].loop_runtime_cloudfront_vpc_origin_ingress_rule_id : null
 
   custom_tags = local.all_custom_tags
 }

--- a/modules/loop-runtime-eks/main.tf
+++ b/modules/loop-runtime-eks/main.tf
@@ -28,7 +28,7 @@ locals {
           Action = "sts:AssumeRoleWithWebIdentity"
           Condition = {
             StringLike = {
-              "${local.oidc_provider}:sub" = "system:serviceaccount:${var.eks_namespace != null ? var.eks_namespace : "*"}:*"
+              "${local.oidc_provider}:sub" = "system:serviceaccount:${var.eks_namespace != null ? var.eks_namespace : "*"}:${var.eks_service_account_name}"
             }
             StringEquals = {
               "${local.oidc_provider}:aud" = "sts.amazonaws.com"
@@ -37,30 +37,29 @@ locals {
         }
       ] : [],
       var.enable_eks_pod_identity ? [
-        merge(
-          {
-            Effect = "Allow"
-            Principal = {
-              Service = "pods.eks.amazonaws.com"
-            }
-            Action = [
-              "sts:AssumeRole",
-              "sts:TagSession"
-            ]
-          },
-          var.eks_cluster_arn != null || var.eks_namespace != null ? {
-            Condition = {
-              StringEquals = merge(
-                var.eks_cluster_arn != null ? {
-                  "aws:RequestTag/eks-cluster-arn" = [var.eks_cluster_arn]
-                } : {},
-                var.eks_namespace != null ? {
-                  "aws:RequestTag/kubernetes-namespace" = [var.eks_namespace]
-                } : {}
-              )
-            }
-          } : {}
-        )
+        {
+          Effect = "Allow"
+          Principal = {
+            Service = "pods.eks.amazonaws.com"
+          }
+          Action = [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+          Condition = {
+            StringEquals = merge(
+              {
+                "aws:RequestTag/kubernetes-service-account" = [var.eks_service_account_name]
+              },
+              var.eks_cluster_arn != null ? {
+                "aws:RequestTag/eks-cluster-arn" = [var.eks_cluster_arn]
+              } : {},
+              var.eks_namespace != null ? {
+                "aws:RequestTag/kubernetes-namespace" = [var.eks_namespace]
+              } : {}
+            )
+          }
+        }
       ] : [],
     )
   })

--- a/modules/loop-runtime-eks/main.tf
+++ b/modules/loop-runtime-eks/main.tf
@@ -14,7 +14,8 @@ locals {
 
   oidc_issuer_url = var.enable_eks_irsa && var.eks_cluster_arn != null ? data.aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer : null
   oidc_provider   = var.enable_eks_irsa && var.eks_cluster_arn != null ? replace(local.oidc_issuer_url, "https://", "") : null
-  locks_s3_path   = trimprefix(var.brainstore_locks_s3_path, "/")
+  # Keep the IAM policy aligned with the existing Helm Brainstore lock URI.
+  locks_s3_path = "brainstore/locks"
 
   assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"

--- a/modules/loop-runtime-eks/main.tf
+++ b/modules/loop-runtime-eks/main.tf
@@ -14,6 +14,7 @@ locals {
 
   oidc_issuer_url = var.enable_eks_irsa && var.eks_cluster_arn != null ? data.aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer : null
   oidc_provider   = var.enable_eks_irsa && var.eks_cluster_arn != null ? replace(local.oidc_issuer_url, "https://", "") : null
+  locks_s3_path   = trimprefix(var.brainstore_locks_s3_path, "/")
 
   assume_role_policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
@@ -112,14 +113,14 @@ resource "aws_iam_role_policy" "brainstore_s3_access" {
       {
         Effect   = "Allow"
         Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:DeleteObjectVersion"]
-        Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/locks/*"]
+        Resource = ["${var.brainstore_s3_bucket_arn}/${local.locks_s3_path}/*"]
       },
       {
         Effect   = "Allow"
         Action   = ["s3:ListBucket"]
         Resource = [var.brainstore_s3_bucket_arn]
         Condition = {
-          StringLike = { "s3:prefix" = ["brainstore/locks/*"] }
+          StringLike = { "s3:prefix" = ["${local.locks_s3_path}/*"] }
         }
       },
     ]

--- a/modules/loop-runtime-eks/main.tf
+++ b/modules/loop-runtime-eks/main.tf
@@ -1,0 +1,192 @@
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+data "aws_eks_cluster" "cluster" {
+  count = var.enable_eks_irsa && var.eks_cluster_arn != null ? 1 : 0
+  name  = split("/", var.eks_cluster_arn)[1]
+}
+
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+
+  oidc_issuer_url = var.enable_eks_irsa && var.eks_cluster_arn != null ? data.aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer : null
+  oidc_provider   = var.enable_eks_irsa && var.eks_cluster_arn != null ? replace(local.oidc_issuer_url, "https://", "") : null
+
+  assume_role_policy = jsonencode({ # nosemgrep
+    Version = "2012-10-17"
+    Statement = concat(
+      var.enable_eks_irsa && var.eks_cluster_arn != null ? [
+        {
+          Effect = "Allow"
+          Principal = {
+            Federated = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_provider}"
+          }
+          Action = "sts:AssumeRoleWithWebIdentity"
+          Condition = {
+            StringLike = {
+              "${local.oidc_provider}:sub" = "system:serviceaccount:${var.eks_namespace != null ? var.eks_namespace : "*"}:*"
+            }
+            StringEquals = {
+              "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+            }
+          }
+        }
+      ] : [],
+      var.enable_eks_pod_identity ? [
+        merge(
+          {
+            Effect = "Allow"
+            Principal = {
+              Service = "pods.eks.amazonaws.com"
+            }
+            Action = [
+              "sts:AssumeRole",
+              "sts:TagSession"
+            ]
+          },
+          var.eks_cluster_arn != null || var.eks_namespace != null ? {
+            Condition = {
+              StringEquals = merge(
+                var.eks_cluster_arn != null ? {
+                  "aws:RequestTag/eks-cluster-arn" = [var.eks_cluster_arn]
+                } : {},
+                var.eks_namespace != null ? {
+                  "aws:RequestTag/kubernetes-namespace" = [var.eks_namespace]
+                } : {}
+              )
+            }
+          } : {}
+        )
+      ] : [],
+    )
+  })
+}
+
+# This role is intentionally separate from APIHandlerRole. The Loop Runtime
+# gets only the object-store, metrics, and sandbox permissions it needs; its
+# Kubernetes pod receives database/Redis URLs from the Kubernetes Secret and
+# therefore must not read Secrets Manager directly.
+resource "aws_iam_role" "loop_runtime" {
+  name                 = "${var.deployment_name}-loop-runtime-eks"
+  assume_role_policy   = local.assume_role_policy
+  permissions_boundary = var.permissions_boundary_arn
+  tags = merge({
+    Name = "${var.deployment_name}-loop-runtime-eks"
+  }, local.common_tags)
+
+  lifecycle {
+    precondition {
+      condition     = !strcontains(lower(var.sandbox_policy_json), "secretsmanager")
+      error_message = "sandbox_policy_json must not grant Secrets Manager access to the Loop Runtime EKS role."
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "brainstore_s3_access" {
+  name = "LoopRuntimeBrainstoreS3Access"
+  role = aws_iam_role.loop_runtime.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/wal/object-store-objects/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/wal/recently-updated/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.brainstore_s3_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["brainstore/wal/recently-updated/*"] }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:DeleteObjectVersion"]
+        Resource = ["${var.brainstore_s3_bucket_arn}/brainstore/locks/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.brainstore_s3_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["brainstore/locks/*"] }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "code_bundle_access" {
+  name = "LoopRuntimeCodeBundleAccess"
+  role = aws_iam_role.loop_runtime.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = ["${var.code_bundle_s3_bucket_arn}/exo/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.code_bundle_s3_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["exo", "exo/*"] }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "kms_access" {
+  name = "LoopRuntimeKmsAccess"
+  role = aws_iam_role.loop_runtime.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+      Resource = var.kms_key_arn
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "s3.${data.aws_region.current.region}.amazonaws.com"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "cloudwatch_metrics_access" {
+  name = "LoopRuntimeCloudWatchMetricsAccess"
+  role = aws_iam_role.loop_runtime.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = ["cloudwatch:PutMetricData"], Resource = "*" }]
+  })
+}
+
+resource "aws_iam_role_policy" "ec2_tags_read_access" {
+  name = "LoopRuntimeEC2TagsReadAccess"
+  role = aws_iam_role.loop_runtime.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = ["ec2:DescribeTags"], Resource = "*" }]
+  })
+}
+
+resource "aws_iam_role_policy" "sandbox" {
+  name   = "LoopRuntimeSandbox"
+  role   = aws_iam_role.loop_runtime.id
+  policy = var.sandbox_policy_json
+}

--- a/modules/loop-runtime-eks/outputs.tf
+++ b/modules/loop-runtime-eks/outputs.tf
@@ -7,3 +7,8 @@ output "role_name" {
   description = "Name of the IAM role for the Loop Runtime EKS service account."
   value       = aws_iam_role.loop_runtime.name
 }
+
+output "locks_s3_path" {
+  description = "Normalized S3 path prefix used by the Loop Runtime EKS role for object-store locks."
+  value       = local.locks_s3_path
+}

--- a/modules/loop-runtime-eks/outputs.tf
+++ b/modules/loop-runtime-eks/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the IAM role for the Loop Runtime EKS service account."
+  value       = aws_iam_role.loop_runtime.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role for the Loop Runtime EKS service account."
+  value       = aws_iam_role.loop_runtime.name
+}

--- a/modules/loop-runtime-eks/outputs.tf
+++ b/modules/loop-runtime-eks/outputs.tf
@@ -12,3 +12,8 @@ output "locks_s3_path" {
   description = "Normalized S3 path prefix used by the Loop Runtime EKS role for object-store locks."
   value       = local.locks_s3_path
 }
+
+output "assume_role_policy_json" {
+  description = "Assume-role policy for the Loop Runtime EKS IAM role."
+  value       = local.assume_role_policy
+}

--- a/modules/loop-runtime-eks/outputs.tf
+++ b/modules/loop-runtime-eks/outputs.tf
@@ -8,8 +8,8 @@ output "role_name" {
   value       = aws_iam_role.loop_runtime.name
 }
 
-output "locks_s3_path" {
-  description = "Normalized S3 path prefix used by the Loop Runtime EKS role for object-store locks."
+output "helm_brainstore_locks_s3_path" {
+  description = "S3 path prefix used by the Helm-managed Brainstore lock namespace."
   value       = local.locks_s3_path
 }
 

--- a/modules/loop-runtime-eks/variables.tf
+++ b/modules/loop-runtime-eks/variables.tf
@@ -53,12 +53,6 @@ variable "code_bundle_s3_bucket_arn" {
   description = "ARN of the code-bundle S3 bucket."
 }
 
-variable "brainstore_locks_s3_path" {
-  type        = string
-  description = "S3 path prefix under the Brainstore bucket for BRAINSTORE_LOCKS_URI. Must match the deployment's Brainstore nodes so lock namespaces overlap."
-  default     = "/locks"
-}
-
 variable "sandbox_policy_json" {
   type        = string
   description = "IAM policy JSON emitted by the AWS MicroVM sandbox module. Must not grant Secrets Manager access."

--- a/modules/loop-runtime-eks/variables.tf
+++ b/modules/loop-runtime-eks/variables.tf
@@ -21,6 +21,11 @@ variable "eks_namespace" {
   default     = null
 }
 
+variable "eks_service_account_name" {
+  type        = string
+  description = "Kubernetes ServiceAccount name used by the Loop Runtime workload."
+}
+
 variable "enable_eks_pod_identity" {
   type        = bool
   description = "Enable EKS Pod Identity trust for the Loop Runtime role."

--- a/modules/loop-runtime-eks/variables.tf
+++ b/modules/loop-runtime-eks/variables.tf
@@ -48,6 +48,12 @@ variable "code_bundle_s3_bucket_arn" {
   description = "ARN of the code-bundle S3 bucket."
 }
 
+variable "brainstore_locks_s3_path" {
+  type        = string
+  description = "S3 path prefix under the Brainstore bucket for BRAINSTORE_LOCKS_URI. Must match the deployment's Brainstore nodes so lock namespaces overlap."
+  default     = "/locks"
+}
+
 variable "sandbox_policy_json" {
   type        = string
   description = "IAM policy JSON emitted by the AWS MicroVM sandbox module. Must not grant Secrets Manager access."

--- a/modules/loop-runtime-eks/variables.tf
+++ b/modules/loop-runtime-eks/variables.tf
@@ -1,0 +1,61 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Will be included in resource names."
+}
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "ARN of the IAM permissions boundary to apply to the Loop Runtime EKS role."
+  default     = null
+}
+
+variable "eks_cluster_arn" {
+  type        = string
+  description = "Optional EKS cluster ARN used to scope Pod Identity and IRSA trust."
+  default     = null
+}
+
+variable "eks_namespace" {
+  type        = string
+  description = "Optional Kubernetes namespace used to scope Pod Identity and IRSA trust."
+  default     = null
+}
+
+variable "enable_eks_pod_identity" {
+  type        = bool
+  description = "Enable EKS Pod Identity trust for the Loop Runtime role."
+  default     = false
+}
+
+variable "enable_eks_irsa" {
+  type        = bool
+  description = "Enable IRSA trust for the Loop Runtime role. Requires eks_cluster_arn."
+  default     = false
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "KMS key ARN used to encrypt the Braintrust object-storage buckets."
+}
+
+variable "brainstore_s3_bucket_arn" {
+  type        = string
+  description = "ARN of the Brainstore S3 bucket."
+}
+
+variable "code_bundle_s3_bucket_arn" {
+  type        = string
+  description = "ARN of the code-bundle S3 bucket."
+}
+
+variable "sandbox_policy_json" {
+  type        = string
+  description = "IAM policy JSON emitted by the AWS MicroVM sandbox module. Must not grant Secrets Manager access."
+  default     = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Tags to apply to the Loop Runtime EKS role and policies."
+  default     = {}
+}

--- a/modules/loop-runtime-eks/versions.tf
+++ b/modules/loop-runtime-eks/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.23.0, < 7.0.0"
+    }
+  }
+}

--- a/modules/loop-runtime-sandbox-aws-microvm/outputs.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/outputs.tf
@@ -4,12 +4,12 @@ output "image_arn" {
 }
 
 output "sandbox_env_vars" {
-  description = "Environment variables the Loop runtime compute module merges into the container to drive this sandbox backend. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape."
+  description = "Environment variables the Loop Runtime compute workload merges into the container to drive this sandbox backend. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape."
   value       = local.sandbox_env_vars
 }
 
 output "task_role_policy_json" {
-  description = "IAM policy (JSON) the Loop runtime ECS task role must attach to drive MicroVMs. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape (empty/adapted as needed)."
+  description = "IAM policy (JSON) the Loop Runtime compute role must attach to drive MicroVMs. Cloud-agnostic contract: a GKE/AKS sandbox module exposes the same output shape (empty/adapted as needed)."
   value       = jsonencode(local.task_role_policy)
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -178,11 +178,6 @@ output "loop_runtime_sandbox_env_vars" {
   description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
 }
 
-output "loop_runtime_locks_s3_path" {
-  value       = local.create_loop_runtime ? trimprefix(var.brainstore_locks_s3_path, "/") : null
-  description = "Normalized S3 path prefix used for Loop Runtime object-store locks"
-}
-
 output "postgres_database_identifier" {
   value       = module.database.postgres_database_identifier
   description = "Identifier of the main Braintrust Postgres database"

--- a/outputs.tf
+++ b/outputs.tf
@@ -154,13 +154,28 @@ output "api_ecs_task_security_group_id" {
 }
 
 output "loop_runtime_url" {
-  value       = local.create_loop_runtime ? module.loop_runtime_alb[0].loop_runtime_url : null
+  value       = local.create_loop_runtime_ecs ? module.loop_runtime_alb[0].loop_runtime_url : null
   description = "Private in-VPC URL of the Loop runtime ALB"
 }
 
 output "loop_runtime_microvm_image_arn" {
   value       = local.create_loop_runtime ? module.loop_runtime_sandbox_aws_microvm[0].image_arn : null
   description = "ARN of the Loop runtime sandbox MicroVM image"
+}
+
+output "loop_runtime_version" {
+  value       = local.create_loop_runtime ? local.loop_runtime_version : null
+  description = "Loop Runtime container and sandbox artifact version"
+}
+
+output "loop_runtime_eks_role_arn" {
+  value       = var.use_deployment_mode_external_eks && var.enable_loop_runtime ? module.loop_runtime_eks[0].role_arn : null
+  description = "ARN of the IAM role to associate with the Loop Runtime EKS service account"
+}
+
+output "loop_runtime_sandbox_env_vars" {
+  value       = local.create_loop_runtime ? module.loop_runtime_sandbox_aws_microvm[0].sandbox_env_vars : {}
+  description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
 }
 
 output "postgres_database_identifier" {
@@ -264,7 +279,7 @@ output "monitoring_contract" {
       log_groups = merge(
         local.create_ecs_api ? { api-ecs = module.api_ecs[0].cloudwatch_log_groups } : {},
         local.create_ai_gateway ? { gateway = module.gateway_ecs[0].cloudwatch_log_groups } : {},
-        local.create_loop_runtime ? { loop-runtime = module.loop_runtime_ecs[0].cloudwatch_log_groups } : {},
+        local.create_loop_runtime_ecs ? { loop-runtime = module.loop_runtime_ecs[0].cloudwatch_log_groups } : {},
         local.create_loop_runtime ? { loop-runtime-sandbox = { group = module.loop_runtime_sandbox_aws_microvm[0].microvm_log_group_name } } : {},
       )
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -178,6 +178,11 @@ output "loop_runtime_sandbox_env_vars" {
   description = "Non-secret AWS sandbox environment variables for the Loop Runtime Helm deployment"
 }
 
+output "loop_runtime_locks_s3_path" {
+  value       = local.create_loop_runtime ? trimprefix(var.brainstore_locks_s3_path, "/") : null
+  description = "Normalized S3 path prefix used for Loop Runtime object-store locks"
+}
+
 output "postgres_database_identifier" {
   value       = module.database.postgres_database_identifier
   description = "Identifier of the main Braintrust Postgres database"

--- a/tests/external_eks.tftest.hcl
+++ b/tests/external_eks.tftest.hcl
@@ -51,7 +51,6 @@ run "external_eks_loop_runtime_plans" {
   variables {
     enable_loop_runtime                  = true
     enable_eks_pod_identity              = true
-    brainstore_locks_s3_path             = "/custom/locks"
     loop_runtime_eks_service_account_name = "custom-loop-runtime"
   }
 
@@ -81,8 +80,8 @@ run "external_eks_loop_runtime_plans" {
   }
 
   assert {
-    condition     = module.loop_runtime_eks[0].locks_s3_path == "custom/locks"
-    error_message = "external EKS Loop Runtime should normalize the configured lock prefix"
+    condition     = module.loop_runtime_eks[0].helm_brainstore_locks_s3_path == "brainstore/locks"
+    error_message = "external EKS Loop Runtime should use the Helm Brainstore lock prefix"
   }
 
   assert {

--- a/tests/external_eks.tftest.hcl
+++ b/tests/external_eks.tftest.hcl
@@ -49,8 +49,9 @@ run "external_eks_loop_runtime_plans" {
   command = plan
 
   variables {
-    enable_loop_runtime     = true
-    enable_eks_pod_identity = true
+    enable_loop_runtime      = true
+    enable_eks_pod_identity  = true
+    brainstore_locks_s3_path = "/custom/locks"
   }
 
   assert {
@@ -76,5 +77,10 @@ run "external_eks_loop_runtime_plans" {
   assert {
     condition     = length(module.ecs) == 0
     error_message = "external EKS Loop Runtime should not create an otherwise-unused ECS cluster"
+  }
+
+  assert {
+    condition     = module.loop_runtime_eks[0].locks_s3_path == "custom/locks"
+    error_message = "external EKS Loop Runtime should normalize the configured lock prefix"
   }
 }

--- a/tests/external_eks.tftest.hcl
+++ b/tests/external_eks.tftest.hcl
@@ -49,9 +49,10 @@ run "external_eks_loop_runtime_plans" {
   command = plan
 
   variables {
-    enable_loop_runtime      = true
-    enable_eks_pod_identity  = true
-    brainstore_locks_s3_path = "/custom/locks"
+    enable_loop_runtime                  = true
+    enable_eks_pod_identity              = true
+    brainstore_locks_s3_path             = "/custom/locks"
+    loop_runtime_eks_service_account_name = "custom-loop-runtime"
   }
 
   assert {
@@ -82,5 +83,10 @@ run "external_eks_loop_runtime_plans" {
   assert {
     condition     = module.loop_runtime_eks[0].locks_s3_path == "custom/locks"
     error_message = "external EKS Loop Runtime should normalize the configured lock prefix"
+  }
+
+  assert {
+    condition     = jsondecode(module.loop_runtime_eks[0].assume_role_policy_json).Statement[0].Condition.StringEquals["aws:RequestTag/kubernetes-service-account"][0] == "custom-loop-runtime"
+    error_message = "external EKS Loop Runtime Pod Identity trust should be scoped to the configured ServiceAccount"
   }
 }

--- a/tests/external_eks.tftest.hcl
+++ b/tests/external_eks.tftest.hcl
@@ -8,6 +8,10 @@ mock_provider "aws" {
 
 mock_provider "random" {}
 
+mock_provider "http" {
+  source = "./tests/mocks/http"
+}
+
 variables {
   braintrust_org_name              = "test-org"
   primary_org_name                 = "test-org"
@@ -38,5 +42,39 @@ run "external_eks_plans" {
   assert {
     condition     = length(module.brainstore) == 0
     error_message = "external EKS mode should skip the brainstore module"
+  }
+}
+
+run "external_eks_loop_runtime_plans" {
+  command = plan
+
+  variables {
+    enable_loop_runtime     = true
+    enable_eks_pod_identity = true
+  }
+
+  assert {
+    condition     = length(module.loop_runtime_sandbox_aws_microvm) == 1
+    error_message = "external EKS Loop Runtime should create the AWS sandbox substrate"
+  }
+
+  assert {
+    condition     = length(module.loop_runtime_eks) == 1
+    error_message = "external EKS Loop Runtime should create its dedicated IAM role"
+  }
+
+  assert {
+    condition     = length(module.loop_runtime_ecs) == 0
+    error_message = "external EKS Loop Runtime should not create the ECS service"
+  }
+
+  assert {
+    condition     = length(module.loop_runtime_alb) == 0
+    error_message = "external EKS Loop Runtime should not create the ECS ALB"
+  }
+
+  assert {
+    condition     = length(module.ecs) == 0
+    error_message = "external EKS Loop Runtime should not create an otherwise-unused ECS cluster"
   }
 }

--- a/tests/invalid_combinations.tftest.hcl
+++ b/tests/invalid_combinations.tftest.hcl
@@ -39,3 +39,16 @@ run "rejects_enable_ai_gateway_without_create" {
     var.enable_ai_gateway,
   ]
 }
+
+run "rejects_loop_runtime_without_eks_identity" {
+  command = plan
+
+  variables {
+    use_deployment_mode_external_eks = true
+    enable_loop_runtime              = true
+  }
+
+  expect_failures = [
+    var.enable_loop_runtime,
+  ]
+}

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -9,6 +9,12 @@ variable "enable_loop_runtime" {
   }
 }
 
+variable "loop_runtime_eks_service_account_name" {
+  type        = string
+  description = "Kubernetes ServiceAccount name used by the Helm-managed Loop Runtime EKS workload."
+  default     = "braintrust-loop-runtime"
+}
+
 variable "loop_runtime_version_override" {
   type        = string
   description = "Pin the Loop runtime container image and MicroVM guest artifact to a specific version tag. Defaults to modules/loop-runtime-ecs/VERSIONS.json."

--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -1,11 +1,11 @@
 variable "enable_loop_runtime" {
   type        = bool
-  description = "Deploy the dedicated Loop runtime ECS/Fargate service (hosted Loop) and its MicroVM sandbox. Requires the ECS API data plane and Brainstore."
+  description = "Deploy hosted Loop Runtime. Standard deployments use ECS/Fargate; external EKS deployments create the AWS MicroVM sandbox and IAM role for the Helm-managed runtime."
   default     = false
 
   validation {
-    condition     = !var.enable_loop_runtime || !var.use_deployment_mode_external_eks
-    error_message = "enable_loop_runtime is not supported with use_deployment_mode_external_eks = true (the Loop runtime requires the in-VPC ECS API data plane)."
+    condition     = !var.enable_loop_runtime || !var.use_deployment_mode_external_eks || var.enable_eks_pod_identity || (var.enable_eks_irsa && var.existing_eks_cluster_arn != null)
+    error_message = "enable_loop_runtime with use_deployment_mode_external_eks requires enable_eks_pod_identity or enable_eks_irsa with existing_eks_cluster_arn."
   }
 }
 


### PR DESCRIPTION
## Context

External EKS deployments previously rejected Loop Runtime because Terraform only provisioned its ECS implementation. The Helm chart needs the AWS sandbox and IAM handoff to run Loop Runtime on Kubernetes.

## Description

Add external-EKS Loop Runtime support by keeping ECS/ALB resources on the standard path, provisioning the AWS MicroVM sandbox and dedicated EKS IAM role on the external-EKS path, and exposing the version/sandbox outputs needed by Helm. Update the external-EKS example and validate that external EKS does not create ECS resources.