### PR TITLE
Keep fixed-name ECS replacements destroy-first

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,11 +62,12 @@ locals {
   # SSM parameter selector passed to Brainstore. ECS mode pins to a specific
   # version ("<name>:<version>") so a URL change (e.g. HTTP -> HTTPS) bumps the
   # version, changes the launch template, and triggers a rolling instance
-  # refresh. Lambda mode passes just the bare name. one() keeps this
-  # index-safe when api_ecs is absent.
+  # refresh. Lambda mode passes just the bare name. The counted terraform_data
+  # indirection below prevents Terraform from retaining the inactive ECS graph
+  # edge and propagating Brainstore's create-before-destroy lifecycle upstream.
   brainstore_ai_proxy_url_ssm_parameter = (
     local.enable_ecs_api
-    ? "${local.brainstore_ai_proxy_url_ssm_parameter_name}:${one(module.api_ecs[*].url_ssm_parameter_version)}"
+    ? "${local.brainstore_ai_proxy_url_ssm_parameter_name}:${one(terraform_data.api_ecs_url_ssm_parameter_version[*].output)}"
     : local.brainstore_ai_proxy_url_ssm_parameter_name
   )
 
@@ -525,6 +526,31 @@ module "api_ecs" {
   custom_tags              = local.all_custom_tags
 }
 
+resource "terraform_data" "api_ecs_url_ssm_parameter_version" {
+  count = local.enable_ecs_api ? 1 : 0
+
+  input = module.api_ecs[0].url_ssm_parameter_version
+}
+
+module "api_gateway" {
+  source = "./modules/api-gateway"
+  count  = !var.use_deployment_mode_external_eks ? 1 : 0
+
+  deployment_name           = var.deployment_name
+  api_handler_function_name = "${var.deployment_name}-APIHandler"
+  custom_tags               = local.all_custom_tags
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  count = !var.use_deployment_mode_external_eks ? 1 : 0
+
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = split(":", module.services[0].api_handler_arn)[6]
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${module.api_gateway[0].execution_arn}/*/*"
+}
+
 module "ingress" {
   source = "./modules/ingress"
   count  = !var.use_deployment_mode_external_eks ? 1 : 0
@@ -544,7 +570,7 @@ module "ingress" {
   gateway_alb_dns_name                = local.enable_private_ai_gateway_origin ? module.gateway_alb[0].gateway_alb_dns_name : null
   gateway_cloudfront_ingress_rule_id  = local.enable_private_ai_gateway_origin ? module.gateway_alb[0].gateway_cloudfront_vpc_origin_ingress_rule_id : null
   ai_proxy_function_url               = module.services[0].ai_proxy_url
-  api_handler_function_arn            = module.services[0].api_handler_arn
+  api_gateway_rest_api_id             = module.api_gateway[0].rest_api_id
   enable_ecs_api                      = local.enable_ecs_api
   api_ecs_alb_arn                     = module.api_ecs[0].alb_arn
   api_ecs_alb_domain                  = module.api_ecs[0].alb_domain

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,7 @@ run = """
 set -e
 terraform init -backend=false -upgrade
 terraform test
+uv run --script scripts/test_ecs_replacement_order.py
 """
 
 [tasks.validate]

--- a/modules/api-gateway/api-gateway-openapi-spec.tf
+++ b/modules/api-gateway/api-gateway-openapi-spec.tf
@@ -19,7 +19,7 @@ locals {
     consumes = ["application/json", "text/plain"]
   })
   snippet_api_gateway_integration = {
-    "uri"                 = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${var.api_handler_function_arn}/invocations"
+    "uri"                 = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${local.api_handler_function_arn}/invocations"
     "type"                = "aws_proxy"
     "httpMethod"          = "POST"
     "contentHandling"     = "CONVERT_TO_TEXT"

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -1,3 +1,14 @@
+locals {
+  common_tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, var.custom_tags)
+  api_handler_function_arn = "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.api_handler_function_name}"
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 resource "aws_api_gateway_rest_api" "api" {
   name = "${var.deployment_name}-API"
 
@@ -17,6 +28,7 @@ resource "aws_api_gateway_deployment" "api" {
   triggers = {
     redeployment = sha256(aws_api_gateway_rest_api.api.body)
   }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -36,15 +48,8 @@ resource "aws_api_gateway_method_settings" "all" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   stage_name  = aws_api_gateway_stage.api.stage_name
   method_path = "*/*"
+
   settings {
     metrics_enabled = true
   }
-}
-
-resource "aws_lambda_permission" "api_gateway" {
-  statement_id  = "AllowAPIGatewayInvoke"
-  action        = "lambda:InvokeFunction"
-  function_name = split(":", var.api_handler_function_arn)[6]
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/*"
 }

--- a/modules/api-gateway/outputs.tf
+++ b/modules/api-gateway/outputs.tf
@@ -1,0 +1,24 @@
+output "rest_api_id" {
+  description = "ID of the API Gateway REST API."
+  value       = aws_api_gateway_rest_api.api.id
+}
+
+output "rest_api_arn" {
+  description = "ARN of the API Gateway REST API."
+  value       = aws_api_gateway_rest_api.api.arn
+}
+
+output "execution_arn" {
+  description = "Execution ARN of the API Gateway REST API."
+  value       = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}"
+}
+
+output "name" {
+  description = "Name of the API Gateway REST API."
+  value       = aws_api_gateway_rest_api.api.name
+}
+
+output "stage_name" {
+  description = "Deployed API Gateway stage name."
+  value       = aws_api_gateway_stage.api.stage_name
+}

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -1,0 +1,15 @@
+variable "deployment_name" {
+  type        = string
+  description = "Name of this deployment. Included in API Gateway resource names."
+}
+
+variable "api_handler_function_name" {
+  type        = string
+  description = "Name of the API handler Lambda function."
+}
+
+variable "custom_tags" {
+  type        = map(string)
+  description = "Tags to apply to API Gateway resources."
+  default     = {}
+}

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.28.0, < 7.0.0"
+    }
+  }
+}

--- a/modules/gateway-ecs/main.tf
+++ b/modules/gateway-ecs/main.tf
@@ -377,7 +377,8 @@ resource "aws_ecs_service" "gateway" {
   depends_on = [terraform_data.gateway_http_listener]
 
   lifecycle {
-    ignore_changes = [desired_count]
+    create_before_destroy = false
+    ignore_changes        = [desired_count]
   }
 
   tags = merge({

--- a/modules/ingress/cloudfront.tf
+++ b/modules/ingress/cloudfront.tf
@@ -109,7 +109,7 @@ resource "aws_cloudfront_distribution" "dataplane" {
   origin {
     origin_id   = local.cloudfront_APIGatewayOrigin
     origin_path = "/api"
-    domain_name = "${aws_api_gateway_rest_api.api.id}.execute-api.${data.aws_region.current.region}.amazonaws.com"
+    domain_name = "${var.api_gateway_rest_api_id}.execute-api.${data.aws_region.current.region}.amazonaws.com"
 
     custom_origin_config {
       origin_protocol_policy   = "https-only"

--- a/modules/ingress/main.tf
+++ b/modules/ingress/main.tf
@@ -5,5 +5,3 @@ locals {
 }
 
 data "aws_region" "current" {}
-
-data "aws_caller_identity" "current" {}

--- a/modules/ingress/outputs.tf
+++ b/modules/ingress/outputs.tf
@@ -22,18 +22,3 @@ output "cloudfront_distribution_hosted_zone_id" {
   description = "The hosted zone ID of the cloudfront distribution"
   value       = aws_cloudfront_distribution.dataplane.hosted_zone_id
 }
-
-output "api_gateway_rest_api_arn" {
-  description = "The ARN of the API gateway rest api"
-  value       = aws_api_gateway_rest_api.api.arn
-}
-
-output "api_gateway_name" {
-  description = "The name of the API Gateway REST API."
-  value       = aws_api_gateway_rest_api.api.name
-}
-
-output "api_gateway_stage_name" {
-  description = "The deployed API Gateway stage name."
-  value       = aws_api_gateway_stage.api.stage_name
-}

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -92,8 +92,8 @@ variable "ai_proxy_function_url" {
   type        = string
 }
 
-variable "api_handler_function_arn" {
-  description = "The ARN of the API handler lambda function"
+variable "api_gateway_rest_api_id" {
+  description = "ID of the API Gateway REST API used as the CloudFront API origin."
   type        = string
 }
 

--- a/modules/loop-runtime-ecs/main.tf
+++ b/modules/loop-runtime-ecs/main.tf
@@ -618,7 +618,8 @@ resource "aws_ecs_service" "loop_runtime" {
   depends_on = [terraform_data.loop_runtime_http_listener]
 
   lifecycle {
-    ignore_changes = [desired_count]
+    create_before_destroy = false
+    ignore_changes        = [desired_count]
   }
 
   tags = merge({

--- a/moved_state.tf
+++ b/moved_state.tf
@@ -129,6 +129,34 @@ moved {
   to   = module.ingress[0].aws_lambda_permission.api_gateway
 }
 
+# API Gateway resources moved from ingress into a lifecycle-isolated top-level
+# module. The Lambda permission remains at the root so it can depend on both
+# the Lambda and API without making the API deployment depend on services.
+moved {
+  from = module.ingress[0].aws_api_gateway_rest_api.api
+  to   = module.api_gateway[0].aws_api_gateway_rest_api.api
+}
+
+moved {
+  from = module.ingress[0].aws_api_gateway_deployment.api
+  to   = module.api_gateway[0].aws_api_gateway_deployment.api
+}
+
+moved {
+  from = module.ingress[0].aws_api_gateway_stage.api
+  to   = module.api_gateway[0].aws_api_gateway_stage.api
+}
+
+moved {
+  from = module.ingress[0].aws_api_gateway_method_settings.all
+  to   = module.api_gateway[0].aws_api_gateway_method_settings.all
+}
+
+moved {
+  from = module.ingress[0].aws_lambda_permission.api_gateway
+  to   = aws_lambda_permission.api_gateway[0]
+}
+
 # Brainstore IAM resources moved from brainstore -> services-common
 moved {
   from = module.brainstore[0].aws_iam_role.brainstore_ec2_role

--- a/outputs.tf
+++ b/outputs.tf
@@ -234,8 +234,8 @@ output "monitoring_contract" {
 
     api_gateway = {
       enabled = !var.use_deployment_mode_external_eks
-      name    = !var.use_deployment_mode_external_eks ? module.ingress[0].api_gateway_name : null
-      stage   = !var.use_deployment_mode_external_eks ? module.ingress[0].api_gateway_stage_name : null
+      name    = !var.use_deployment_mode_external_eks ? module.api_gateway[0].name : null
+      stage   = !var.use_deployment_mode_external_eks ? module.api_gateway[0].stage_name : null
     }
 
     brainstore = {

--- a/scripts/test_ecs_replacement_order.py
+++ b/scripts/test_ecs_replacement_order.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Assert fixed-name ECS replacements destroy before creating."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_ORDER = ["delete", "create"]
+
+TEST_CASES = {
+    "tests/api_ecs_root_replacement_order.tftest.hcl": {
+        "run": "force_root_api_ecs_replacements",
+        "resources": {
+            "module.api_ecs[0].aws_ecs_service.braintrust_api",
+            "module.api_ecs[0].aws_ecs_service.braintrust_api_ingest",
+            "module.api_ecs[0].aws_ecs_service.braintrust_api_background",
+        },
+    },
+    "tests/api_ecs_warm_root_replacement_order.tftest.hcl": {
+        "run": "force_warm_root_api_ecs_replacements",
+        "resources": {
+            "module.api_ecs[0].aws_ecs_service.braintrust_api",
+            "module.api_ecs[0].aws_ecs_service.braintrust_api_ingest",
+            "module.api_ecs[0].aws_ecs_service.braintrust_api_background",
+        },
+    },
+    "tests/api_ecs_replacement_order.tftest.hcl": {
+        "run": "force_fixed_name_api_ecs_replacements",
+        "resources": {
+            "aws_ecs_service.braintrust_api",
+            "aws_ecs_service.braintrust_api_ingest",
+            "aws_ecs_service.braintrust_api_background",
+        },
+    },
+    "tests/gateway_ecs_replacement_order.tftest.hcl": {
+        "run": "force_fixed_name_gateway_replacement",
+        "resources": {"aws_ecs_service.gateway"},
+    },
+    "tests/loop_runtime_ecs_replacement_order.tftest.hcl": {
+        "run": "force_fixed_name_loop_runtime_replacement",
+        "resources": {"aws_ecs_service.loop_runtime"},
+    },
+}
+
+LIFECYCLE_INVARIANTS = {
+    ("modules/api-ecs/braintrust-api.tf", "aws_ecs_service", "braintrust_api"): False,
+    (
+        "modules/api-ecs/braintrust-api-ingest.tf",
+        "aws_ecs_service",
+        "braintrust_api_ingest",
+    ): False,
+    (
+        "modules/api-ecs/braintrust-api-background.tf",
+        "aws_ecs_service",
+        "braintrust_api_background",
+    ): False,
+    ("modules/gateway-ecs/main.tf", "aws_ecs_service", "gateway"): False,
+    ("modules/loop-runtime-ecs/main.tf", "aws_ecs_service", "loop_runtime"): False,
+    (
+        "modules/api-gateway/main.tf",
+        "aws_api_gateway_deployment",
+        "api",
+    ): True,
+}
+
+
+def extract_block(source: str, block_type: str, name: str) -> str:
+    marker = re.compile(
+        rf'\bresource\s+"{re.escape(block_type)}"\s+"{re.escape(name)}"\s*\{{'
+    )
+    match = marker.search(source)
+    if match is None:
+        raise ValueError(f'resource "{block_type}" "{name}" not found')
+
+    start = source.find("{", match.start())
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(start, len(source)):
+        char = source[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start + 1 : index]
+    raise ValueError(f'resource "{block_type}" "{name}" has no closing brace')
+
+
+def check_lifecycle_invariants() -> list[str]:
+    failures: list[str] = []
+    for (relative_path, block_type, name), expected in LIFECYCLE_INVARIANTS.items():
+        source = (REPO_ROOT / relative_path).read_text()
+        try:
+            block = extract_block(source, block_type, name)
+        except ValueError as error:
+            failures.append(f"{relative_path}: {error}")
+            continue
+        lifecycle = re.search(r"\blifecycle\s*\{(?P<body>.*?)\}", block, re.DOTALL)
+        if lifecycle is None:
+            failures.append(f"{relative_path}: {block_type}.{name} has no lifecycle block")
+            continue
+        configured = re.search(
+            r"\bcreate_before_destroy\s*=\s*(true|false)\b",
+            lifecycle.group("body"),
+        )
+        if configured is None:
+            failures.append(
+                f"{relative_path}: {block_type}.{name} must explicitly set "
+                f"create_before_destroy = {str(expected).lower()}"
+            )
+        elif (configured.group(1) == "true") != expected:
+            failures.append(
+                f"{relative_path}: {block_type}.{name} has "
+                f"create_before_destroy = {configured.group(1)}, expected "
+                f"{str(expected).lower()}"
+            )
+    return failures
+
+
+def read_replacement_plan(test_file: str, run_name: str) -> tuple[dict[str, list[str]], list[str]]:
+    command = [
+        "terraform",
+        "test",
+        f"-filter={test_file}",
+        "-json",
+        "-verbose",
+        "-no-color",
+    ]
+    process = subprocess.Popen(
+        command,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert process.stdout is not None
+
+    actions: dict[str, list[str]] = {}
+    errors: list[str] = []
+    for line in process.stdout:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            if line.strip():
+                errors.append(line.strip())
+            continue
+
+        if event.get("@level") == "error":
+            diagnostic = event.get("diagnostic", {})
+            errors.append(
+                f"{diagnostic.get('summary', event.get('@message', 'Terraform error'))}: "
+                f"{diagnostic.get('detail', '')}".rstrip()
+            )
+
+        if event.get("type") != "test_plan" or event.get("@testrun") != run_name:
+            continue
+        for resource_change in event["test_plan"].get("resource_changes", []):
+            address = resource_change.get("address")
+            if address:
+                actions[address] = resource_change.get("change", {}).get("actions", [])
+
+    return_code = process.wait()
+    if return_code != 0 and not errors:
+        errors.append(f"terraform test exited with status {return_code}")
+    return actions, errors
+
+
+def main() -> int:
+    failures = check_lifecycle_invariants()
+
+    for test_file, test_case in TEST_CASES.items():
+        actions, errors = read_replacement_plan(test_file, test_case["run"])
+        failures.extend(f"{test_file}: {error}" for error in errors)
+
+        for address in sorted(test_case["resources"]):
+            actual = actions.get(address)
+            if actual != EXPECTED_ORDER:
+                failures.append(
+                    f"{test_file}: {address} replacement actions were {actual!r}; "
+                    f"expected {EXPECTED_ORDER!r}"
+                )
+            else:
+                print(f"PASS {address}: {actual}")
+
+    if failures:
+        print("\nECS replacement-order regression failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("All fixed-name ECS services destroy before replacement creation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api_ecs_replacement_order.tftest.hcl
+++ b/tests/api_ecs_replacement_order.tftest.hcl
@@ -1,0 +1,227 @@
+# Replacement-order regression fixture for all fixed-name API ECS services.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+override_resource {
+  target = aws_iam_role.task_execution
+  values = {
+    arn  = "arn:aws:iam::123456789012:role/bt-test-api-task-exec"
+    id   = "bt-test-api-task-exec"
+    name = "bt-test-api-task-exec"
+  }
+}
+
+override_resource {
+  target = aws_lb.api_ecs
+  values = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/bt-test-api/test"
+    arn_suffix = "app/bt-test-api/test"
+    dns_name   = "bt-test-api.us-east-1.elb.amazonaws.com"
+    id         = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/bt-test-api/test"
+    zone_id    = "Z35SXDOTRQ7X7K"
+  }
+}
+
+override_resource {
+  target = aws_lb_listener.api_ecs_http
+  values = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/bt-test-api/1234567890abcdef/1234567890abcdef"
+    id  = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/bt-test-api/1234567890abcdef/1234567890abcdef"
+  }
+}
+
+override_resource {
+  target = aws_lb_target_group.braintrust_api
+  values = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/braintrust-api/test"
+    arn_suffix = "targetgroup/braintrust-api/test"
+  }
+}
+
+override_resource {
+  target = aws_lb_target_group.braintrust_api_ingest
+  values = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/braintrust-api-ingest/test"
+    arn_suffix = "targetgroup/braintrust-api-ingest/test"
+  }
+}
+
+override_resource {
+  target = aws_lb_target_group.braintrust_api_background
+  values = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/braintrust-api-background/test"
+    arn_suffix = "targetgroup/braintrust-api-background/test"
+  }
+}
+
+override_resource {
+  target = aws_appautoscaling_policy.braintrust_api_event_loop_delay_step
+  values = {
+    arn = "arn:aws:sns:us-east-1:123456789012:braintrust-api-scale"
+  }
+}
+
+override_resource {
+  target = aws_appautoscaling_policy.braintrust_api_ingest_event_loop_delay_step
+  values = {
+    arn = "arn:aws:sns:us-east-1:123456789012:braintrust-api-ingest-scale"
+  }
+}
+
+override_resource {
+  target = aws_appautoscaling_policy.braintrust_api_background_event_loop_delay_step
+  values = {
+    arn = "arn:aws:sns:us-east-1:123456789012:braintrust-api-background-scale"
+  }
+}
+
+override_resource {
+  target = aws_ecs_task_definition.braintrust_api
+  values = {
+    arn      = "arn:aws:ecs:us-east-1:123456789012:task-definition/bt-test-braintrust-api:1"
+    family   = "bt-test-braintrust-api"
+    revision = 1
+  }
+}
+
+override_resource {
+  target = aws_ecs_task_definition.braintrust_api_ingest
+  values = {
+    arn      = "arn:aws:ecs:us-east-1:123456789012:task-definition/bt-test-braintrust-api-ingest:1"
+    family   = "bt-test-braintrust-api-ingest"
+    revision = 1
+  }
+}
+
+override_resource {
+  target = aws_ecs_task_definition.braintrust_api_background
+  values = {
+    arn      = "arn:aws:ecs:us-east-1:123456789012:task-definition/bt-test-braintrust-api-background:1"
+    family   = "bt-test-braintrust-api-background"
+    revision = 1
+  }
+}
+
+variables {
+  deployment_name      = "bt-test"
+  kms_key_arn          = "arn:aws:kms:us-east-1:123456789012:key/test"
+  vpc_id               = "vpc-test"
+  private_subnet_ids   = ["subnet-a", "subnet-b"]
+  ecs_cluster_arn      = "arn:aws:ecs:us-east-1:123456789012:cluster/bt-test"
+  ecs_cluster_name     = "bt-test"
+  api_version_override = "test"
+
+  braintrust_org_name    = "test-org"
+  primary_org_name       = "test-org"
+  brainstore_license_key = "test-license"
+
+  database_url_secret_arn   = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database"
+  redis_url_secret_arn      = "arn:aws:secretsmanager:us-east-1:123456789012:secret:redis"
+  function_tools_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:function-tools"
+  response_bucket           = "responses-test"
+  code_bundle_bucket        = "code-bundle-test"
+
+  brainstore_hostname             = "brainstore.test"
+  brainstore_writer_hostname      = "brainstore-writer.test"
+  brainstore_fast_reader_hostname = "brainstore-fast-reader.test"
+  brainstore_s3_bucket_name       = "brainstore-test"
+  brainstore_port                 = 4000
+  brainstore_etl_batch_size       = 100
+
+  whitelisted_origins                   = ["https://www.braintrust.dev"]
+  outbound_rate_limit_window_minutes    = 1
+  outbound_rate_limit_max_requests      = 100
+  monitoring_telemetry                  = "status,metrics"
+  disable_billing_telemetry_aggregation = false
+  billing_telemetry_log_level           = "info"
+  quarantine_proxy_url                  = "https://ai-proxy.test"
+  task_role_arn                         = "arn:aws:iam::123456789012:role/bt-test-api-task"
+  task_security_group_id                = "sg-api"
+
+  braintrust_api_cpu_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_event_loop_utilization_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_event_loop_delay_autoscaling = {
+    evaluation_periods = 1
+    period             = 60
+    cooldown           = 60
+    steps = [{
+      threshold_ms       = 10
+      scaling_adjustment = 10
+    }]
+  }
+
+  braintrust_api_ingest_cpu_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_ingest_event_loop_utilization_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_ingest_event_loop_delay_autoscaling = {
+    evaluation_periods = 1
+    period             = 60
+    cooldown           = 60
+    steps = [{
+      threshold_ms       = 10
+      scaling_adjustment = 10
+    }]
+  }
+
+  braintrust_api_background_cpu_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_background_event_loop_utilization_autoscaling = {
+    target_value       = 50
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+  }
+  braintrust_api_background_event_loop_delay_autoscaling = {
+    evaluation_periods = 1
+    period             = 60
+    cooldown           = 60
+    steps = [{
+      threshold_ms       = 10
+      scaling_adjustment = 10
+    }]
+  }
+}
+
+run "seed_mocked_api_ecs_state" {
+  command = apply
+
+  module {
+    source = "./modules/api-ecs"
+  }
+}
+
+run "force_fixed_name_api_ecs_replacements" {
+  command = plan
+
+  module {
+    source = "./modules/api-ecs"
+  }
+
+  plan_options {
+    refresh = false
+    replace = [
+      aws_ecs_service.braintrust_api,
+      aws_ecs_service.braintrust_api_ingest,
+      aws_ecs_service.braintrust_api_background,
+    ]
+  }
+}

--- a/tests/api_ecs_root_replacement_order.tftest.hcl
+++ b/tests/api_ecs_root_replacement_order.tftest.hcl
@@ -1,0 +1,40 @@
+# Root-module regression fixture for the fixed-name API ECS services.
+#
+# Running through the complete module graph catches transitive lifecycle
+# propagation from downstream resources such as API Gateway deployments.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "random" {}
+
+mock_provider "http" {
+  source = "./tests/mocks/http"
+}
+
+variables {
+  braintrust_org_name    = "test-org"
+  primary_org_name       = "test-org"
+  deployment_name        = "bt-test"
+  brainstore_license_key = "test-license"
+  enable_quarantine_vpc  = true
+  enable_ecs_api         = true
+}
+
+run "seed_mocked_root_state" {
+  command = apply
+}
+
+run "force_root_api_ecs_replacements" {
+  command = plan
+
+  plan_options {
+    refresh = false
+    replace = [
+      module.api_ecs[0].aws_ecs_service.braintrust_api,
+      module.api_ecs[0].aws_ecs_service.braintrust_api_ingest,
+      module.api_ecs[0].aws_ecs_service.braintrust_api_background,
+    ]
+  }
+}

--- a/tests/api_ecs_warm_root_replacement_order.tftest.hcl
+++ b/tests/api_ecs_warm_root_replacement_order.tftest.hcl
@@ -1,0 +1,37 @@
+# Root-module regression fixture for warm API ECS services before traffic cutover.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "random" {}
+
+mock_provider "http" {
+  source = "./tests/mocks/http"
+}
+
+variables {
+  braintrust_org_name    = "test-org"
+  primary_org_name       = "test-org"
+  deployment_name        = "bt-test"
+  brainstore_license_key = "test-license"
+  enable_quarantine_vpc  = true
+  enable_ecs_api         = false
+}
+
+run "seed_mocked_warm_root_state" {
+  command = apply
+}
+
+run "force_warm_root_api_ecs_replacements" {
+  command = plan
+
+  plan_options {
+    refresh = false
+    replace = [
+      module.api_ecs[0].aws_ecs_service.braintrust_api,
+      module.api_ecs[0].aws_ecs_service.braintrust_api_ingest,
+      module.api_ecs[0].aws_ecs_service.braintrust_api_background,
+    ]
+  }
+}

--- a/tests/gateway_ecs_replacement_order.tftest.hcl
+++ b/tests/gateway_ecs_replacement_order.tftest.hcl
@@ -1,0 +1,63 @@
+# Focused replacement-order fixture for the fixed-name gateway ECS service.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+override_resource {
+  target = aws_iam_role.task_execution
+  values = {
+    arn  = "arn:aws:iam::123456789012:role/bt-test-gateway-task-exec"
+    id   = "bt-test-gateway-task-exec"
+    name = "bt-test-gateway-task-exec"
+  }
+}
+
+override_resource {
+  target = aws_iam_role.task
+  values = {
+    arn  = "arn:aws:iam::123456789012:role/bt-test-gateway-task"
+    id   = "bt-test-gateway-task"
+    name = "bt-test-gateway-task"
+  }
+}
+
+variables {
+  deployment_name             = "bt-test"
+  kms_key_arn                 = "arn:aws:kms:us-east-1:123456789012:key/test"
+  vpc_id                      = "vpc-test"
+  private_subnet_ids          = ["subnet-a", "subnet-b"]
+  ecs_cluster_arn             = "arn:aws:ecs:us-east-1:123456789012:cluster/bt-test"
+  ecs_cluster_name            = "bt-test"
+  container_image             = "public.ecr.aws/braintrust/gateway:test"
+  target_group_arn            = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/gateway/test"
+  alb_security_group_id       = "sg-alb"
+  gateway_http_listener_arn   = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/gateway/test/listener"
+  use_redis_replication_group = true
+  redis_host                  = "redis.test"
+  redis_port                  = 6379
+  redis_security_group_id     = "sg-redis"
+}
+
+run "seed_mocked_gateway_state" {
+  command = apply
+
+  module {
+    source = "./modules/gateway-ecs"
+  }
+}
+
+run "force_fixed_name_gateway_replacement" {
+  command = plan
+
+  module {
+    source = "./modules/gateway-ecs"
+  }
+
+  plan_options {
+    refresh = false
+    replace = [
+      aws_ecs_service.gateway,
+    ]
+  }
+}

--- a/tests/loop_runtime_ecs_replacement_order.tftest.hcl
+++ b/tests/loop_runtime_ecs_replacement_order.tftest.hcl
@@ -1,0 +1,72 @@
+# Focused replacement-order fixture for the fixed-name Loop runtime ECS service.
+# Testing the submodule directly keeps all optional upstream IDs known while
+# retaining the repository's mocked AWS provider and real Terraform graph.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+override_resource {
+  target = aws_iam_role.task_execution
+  values = {
+    arn  = "arn:aws:iam::123456789012:role/bt-test-loop-runtime-task-exec"
+    id   = "bt-test-loop-runtime-task-exec"
+    name = "bt-test-loop-runtime-task-exec"
+  }
+}
+
+override_resource {
+  target = aws_iam_role.task
+  values = {
+    arn  = "arn:aws:iam::123456789012:role/bt-test-loop-runtime-task"
+    id   = "bt-test-loop-runtime-task"
+    name = "bt-test-loop-runtime-task"
+  }
+}
+
+variables {
+  deployment_name                = "bt-test"
+  kms_key_arn                    = "arn:aws:kms:us-east-1:123456789012:key/test"
+  vpc_id                         = "vpc-test"
+  private_subnet_ids             = ["subnet-a", "subnet-b"]
+  ecs_cluster_arn                = "arn:aws:ecs:us-east-1:123456789012:cluster/bt-test"
+  ecs_cluster_name               = "bt-test"
+  container_image                = "public.ecr.aws/braintrust/loop-runtime:test"
+  ephemeral_storage_gib          = 21
+  target_group_arn               = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/loop-runtime/test"
+  alb_security_group_id          = "sg-alb"
+  loop_runtime_http_listener_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/loop-runtime/test/listener"
+  database_url_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database"
+  redis_url_secret_arn           = "arn:aws:secretsmanager:us-east-1:123456789012:secret:redis"
+  function_tools_secret_arn      = "arn:aws:secretsmanager:us-east-1:123456789012:secret:function-tools"
+  brainstore_s3_bucket_name      = "brainstore-test"
+  brainstore_s3_bucket_arn       = "arn:aws:s3:::brainstore-test"
+  code_bundle_bucket             = "code-bundle-test"
+  code_bundle_bucket_arn         = "arn:aws:s3:::code-bundle-test"
+  brainstore_reader_url          = "http://brainstore.test:4000"
+  ai_proxy_url                   = "https://ai-proxy.test"
+  braintrust_api_url             = "https://api.test"
+}
+
+run "seed_mocked_loop_runtime_state" {
+  command = apply
+
+  module {
+    source = "./modules/loop-runtime-ecs"
+  }
+}
+
+run "force_fixed_name_loop_runtime_replacement" {
+  command = plan
+
+  module {
+    source = "./modules/loop-runtime-ecs"
+  }
+
+  plan_options {
+    refresh = false
+    replace = [
+      aws_ecs_service.loop_runtime,
+    ]
+  }
+}

--- a/tests/mocks/aws/resource.tfmock.hcl
+++ b/tests/mocks/aws/resource.tfmock.hcl
@@ -1,0 +1,99 @@
+# Valid shared resource defaults for stateful root-module tests. Provider
+# generated random strings are not sufficient for downstream ARN validation.
+
+mock_resource "aws_lb" {
+  defaults = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/mock/1234567890abcdef"
+    arn_suffix = "app/mock/1234567890abcdef"
+    dns_name   = "mock.us-east-1.elb.amazonaws.com"
+    zone_id    = "Z35SXDOTRQ7X7K"
+  }
+}
+
+mock_resource "aws_lb_target_group" {
+  defaults = {
+    arn        = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/mock/1234567890abcdef"
+    arn_suffix = "targetgroup/mock/1234567890abcdef"
+  }
+}
+
+mock_resource "aws_lb_listener" {
+  defaults = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/mock/1234567890abcdef/1234567890abcdef"
+  }
+}
+
+mock_resource "aws_s3_bucket" {
+  defaults = {
+    arn    = "arn:aws:s3:::mock-bucket"
+    bucket = "mock-bucket"
+    id     = "mock-bucket"
+  }
+}
+
+mock_resource "aws_lambda_function" {
+  defaults = {
+    arn           = "arn:aws:lambda:us-east-1:123456789012:function:mock-function"
+    function_name = "mock-function"
+  }
+}
+
+mock_resource "aws_cloudwatch_event_rule" {
+  defaults = {
+    arn = "arn:aws:events:us-east-1:123456789012:rule/mock-rule"
+  }
+}
+
+mock_resource "aws_appautoscaling_policy" {
+  defaults = {
+    arn = "arn:aws:sns:us-east-1:123456789012:mock-scaling-action"
+  }
+}
+
+mock_resource "aws_iam_role" {
+  defaults = {
+    arn  = "arn:aws:iam::123456789012:role/mock-role"
+    id   = "mock-role"
+    name = "mock-role"
+  }
+}
+
+mock_resource "aws_iam_instance_profile" {
+  defaults = {
+    arn  = "arn:aws:iam::123456789012:instance-profile/mock-instance-profile"
+    name = "mock-instance-profile"
+  }
+}
+
+mock_resource "aws_launch_template" {
+  defaults = {
+    id             = "lt-0123456789abcdef0"
+    latest_version = 1
+  }
+}
+
+mock_resource "aws_iam_policy" {
+  defaults = {
+    arn = "arn:aws:iam::123456789012:policy/mock-policy"
+  }
+}
+
+mock_resource "aws_kms_key" {
+  defaults = {
+    arn    = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+    key_id = "00000000-0000-0000-0000-000000000000"
+  }
+}
+
+mock_resource "aws_elasticache_cluster" {
+  defaults = {
+    cache_nodes = [{
+      address               = "mock-cache.example.test"
+      availability_zone     = "us-east-1a"
+      id                    = "0001"
+      outpost_arn           = null
+      port                  = 6379
+      preferred_outpost_arn = null
+    }]
+  }
+}


### PR DESCRIPTION
## Summary
- isolate API Gateway's create-before-destroy deployment in a top-level module so lifecycle propagation cannot infect fixed-name ECS services
- preserve existing API Gateway behavior and state addresses through explicit moved blocks
- add root-graph and submodule mocked plans that assert every fixed-name ECS replacement is delete-then-create in both warm and active ECS routing modes

## Test plan
- [x] `mise run test` (23 Terraform tests passed)
- [x] replacement-order parser verified all root and submodule ECS services use `delete`, then `create`
- [x] `git diff --check`

## Dependency
Stacked on #357; retarget to `main` after that prerequisite merges.