### PR TITLE
Deny EC2 permissions from quarantine Lambda function code

### DIFF
--- a/modules/services-common/iam-quarantine.tf
+++ b/modules/services-common/iam-quarantine.tf
@@ -83,6 +83,35 @@ resource "aws_iam_role_policy_attachment" "quarantine_function_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+resource "aws_iam_role_policy" "quarantine_function_deny_ec2" {
+  count = var.enable_quarantine_vpc ? 1 : 0
+  name  = "DenyEC2FromFunctionCode"
+  role  = aws_iam_role.quarantine_function_role[0].id
+  policy = jsonencode({ # nosemgrep
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Deny"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeSubnets",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DetachNetworkInterface",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "lambda:SourceFunctionArn" = "arn:aws:lambda:*:*:function:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
 # Policy attached to the API handler role for quarantine operations
 resource "aws_iam_policy" "api_handler_quarantine" {
   count = var.enable_quarantine_vpc ? 1 : 0

--- a/tests/quarantine_iam.tftest.hcl
+++ b/tests/quarantine_iam.tftest.hcl
@@ -1,0 +1,82 @@
+# Verify the quarantine function role keeps Lambda's managed VPC permissions
+# while denying the same EC2 actions to code running inside the function.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+variables {
+  deployment_name                = "bt-test"
+  vpc_id                         = "vpc-12345678"
+  kms_key_arn                    = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+  brainstore_s3_bucket_arn       = "arn:aws:s3:::bt-test-brainstore"
+  database_secret_arn            = "arn:aws:secretsmanager:us-east-1:123456789012:secret:bt-test-database"
+  code_bundle_s3_bucket_arn      = "arn:aws:s3:::bt-test-code-bundles"
+  lambda_responses_s3_bucket_arn = "arn:aws:s3:::bt-test-lambda-responses"
+  enable_quarantine_vpc          = true
+  quarantine_vpc_id              = "vpc-87654321"
+}
+
+run "quarantine_function_role_is_hardened" {
+  command = plan
+
+  module {
+    source = "./modules/services-common"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.quarantine_function_deny_ec2) == 1
+    error_message = "quarantine should attach the EC2 deny policy to the function role"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy.quarantine_function_deny_ec2[0].name == "DenyEC2FromFunctionCode"
+    error_message = "quarantine should use the CloudFormation inline policy name"
+  }
+
+  assert {
+    condition = (
+      jsondecode(aws_iam_role_policy.quarantine_function_deny_ec2[0].policy).Version == "2012-10-17" &&
+      jsondecode(aws_iam_role_policy.quarantine_function_deny_ec2[0].policy).Statement[0].Effect == "Deny" &&
+      jsondecode(aws_iam_role_policy.quarantine_function_deny_ec2[0].policy).Statement[0].Resource == "*" &&
+      jsondecode(aws_iam_role_policy.quarantine_function_deny_ec2[0].policy).Statement[0].Condition.ArnLike["lambda:SourceFunctionArn"] == "arn:aws:lambda:*:*:function:*" &&
+      toset(jsondecode(aws_iam_role_policy.quarantine_function_deny_ec2[0].policy).Statement[0].Action) == toset([
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSubnets",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DetachNetworkInterface",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses"
+      ])
+    )
+    error_message = "quarantine EC2 deny policy should match the CloudFormation policy"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.quarantine_function_role[0].policy_arn == "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+    error_message = "quarantine should retain AWSLambdaVPCAccessExecutionRole"
+  }
+}
+
+run "quarantine_function_role_is_disabled_with_quarantine" {
+  command = plan
+
+  module {
+    source = "./modules/services-common"
+  }
+
+  variables {
+    enable_quarantine_vpc = false
+    quarantine_vpc_id     = null
+  }
+
+  assert {
+    condition = (
+      length(aws_iam_role.quarantine_function_role) == 0 &&
+      length(aws_iam_role_policy.quarantine_function_deny_ec2) == 0 &&
+      length(aws_iam_role_policy_attachment.quarantine_function_role) == 0
+    )
+    error_message = "quarantine function IAM resources should share the quarantine count gate"
+  }
+}


### PR DESCRIPTION
@alsmola says:

> I discovered the [PR](https://github.com/braintrustdata/braintrust/pull/13825) to reduce quarantine Lambda IAM privileges never made it to Terraform. This change should port it over.

## Description

Adds the Terraform equivalent of the quarantine Lambda execution-role hardening from braintrustdata/braintrust#13825.

- Retains `AWSLambdaVPCAccessExecutionRole` so the Lambda service can continue managing ENIs.
- Adds the conditional inline `DenyEC2FromFunctionCode` policy to block EC2 network-interface operations made by function code.
- Uses the same `enable_quarantine_vpc` count behavior as the existing role and managed-policy attachment.
- Adds focused mocked-plan coverage for the exact policy, retained managed policy, and disabled-quarantine path.

For an existing deployment, Terraform adds the standalone inline policy without replacing the IAM role. No operator configuration changes are required.

## Context

- Linear: [INF-521](https://linear.app/braintrustdata/issue/INF-521/deny-ec2-network-interface-operations-from-terraform-quarantine-lambda)
- CloudFormation change: [braintrustdata/braintrust#13825](https://github.com/braintrustdata/braintrust/pull/13825)
- AWS guidance: [Using source function ARN to control function access behavior](https://docs.aws.amazon.com/lambda/latest/dg/permissions-source-function-arn.html)

This is intentionally a minimal security fix. It does not include the VPC endpoints or broader lockdown work from #275.

## Testing

- `mise run lint`
- `mise run validate`
- `mise run validate-tofu`
- `mise run test` — 22 passed, 0 failed
- Focused `tests/quarantine_iam.tftest.hcl` run — 2 passed, 0 failed
- `git diff --check`
