### PR TITLE
Default Loop runtime sandbox egress to restricted

### DIFF
--- a/variables-loop-runtime.tf
+++ b/variables-loop-runtime.tf
@@ -134,5 +134,5 @@ variable "enable_loop_runtime_microvm_runtime_logs" {
 variable "loop_runtime_sandbox_egress_mode" {
   type        = string
   description = "Outbound-network mode for Loop runtime sandbox MicroVMs. Exactly \"internet\" uses AWS-managed Internet egress; any other value uses a restricted connector with no outbound network access."
-  default     = "internet"
+  default     = "restricted"
 }


### PR DESCRIPTION
## Context

Loop runtime sandbox MicroVMs currently default to AWS-managed Internet egress when no mode is configured.

## Description

Change `loop_runtime_sandbox_egress_mode` to default to `"restricted"`. Explicitly configured values remain unchanged.

## Testing

- `terraform fmt -check -recursive`
- `terraform validate`
- `terraform test -filter=tests/default.tftest.hcl`