### PR TITLE
Pin Loop tasks to their deployed MicroVM image version

### DIFF
--- a/modules/loop-runtime-sandbox-aws-microvm/main.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/main.tf
@@ -81,6 +81,7 @@ locals {
     EXO_SANDBOX_PROVIDER                              = "aws-lambda-microvm"
     EXO_SANDBOX_IMAGE                                 = "lambda-microvm"
     AWS_LAMBDA_MICROVM_IMAGE_IDENTIFIER               = local.image_arn
+    AWS_LAMBDA_MICROVM_IMAGE_VERSION                  = aws_cloudformation_stack.microvm_image.outputs["ImageVersion"]
     AWS_LAMBDA_MICROVM_REGION                         = local.region
     AWS_LAMBDA_MICROVM_INGRESS_NETWORK_CONNECTOR_ARNS = join(",", local.ingress_connector_arns)
     AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARNS  = join(",", local.egress_connector_arns)
@@ -445,6 +446,8 @@ resource "aws_cloudformation_stack" "microvm_image" {
     Outputs:
       ImageArn:
         Value: !GetAtt MicrovmImage.ImageArn
+      ImageVersion:
+        Value: !GetAtt MicrovmImage.LatestActiveImageVersion
   YAML
 
   tags = local.common_tags


### PR DESCRIPTION
Pass the MicroVM image's concrete AWS version to Loop through `AWS_LAMBDA_MICROVM_IMAGE_VERSION`, using an output from the existing nested CloudFormation stack. Each ECS task definition then keeps launching its matching guest image during subsequent runtime upgrades.