### PR TITLE
Disable API Handler provisioned concurrency in ECS mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,15 +49,19 @@ locals {
     local.main_vpc_private_subnet_3_id
   ]
 
-  create_ecs_api                             = !var.use_deployment_mode_external_eks
-  enable_ecs_api                             = local.create_ecs_api && var.enable_ecs_api
-  create_ai_gateway                          = var.create_ai_gateway
-  enable_ai_gateway                          = local.create_ai_gateway && var.enable_ai_gateway
-  enable_internal_observability              = trimspace(nonsensitive(var.internal_observability_api_key)) != ""
-  create_internal_observability_secret       = local.enable_internal_observability && (local.create_ecs_api || local.create_ai_gateway)
-  ai_proxy_url_ssm_parameter_name            = "/braintrust/${var.deployment_name}/ai-proxy-url"
-  api_ecs_url_ssm_parameter_name             = "/braintrust/${var.deployment_name}/ecs-api-url"
-  brainstore_ai_proxy_url_ssm_parameter_name = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
+  create_ecs_api = !var.use_deployment_mode_external_eks
+  enable_ecs_api = local.create_ecs_api && var.enable_ecs_api
+  # The API Handler Lambda is not on the customer traffic path after the ECS
+  # API cutover. Keeping provisioned concurrency on its alias adds cost and can
+  # leave upgrades stuck when a newly published Lambda version fails to start.
+  effective_api_handler_provisioned_concurrency = local.enable_ecs_api ? 0 : var.api_handler_provisioned_concurrency
+  create_ai_gateway                             = var.create_ai_gateway
+  enable_ai_gateway                             = local.create_ai_gateway && var.enable_ai_gateway
+  enable_internal_observability                 = trimspace(nonsensitive(var.internal_observability_api_key)) != ""
+  create_internal_observability_secret          = local.enable_internal_observability && (local.create_ecs_api || local.create_ai_gateway)
+  ai_proxy_url_ssm_parameter_name               = "/braintrust/${var.deployment_name}/ai-proxy-url"
+  api_ecs_url_ssm_parameter_name                = "/braintrust/${var.deployment_name}/ecs-api-url"
+  brainstore_ai_proxy_url_ssm_parameter_name    = local.enable_ecs_api ? local.api_ecs_url_ssm_parameter_name : local.ai_proxy_url_ssm_parameter_name
 
   # SSM parameter selector passed to Brainstore. ECS mode pins to a specific
   # version ("<name>:<version>") so a URL change (e.g. HTTP -> HTTPS) bumps the
@@ -307,7 +311,7 @@ module "services" {
   allowed_org_ids                            = var.allowed_org_ids
   btql_audit_logs_strict_org_ids             = var.btql_audit_logs_strict_org_ids
   btql_audit_logs_best_effort_org_ids        = var.btql_audit_logs_best_effort_org_ids
-  api_handler_provisioned_concurrency        = var.api_handler_provisioned_concurrency
+  api_handler_provisioned_concurrency        = local.effective_api_handler_provisioned_concurrency
   api_handler_reserved_concurrent_executions = var.api_handler_reserved_concurrent_executions
   api_handler_memory_limit                   = var.api_handler_memory_limit
   ai_proxy_reserved_concurrent_executions    = var.ai_proxy_reserved_concurrent_executions

--- a/tests/ecs_api_cutover.tftest.hcl
+++ b/tests/ecs_api_cutover.tftest.hcl
@@ -38,4 +38,23 @@ run "ecs_api_cutover_plans" {
     condition     = length(module.ingress) == 1
     error_message = "cutover path should keep ingress for CloudFront routing"
   }
+
+  assert {
+    condition     = local.effective_api_handler_provisioned_concurrency == 0
+    error_message = "ECS API mode should disable unused API Handler Lambda provisioned concurrency"
+  }
+}
+
+run "lambda_api_mode_keeps_provisioned_concurrency" {
+  command = plan
+
+  variables {
+    enable_ecs_api                      = false
+    api_handler_provisioned_concurrency = 2
+  }
+
+  assert {
+    condition     = local.effective_api_handler_provisioned_concurrency == 2
+    error_message = "Lambda API mode should preserve configured API Handler provisioned concurrency"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -931,7 +931,7 @@ variable "braintrust_api_url" {
 }
 
 variable "api_handler_provisioned_concurrency" {
-  description = "The number API Handler instances to provision and keep alive. This reduces cold start times and improves latency, with some increase in cost."
+  description = "The number of API Handler Lambda instances to provision and keep alive while Lambda serves API traffic. Ignored when enable_ecs_api is true because customer API traffic is routed to ECS."
   type        = number
   default     = 1
 }


### PR DESCRIPTION
## Summary

- Disables API Handler Lambda provisioned concurrency when `enable_ecs_api = true`.
- Preserves the configured provisioned concurrency when Lambda serves API traffic.

## Customer impact

For ECS API deployments, the next Terraform apply will remove the unused API Handler provisioned-concurrency configuration. API traffic remains on ECS, while the API Handler function and alias remain in place. If ECS API is later disabled, the configured Lambda provisioned concurrency will be restored automatically.

Deployments with `enable_ecs_api = false` are unchanged. No module input changes, state migration, manual AWS changes, or downtime are expected from this update.

This reduces idle Lambda cost and avoids provisioned-concurrency state blocking future Lambda alias updates.

## Validation

- `terraform fmt -check -recursive`
- `terraform validate`
- `tflint --recursive`
- `terraform test`: 21 passed, 0 failed
