### PR TITLE
Fix read after write drift on Route53 firewall domain list

### DIFF
--- a/modules/loop-runtime-sandbox-aws-microvm/main.tf
+++ b/modules/loop-runtime-sandbox-aws-microvm/main.tf
@@ -201,7 +201,7 @@ resource "aws_route_table_association" "restricted_egress" {
 resource "aws_route53_resolver_firewall_domain_list" "restricted_egress" {
   count = local.use_restricted_egress ? 1 : 0
 
-  domains = ["*"]
+  domains = ["*."]
   name    = "bt-loop-${var.deployment_name}-dns-domains"
   tags    = local.common_tags
 }


### PR DESCRIPTION
## Description 

When the wildcard `*` is written to aws_route53_resolver_firewall_domain_list's domain list, it's stored and returned at `*.` which is showing as drift on every plan. This PR updates the default to *. instead.


## Context 
<!-- Help the reviewer understand the background on why you are doing this -->


## Testing 
<!-- Describe how and what you tested. Include screenshots or videos as needed -->
