### PR TITLE
Add custom CA bundle support to Brainstore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,15 @@ Variables prefixed with `DANGER_` (e.g., `DANGER_disable_database_deletion_prote
 
 The `internal_observability_*` variables (Datadog API key, env name, region) are for internal Braintrust engineering use. Do not add them to customer-facing documentation, production examples, or sandbox examples.
 
+### Custom CA bundle delivery
+
+`custom_ca_bundle_secret_arn` references a Secrets Manager secret containing a PEM-encoded CA bundle. Keep the certificate value out of Terraform configuration and retrieve it at runtime.
+
+- API ECS uses native ECS secret injection.
+- Brainstore EC2 retrieves the secret in `user_data` and passes the exported multiline value to Docker with `--env BRAINTRUST_CUSTOM_CA_BUNDLE`. Do not place the multiline PEM in `/etc/brainstore.env`.
+- When `custom_ca_bundle_kms_key_arn` is set, grant only `kms:Decrypt` for the supplied key and restrict it to Secrets Manager.
+- Leave existing runtime behavior unchanged when these inputs are unset.
+
 ### Scripts use `uv` shebangs
 
 Python scripts in `scripts/` use `#!/usr/bin/env -S uv run --script` with inline dependency metadata. This allows zero-setup execution without managing virtual environments. Do not replace these with plain `python3` shebangs or add `requirements.txt` files.

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -115,7 +115,7 @@ module "braintrust-data-plane" {
   # Allowed values: "off", "proxy", "warn", "reject". Defaults to "warn".
   # unsafe_url_request_mode = "warn"
 
-  # Optional custom CA bundle for outbound HTTPS from API ECS.
+  # Optional custom CA bundle for outbound HTTPS from API ECS and Brainstore EC2.
   # custom_ca_bundle_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
 
   ### Network configuration

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -147,9 +147,9 @@ module "braintrust-data-plane" {
   # url_security_dns_servers = "1.1.1.1,8.8.8.8"
   # url_security_allow_cidrs = "10.0.0.0/8"
 
-  # Optional custom CA bundle for outbound HTTPS from API ECS. The secret value
-  # must contain PEM-encoded CA certificates. Set the KMS key ARN only when the
-  # secret uses a customer-managed key instead of the default Secrets Manager key.
+  # Optional custom CA bundle for outbound HTTPS from API ECS and Brainstore EC2.
+  # The secret value must contain PEM-encoded CA certificates. Set the KMS key ARN
+  # only when the secret uses a customer-managed key instead of the default Secrets Manager key.
   # custom_ca_bundle_secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:braintrust-custom-ca-AbCdEf"
   # custom_ca_bundle_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
 

--- a/main.tf
+++ b/main.tf
@@ -567,8 +567,8 @@ module "services_common" {
   vpc_id                                    = local.main_vpc_id
   kms_key_arn                               = local.kms_key_arn
   database_secret_arn                       = module.database.postgres_database_secret_arn
-  brainstore_custom_ca_bundle_secret_arn    = var.enable_brainstore && !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_secret_arn : null
-  brainstore_custom_ca_bundle_kms_key_arn   = var.enable_brainstore && !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_kms_key_arn : null
+  brainstore_custom_ca_bundle_secret_arn    = !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_secret_arn : null
+  brainstore_custom_ca_bundle_kms_key_arn   = !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_kms_key_arn : null
   brainstore_s3_bucket_arn                  = module.storage.brainstore_bucket_arn
   code_bundle_s3_bucket_arn                 = module.storage.code_bundle_bucket_arn
   lambda_responses_s3_bucket_arn            = module.storage.lambda_responses_bucket_arn

--- a/main.tf
+++ b/main.tf
@@ -567,6 +567,8 @@ module "services_common" {
   vpc_id                                    = local.main_vpc_id
   kms_key_arn                               = local.kms_key_arn
   database_secret_arn                       = module.database.postgres_database_secret_arn
+  brainstore_custom_ca_bundle_secret_arn    = var.enable_brainstore && !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_secret_arn : null
+  brainstore_custom_ca_bundle_kms_key_arn   = var.enable_brainstore && !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_kms_key_arn : null
   brainstore_s3_bucket_arn                  = module.storage.brainstore_bucket_arn
   code_bundle_s3_bucket_arn                 = module.storage.code_bundle_bucket_arn
   lambda_responses_s3_bucket_arn            = module.storage.lambda_responses_bucket_arn
@@ -620,6 +622,7 @@ module "brainstore" {
   redis_host                            = module.redis.redis_endpoint
   redis_port                            = module.redis.redis_port
   service_token_secret_arn              = module.services_common.function_tools_secret_arn
+  custom_ca_bundle_secret_arn           = var.custom_ca_bundle_secret_arn
   brainstore_s3_bucket_arn              = module.storage.brainstore_bucket_arn
   lambda_responses_s3_bucket_arn        = module.storage.lambda_responses_bucket_arn
   code_bundle_s3_bucket_arn             = module.storage.code_bundle_bucket_arn

--- a/modules/brainstore-ec2/main-fast-reader.tf
+++ b/modules/brainstore-ec2/main-fast-reader.tf
@@ -60,6 +60,7 @@ resource "aws_launch_template" "brainstore_fast_reader" {
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
     service_token_secret_arn        = var.service_token_secret_arn
+    custom_ca_bundle_secret_arn     = var.custom_ca_bundle_secret_arn == null ? "" : var.custom_ca_bundle_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_fast_reader_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/main-writer.tf
+++ b/modules/brainstore-ec2/main-writer.tf
@@ -60,6 +60,7 @@ resource "aws_launch_template" "brainstore_writer" {
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
     service_token_secret_arn        = var.service_token_secret_arn
+    custom_ca_bundle_secret_arn     = var.custom_ca_bundle_secret_arn == null ? "" : var.custom_ca_bundle_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_writer_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/main.tf
+++ b/modules/brainstore-ec2/main.tf
@@ -82,6 +82,7 @@ resource "aws_launch_template" "brainstore" {
     internal_observability_env_name = var.internal_observability_env_name
     internal_observability_region   = var.internal_observability_region
     service_token_secret_arn        = var.service_token_secret_arn
+    custom_ca_bundle_secret_arn     = var.custom_ca_bundle_secret_arn == null ? "" : var.custom_ca_bundle_secret_arn
     custom_post_install_script      = var.custom_post_install_script
     brainstore_cache_file_size      = local.brainstore_cache_file_size
     skip_pg_for_brainstore_objects  = var.skip_pg_for_brainstore_objects

--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -139,6 +139,14 @@ if ! SERVICE_TOKEN_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id 
   exit 1
 fi
 
+%{ if custom_ca_bundle_secret_arn != "" ~}
+if ! BRAINTRUST_CUSTOM_CA_BUNDLE=$(aws secretsmanager get-secret-value --secret-id ${custom_ca_bundle_secret_arn} --query SecretString --output text); then
+  echo "Failed to retrieve BRAINTRUST_CUSTOM_CA_BUNDLE from Secrets Manager. Exiting with failure."
+  exit 1
+fi
+export BRAINTRUST_CUSTOM_CA_BUNDLE
+%{ endif ~}
+
 cat <<EOF > /etc/brainstore.env
 # WARNING: Do NOT use quotes around values here. They get passed as literals by docker.
 BRAINSTORE_VERBOSE=1
@@ -267,6 +275,9 @@ docker run -d \
   --network host \
   --name brainstore \
   --env-file /etc/brainstore.env \
+%{ if custom_ca_bundle_secret_arn != "" ~}
+  --env BRAINTRUST_CUSTOM_CA_BUNDLE \
+%{ endif ~}
   --restart always \
   --ulimit nofile=65535:65535 \
   -v /mnt/tmp/brainstore:/mnt/tmp/brainstore \

--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -130,7 +130,6 @@ systemctl enable amazon-cloudwatch-agent
 
 get_secret_value_with_retry() {
   local secret_id="$1"
-  local secret_name="$2"
   local attempt
   local retry_delay
 
@@ -140,30 +139,30 @@ get_secret_value_with_retry() {
     fi
 
     if [ "$attempt" -eq 5 ]; then
-      echo "Failed to retrieve $secret_name from Secrets Manager after $attempt attempts. Exiting with failure." >&2
+      echo "Failed to retrieve secret $secret_id from Secrets Manager after $attempt attempts. Exiting with failure." >&2
       return 1
     fi
 
     retry_delay=$((1 << (attempt - 1)))
-    echo "Failed to retrieve $secret_name from Secrets Manager. Retrying in $retry_delay seconds." >&2
+    echo "Failed to retrieve secret $secret_id from Secrets Manager. Retrying in $retry_delay seconds." >&2
     sleep "$retry_delay"
   done
 }
 
 # Get database credentials from Secrets Manager
-if ! DB_CREDS=$(get_secret_value_with_retry "${database_secret_arn}" "database credentials"); then
+if ! DB_CREDS=$(get_secret_value_with_retry "${database_secret_arn}"); then
   exit 1
 fi
 DB_USERNAME=$(echo $DB_CREDS | jq -r .username)
 DB_PASSWORD=$(echo $DB_CREDS | jq -r .password)
 
 # Get the function tools secret used by Brainstore as SERVICE_TOKEN_SECRET_KEY from Secrets Manager
-if ! SERVICE_TOKEN_SECRET_KEY=$(get_secret_value_with_retry "${service_token_secret_arn}" "SERVICE_TOKEN_SECRET_KEY"); then
+if ! SERVICE_TOKEN_SECRET_KEY=$(get_secret_value_with_retry "${service_token_secret_arn}"); then
   exit 1
 fi
 
 %{ if custom_ca_bundle_secret_arn != "" ~}
-if ! BRAINTRUST_CUSTOM_CA_BUNDLE=$(get_secret_value_with_retry "${custom_ca_bundle_secret_arn}" "BRAINTRUST_CUSTOM_CA_BUNDLE"); then
+if ! BRAINTRUST_CUSTOM_CA_BUNDLE=$(get_secret_value_with_retry "${custom_ca_bundle_secret_arn}"); then
   exit 1
 fi
 export BRAINTRUST_CUSTOM_CA_BUNDLE

--- a/modules/brainstore-ec2/templates/user_data.sh.tpl
+++ b/modules/brainstore-ec2/templates/user_data.sh.tpl
@@ -128,20 +128,42 @@ systemctl daemon-reload
 systemctl start amazon-cloudwatch-agent
 systemctl enable amazon-cloudwatch-agent
 
+get_secret_value_with_retry() {
+  local secret_id="$1"
+  local secret_name="$2"
+  local attempt
+  local retry_delay
+
+  for attempt in 1 2 3 4 5; do
+    if aws secretsmanager get-secret-value --secret-id "$secret_id" --query SecretString --output text; then
+      return 0
+    fi
+
+    if [ "$attempt" -eq 5 ]; then
+      echo "Failed to retrieve $secret_name from Secrets Manager after $attempt attempts. Exiting with failure." >&2
+      return 1
+    fi
+
+    retry_delay=$((1 << (attempt - 1)))
+    echo "Failed to retrieve $secret_name from Secrets Manager. Retrying in $retry_delay seconds." >&2
+    sleep "$retry_delay"
+  done
+}
+
 # Get database credentials from Secrets Manager
-DB_CREDS=$(aws secretsmanager get-secret-value --secret-id ${database_secret_arn} --query SecretString --output text)
+if ! DB_CREDS=$(get_secret_value_with_retry "${database_secret_arn}" "database credentials"); then
+  exit 1
+fi
 DB_USERNAME=$(echo $DB_CREDS | jq -r .username)
 DB_PASSWORD=$(echo $DB_CREDS | jq -r .password)
 
 # Get the function tools secret used by Brainstore as SERVICE_TOKEN_SECRET_KEY from Secrets Manager
-if ! SERVICE_TOKEN_SECRET_KEY=$(aws secretsmanager get-secret-value --secret-id ${service_token_secret_arn} --query SecretString --output text); then
-  echo "Failed to retrieve SERVICE_TOKEN_SECRET_KEY from Secrets Manager. Exiting with failure."
+if ! SERVICE_TOKEN_SECRET_KEY=$(get_secret_value_with_retry "${service_token_secret_arn}" "SERVICE_TOKEN_SECRET_KEY"); then
   exit 1
 fi
 
 %{ if custom_ca_bundle_secret_arn != "" ~}
-if ! BRAINTRUST_CUSTOM_CA_BUNDLE=$(aws secretsmanager get-secret-value --secret-id ${custom_ca_bundle_secret_arn} --query SecretString --output text); then
-  echo "Failed to retrieve BRAINTRUST_CUSTOM_CA_BUNDLE from Secrets Manager. Exiting with failure."
+if ! BRAINTRUST_CUSTOM_CA_BUNDLE=$(get_secret_value_with_retry "${custom_ca_bundle_secret_arn}" "BRAINTRUST_CUSTOM_CA_BUNDLE"); then
   exit 1
 fi
 export BRAINTRUST_CUSTOM_CA_BUNDLE

--- a/modules/brainstore-ec2/variables.tf
+++ b/modules/brainstore-ec2/variables.tf
@@ -171,6 +171,12 @@ variable "service_token_secret_arn" {
   description = "The ARN of the Secrets Manager secret containing SERVICE_TOKEN_SECRET_KEY."
 }
 
+variable "custom_ca_bundle_secret_arn" {
+  type        = string
+  description = "Optional ARN of the secret containing a PEM-encoded custom CA bundle."
+  default     = null
+}
+
 variable "ai_proxy_url_ssm_parameter" {
   type        = string
   description = "Selector for the SSM parameter holding the URL Brainstore uses for BRAINSTORE_AI_PROXY_URL. Either a bare \"<name>\" or a version-pinned \"<name>:<version>\". When a version is pinned, it is baked into user_data so a URL change forces a rolling instance refresh."

--- a/modules/services-common/iam-brainstore.tf
+++ b/modules/services-common/iam-brainstore.tf
@@ -119,16 +119,33 @@ resource "aws_iam_role_policy" "brainstore_secrets_access" {
 
   policy = jsonencode({ # nosemgrep
     Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = "secretsmanager:GetSecretValue"
-        Resource = [
-          var.database_secret_arn,
-          aws_secretsmanager_secret.function_tools_secret.arn
-        ]
-      }
-    ]
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = "secretsmanager:GetSecretValue"
+          Resource = concat(
+            [
+              var.database_secret_arn,
+              aws_secretsmanager_secret.function_tools_secret.arn
+            ],
+            var.brainstore_custom_ca_bundle_secret_arn == null ? [] : [var.brainstore_custom_ca_bundle_secret_arn]
+          )
+        }
+      ],
+      var.brainstore_custom_ca_bundle_kms_key_arn == null ? [] : [
+        {
+          Effect   = "Allow"
+          Action   = "kms:Decrypt"
+          Resource = var.brainstore_custom_ca_bundle_kms_key_arn
+          Condition = {
+            StringEquals = {
+              "kms:ViaService" = "secretsmanager.${data.aws_region.current.region}.amazonaws.com"
+            }
+          }
+        }
+      ]
+    )
   })
 }
 

--- a/modules/services-common/variables.tf
+++ b/modules/services-common/variables.tf
@@ -23,6 +23,18 @@ variable "database_secret_arn" {
   description = "The ARN of the secret containing database credentials"
 }
 
+variable "brainstore_custom_ca_bundle_secret_arn" {
+  type        = string
+  description = "Optional ARN of the secret containing the PEM-encoded custom CA bundle for Brainstore EC2."
+  default     = null
+}
+
+variable "brainstore_custom_ca_bundle_kms_key_arn" {
+  type        = string
+  description = "Optional ARN of the customer-managed KMS key encrypting the custom CA bundle secret for Brainstore EC2."
+  default     = null
+}
+
 variable "permissions_boundary_arn" {
   type        = string
   description = "ARN of the IAM permissions boundary to apply to all IAM roles created by this module"
@@ -156,4 +168,3 @@ variable "quarantine_vpc_id" {
     error_message = "quarantine_vpc_id is required when enable_quarantine_vpc is true."
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -862,7 +862,7 @@ variable "braintrust_api_extra_env_vars" {
 }
 
 variable "custom_ca_bundle_secret_arn" {
-  description = "Optional ARN of an existing AWS Secrets Manager secret containing a PEM-encoded custom CA bundle for API ECS outbound HTTPS."
+  description = "Optional ARN of an existing AWS Secrets Manager secret containing a PEM-encoded custom CA bundle for API ECS and Brainstore EC2 outbound HTTPS."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description

Extends the custom CA bundle support introduced in #350 to Brainstore.

When `custom_ca_bundle_secret_arn` is configured, Brainstore instances retrieve the PEM bundle from AWS Secrets Manager at startup (cloud-init) and pass it into the Brainstore containers through a Docker environment variable - `BRAINTRUST_CUSTOM_CA_BUNDLE`.

A separate, corresponding Brainstore application change reads this environment variable and appends the supplied certificates to its default trust store.

If the secret uses a customer-managed KMS key, `custom_ca_bundle_kms_key_arn` grants the Brainstore instance role the required scoped decrypt permission.

No Brainstore behavior changes when these inputs are unset.

> This PR is currently stacked on #350 and should be reviewed as the Brainstore portion of the custom CA bundle work.

Also, a reusable secrets retrieval function was created within the `user_data` script that includes backoff / retry logic when fetching secrets from AWS Secrets Manager (in case IAM permissions haven't propagated by the first attempt during instance startup).

## Context

Brainstore outbound HTTPS requests fail certificate verification when a customer's network uses a TLS-inspecting proxy signed by a private CA.

This extends private CA trust to Brainstore without placing the multiline PEM bundle directly in Terraform configuration or `/etc/brainstore.env`.

## Testing

- Ran `mise run lint`
- Ran `mise run validate`
- Deployed the changes to an AWS Vanilla Hybrid sandbox
- Confirmed updated Brainstore reader and writer instances launched successfully
- Confirmed both Brainstore containers started and remained healthy
- Confirmed the custom Brainstore image was running
- Confirmed Secrets Manager and customer-managed KMS access succeeded during startup
- Confirmed Brainstore outbound requests traversed the TLS-inspecting proxy without certificate or TLS errors
