### PR TITLE
Route ECS API self-calls through the internal ALB

### DIFF
--- a/modules/api-ecs/locals.tf
+++ b/modules/api-ecs/locals.tf
@@ -53,6 +53,7 @@ locals {
     PRIMARY_ORG_NAME                                  = var.primary_org_name
     ALLOWED_ORG_IDS                                   = var.allowed_org_ids
     BRAINTRUST_DEPLOYMENT_NAME                        = var.deployment_name
+    BRAINTRUST_API_URL                                = local.api_ecs_url
     BRAINTRUST_LEGACY_IDS                             = "true" # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
     RESPONSE_BUCKET                                   = var.response_bucket
     CODE_BUNDLE_BUCKET                                = var.code_bundle_bucket
@@ -77,7 +78,7 @@ locals {
     TELEMETRY_LOG_LEVEL                               = var.billing_telemetry_log_level
     INSERT_LOGS2                                      = "true"
     NODE_MEMORY_PERCENT                               = "80"
-    AI_PROXY_FN_URL                                   = "http://127.0.0.1:8000"
+    AI_PROXY_FN_URL                                   = local.api_ecs_url
     BRAINSTORE_DISABLE_ETL_LOOP                       = "true"
     DISABLE_ASYNC_SCORING                             = "false"
     DISABLE_ATTACHMENT_OPTIMIZATION                   = "false"
@@ -89,7 +90,7 @@ locals {
     TS_API_HOST                                       = "0.0.0.0"
     TS_API_PORT                                       = "8000"
     PROXY_URL                                         = "http://127.0.0.1:8000/v1/proxy"
-    TS_API_ASYNC_SCORING_PROXY_URL                    = "http://127.0.0.1:8000"
+    TS_API_ASYNC_SCORING_PROXY_URL                    = local.api_ecs_url
     },
     local.quarantine_proxy_env_vars,
     local.url_security_env_vars,


### PR DESCRIPTION
## Description

 Routes ECS API self-calls through the internal API ALB:

 - Sets AI_PROXY_FN_URL, TS_API_ASYNC_SCORING_PROXY_URL, and BRAINTRUST_API_URL to local.api_ecs_url.
 - Leaves PROXY_URL on loopback for the local proxy path.
 - Does not change Lambda, gateway, or loop-runtime wiring.

 No customer configuration changes required.

## Context

 ECS API tasks run with IS_LOCAL=true. Async scoring writebacks and invoke dispatch previously used loopback URLs, bypassing ALB path-based routing and concentrating PostgreSQL/TLS work on the calling task.

 Using the internal ALB URL routes those calls through the appropriate ingest/background pools.