### PR TITLE
Support alternate PostgreSQL connection settings

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -3,8 +3,7 @@ data "aws_availability_zones" "available" {
 }
 
 data "aws_secretsmanager_secret_version" "postgres_credentials" {
-  count     = var.postgres_credentials_secret_arn == null ? 0 : 1
-  secret_id = var.postgres_credentials_secret_arn
+  secret_id = local.postgres_credentials_secret_arn
 }
 
 data "aws_caller_identity" "current" {}

--- a/data.tf
+++ b/data.tf
@@ -2,4 +2,9 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+data "aws_secretsmanager_secret_version" "postgres_credentials" {
+  count     = var.postgres_credentials_secret_arn == null ? 0 : 1
+  secret_id = var.postgres_credentials_secret_arn
+}
+
 data "aws_caller_identity" "current" {}

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -65,13 +65,12 @@ module "braintrust-data-plane" {
   # quarantine_vpc_cidr = "10.175.8.0/21"
 
   ### Postgres configuration
-  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
-  # Defaults to the module-managed database address.
-  # postgres_host = "database.example.internal"
-  #
-  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
-  # JSON fields named "username" and "password".
-  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # Optional connection override. Omit either field to keep using the
+  # corresponding module-managed database value.
+  # postgres_connection_override = {
+  #   host                   = "database.example.internal"
+  #   credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # }
 
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -65,6 +65,14 @@ module "braintrust-data-plane" {
   # quarantine_vpc_cidr = "10.175.8.0/21"
 
   ### Postgres configuration
+  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
+  # Defaults to the module-managed database address.
+  # postgres_host = "database.example.internal"
+  #
+  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
+  # JSON fields named "username" and "password".
+  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"
 

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -43,13 +43,12 @@ module "braintrust-data-plane" {
   # }
 
   ### Postgres configuration
-  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
-  # Defaults to the module-managed database address.
-  # postgres_host = "database.example.internal"
-  #
-  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
-  # JSON fields named "username" and "password".
-  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # Optional connection override. Omit either field to keep using the
+  # corresponding module-managed database value.
+  # postgres_connection_override = {
+  #   host                   = "database.example.internal"
+  #   credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # }
 
   postgres_instance_type = "db.r8g.large"
 

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -43,6 +43,14 @@ module "braintrust-data-plane" {
   # }
 
   ### Postgres configuration
+  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
+  # Defaults to the module-managed database address.
+  # postgres_host = "database.example.internal"
+  #
+  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
+  # JSON fields named "username" and "password".
+  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+
   postgres_instance_type = "db.r8g.large"
 
   # Smaller storage for sandbox

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -35,6 +35,14 @@ module "braintrust-data-plane" {
   loop_runtime_sandbox_egress_mode = "internet"
 
   ### Postgres configuration
+  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
+  # Defaults to the module-managed database address.
+  # postgres_host = "database.example.internal"
+  #
+  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
+  # JSON fields named "username" and "password".
+  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"
 

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -35,13 +35,12 @@ module "braintrust-data-plane" {
   loop_runtime_sandbox_egress_mode = "internet"
 
   ### Postgres configuration
-  # Optional alternate PostgreSQL endpoint used by services and Brainstore.
-  # Defaults to the module-managed database address.
-  # postgres_host = "database.example.internal"
-  #
-  # Optional ARN of an out-of-band PostgreSQL credentials secret containing
-  # JSON fields named "username" and "password".
-  # postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # Optional connection override. Omit either field to keep using the
+  # corresponding module-managed database value.
+  # postgres_connection_override = {
+  #   host                   = "database.example.internal"
+  #   credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-AbCdEf"
+  # }
 
   # Changing this will incur a short downtime.
   postgres_instance_type = "db.r8g.2xlarge"

--- a/loop-runtime.tf
+++ b/loop-runtime.tf
@@ -86,7 +86,7 @@ module "loop_runtime_ecs" {
   additional_task_role_policy_json = module.loop_runtime_sandbox_aws_microvm[0].task_role_policy_json
 
   # Data-plane connectivity
-  database_url_secret_arn   = module.database.postgres_database_url_secret_arn
+  database_url_secret_arn   = local.database_url_secret_arn
   redis_url_secret_arn      = module.redis.redis_url_secret_arn
   function_tools_secret_arn = module.services_common.function_tools_secret_arn
 

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,23 @@ locals {
     local.main_vpc_private_subnet_2_id,
     local.main_vpc_private_subnet_3_id
   ]
+  postgres_credentials_secret_arn = coalesce(var.postgres_credentials_secret_arn, module.database.postgres_database_secret_arn)
+  postgres_credentials = var.postgres_credentials_secret_arn != null ? jsondecode(data.aws_secretsmanager_secret_version.postgres_credentials[0].secret_string) : {
+    username = module.database.postgres_database_username
+    password = module.database.postgres_database_password
+  }
+  postgres_username = local.postgres_credentials.username
+  postgres_password = local.postgres_credentials.password
+  postgres_host     = coalesce(var.postgres_host, module.database.postgres_database_address)
+  database_url_override_suffix = substr(sha1(join("|", [
+    var.postgres_host != null ? var.postgres_host : "",
+    var.postgres_credentials_secret_arn != null ? var.postgres_credentials_secret_arn : "",
+  ])), 0, 8)
+  database_url_secret_arn = (
+    var.postgres_host != null || var.postgres_credentials_secret_arn != null
+    ? aws_secretsmanager_secret.database_url_override[0].arn
+    : module.database.postgres_database_url_secret_arn
+  )
 
   create_ecs_api                             = !var.use_deployment_mode_external_eks
   enable_ecs_api                             = local.create_ecs_api && var.enable_ecs_api
@@ -289,9 +306,9 @@ module "services" {
   monitoring_telemetry = var.monitoring_telemetry
 
   # Data stores
-  postgres_username = module.database.postgres_database_username
-  postgres_password = module.database.postgres_database_password
-  postgres_host     = module.database.postgres_database_address
+  postgres_username = local.postgres_username
+  postgres_password = local.postgres_password
+  postgres_host     = local.postgres_host
   postgres_port     = module.database.postgres_database_port
 
   use_redis_replication_group = var.use_redis_replication_group
@@ -468,7 +485,7 @@ module "api_ecs" {
   internal_observability_trace_disabled_plugins = var.internal_observability_trace_disabled_plugins
 
   # Data stores
-  database_url_secret_arn      = module.database.postgres_database_url_secret_arn
+  database_url_secret_arn      = local.database_url_secret_arn
   redis_url_secret_arn         = module.redis.redis_url_secret_arn
   function_tools_secret_arn    = module.services_common.function_tools_secret_arn
   custom_ca_bundle_secret_arn  = var.custom_ca_bundle_secret_arn
@@ -607,7 +624,7 @@ module "services_common" {
   deployment_name                           = var.deployment_name
   vpc_id                                    = local.main_vpc_id
   kms_key_arn                               = local.kms_key_arn
-  database_secret_arn                       = module.database.postgres_database_secret_arn
+  database_secret_arn                       = local.postgres_credentials_secret_arn
   brainstore_custom_ca_bundle_secret_arn    = !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_secret_arn : null
   brainstore_custom_ca_bundle_kms_key_arn   = !var.use_deployment_mode_external_eks ? var.custom_ca_bundle_kms_key_arn : null
   brainstore_s3_bucket_arn                  = module.storage.brainstore_bucket_arn
@@ -657,9 +674,9 @@ module "brainstore" {
   cache_file_size_fast_reader           = var.brainstore_cache_file_size_fast_reader
   ai_proxy_url_ssm_parameter            = local.brainstore_ai_proxy_url_ssm_parameter
   monitoring_telemetry                  = var.monitoring_telemetry
-  database_host                         = module.database.postgres_database_address
+  database_host                         = local.postgres_host
   database_port                         = module.database.postgres_database_port
-  database_secret_arn                   = module.database.postgres_database_secret_arn
+  database_secret_arn                   = local.postgres_credentials_secret_arn
   use_redis_replication_group           = var.use_redis_replication_group
   redis_host                            = module.redis.redis_endpoint
   redis_port                            = module.redis.redis_port

--- a/main.tf
+++ b/main.tf
@@ -48,20 +48,26 @@ locals {
     local.main_vpc_private_subnet_2_id,
     local.main_vpc_private_subnet_3_id
   ]
-  postgres_credentials_secret_arn = coalesce(var.postgres_credentials_secret_arn, module.database.postgres_database_secret_arn)
-  postgres_credentials = var.postgres_credentials_secret_arn != null ? jsondecode(data.aws_secretsmanager_secret_version.postgres_credentials[0].secret_string) : {
-    username = module.database.postgres_database_username
-    password = module.database.postgres_database_password
-  }
-  postgres_username = local.postgres_credentials.username
-  postgres_password = local.postgres_credentials.password
-  postgres_host     = coalesce(var.postgres_host, module.database.postgres_database_address)
+  # Object presence remains plan-known even when its fields reference resources
+  # whose values will not be known until apply.
+  use_postgres_connection_override = var.postgres_connection_override != null
+  postgres_credentials_secret_arn = coalesce(
+    try(var.postgres_connection_override.credentials_secret_arn, null),
+    module.database.postgres_database_secret_arn,
+  )
+  postgres_credentials = jsondecode(data.aws_secretsmanager_secret_version.postgres_credentials.secret_string)
+  postgres_username    = local.postgres_credentials.username
+  postgres_password    = local.postgres_credentials.password
+  postgres_host = coalesce(
+    try(var.postgres_connection_override.host, null),
+    module.database.postgres_database_address,
+  )
   database_url_override_suffix = substr(sha1(join("|", [
-    var.postgres_host != null ? var.postgres_host : "",
-    var.postgres_credentials_secret_arn != null ? var.postgres_credentials_secret_arn : "",
+    try(coalesce(var.postgres_connection_override.host, ""), ""),
+    try(coalesce(var.postgres_connection_override.credentials_secret_arn, ""), ""),
   ])), 0, 8)
   database_url_secret_arn = (
-    var.postgres_host != null || var.postgres_credentials_secret_arn != null
+    local.use_postgres_connection_override
     ? aws_secretsmanager_secret.database_url_override[0].arn
     : module.database.postgres_database_url_secret_arn
   )

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -52,7 +52,8 @@ locals {
     lambda => trimspace(data.http.lambda_versions[lambda].response_body)
   }
 
-  postgres_url                 = "postgres://${var.postgres_username}:${var.postgres_password}@${var.postgres_host}:${var.postgres_port}/postgres"
+  # urlencode uses query-string encoding for spaces; PostgreSQL URIs require %20.
+  postgres_url                 = "postgres://${replace(urlencode(var.postgres_username), "+", "%20")}:${replace(urlencode(var.postgres_password), "+", "%20")}@${var.postgres_host}:${var.postgres_port}/postgres"
   using_brainstore_writer      = var.brainstore_writer_hostname != null && var.brainstore_writer_hostname != ""
   using_brainstore_fast_reader = var.brainstore_fast_reader_hostname != null && var.brainstore_fast_reader_hostname != ""
   brainstore_url               = var.brainstore_enabled ? "http://${var.brainstore_hostname}:${var.brainstore_port}" : ""

--- a/remote_support.tf
+++ b/remote_support.tf
@@ -11,8 +11,8 @@ module "remote_support" {
 
   deployment_name = var.deployment_name
 
-  database_host       = module.database.postgres_database_address
-  database_secret_arn = module.database.postgres_database_secret_arn
+  database_host       = local.postgres_host
+  database_secret_arn = local.postgres_credentials_secret_arn
   redis_host          = module.redis.redis_endpoint
   redis_port          = module.redis.redis_port
   kms_key_arn         = local.kms_key_arn

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "database_url_override" {
-  count = var.postgres_host != null || var.postgres_credentials_secret_arn != null ? 1 : 0
+  count = local.use_postgres_connection_override ? 1 : 0
 
   name_prefix = "${var.deployment_name}/DatabaseUrlOverride-${local.database_url_override_suffix}-"
   description = "PostgreSQL URL for the configured database connection"

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,3 +1,27 @@
+resource "aws_secretsmanager_secret" "database_url_override" {
+  count = var.postgres_host != null || var.postgres_credentials_secret_arn != null ? 1 : 0
+
+  name_prefix = "${var.deployment_name}/DatabaseUrlOverride-${local.database_url_override_suffix}-"
+  description = "PostgreSQL URL for the configured database connection"
+  kms_key_id  = local.kms_key_arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge({
+    BraintrustDeploymentName = var.deployment_name
+  }, local.all_custom_tags)
+}
+
+resource "aws_secretsmanager_secret_version" "database_url_override" {
+  count = length(aws_secretsmanager_secret.database_url_override)
+
+  secret_id = aws_secretsmanager_secret.database_url_override[0].id
+  # urlencode uses query-string encoding for spaces; PostgreSQL URIs require %20.
+  secret_string = "postgres://${replace(urlencode(local.postgres_username), "+", "%20")}:${replace(urlencode(local.postgres_password), "+", "%20")}@${local.postgres_host}:${module.database.postgres_database_port}/postgres?sslmode=require"
+}
+
 resource "aws_secretsmanager_secret" "internal_observability_api_key" {
   count = local.create_internal_observability_secret ? 1 : 0
 

--- a/tests/mocks/aws/data.tfmock.hcl
+++ b/tests/mocks/aws/data.tfmock.hcl
@@ -29,6 +29,12 @@ mock_data "aws_secretsmanager_random_password" {
   }
 }
 
+mock_data "aws_secretsmanager_secret_version" {
+  defaults = {
+    secret_string = "{\"username\":\"test-user\",\"password\":\"test-password\"}"
+  }
+}
+
 # Brainstore postconditions require local NVMe (total_instance_storage != null).
 mock_data "aws_ec2_instance_type" {
   defaults = {

--- a/tests/postgres_overrides.tftest.hcl
+++ b/tests/postgres_overrides.tftest.hcl
@@ -13,12 +13,14 @@ mock_provider "http" {
 }
 
 variables {
-  braintrust_org_name             = "test-org"
-  primary_org_name                = "test-org"
-  deployment_name                 = "bt-test"
-  brainstore_license_key          = "test-license"
-  postgres_host                   = "database-alternate.example.internal"
-  postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-test"
+  braintrust_org_name    = "test-org"
+  primary_org_name       = "test-org"
+  deployment_name        = "bt-test"
+  brainstore_license_key = "test-license"
+  postgres_connection_override = {
+    host                   = "database-alternate.example.internal"
+    credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-test"
+  }
 }
 
 run "alternate_postgres_connection" {
@@ -30,7 +32,7 @@ run "alternate_postgres_connection" {
   }
 
   assert {
-    condition     = local.postgres_credentials_secret_arn == var.postgres_credentials_secret_arn
+    condition     = local.postgres_credentials_secret_arn == var.postgres_connection_override.credentials_secret_arn
     error_message = "the alternate PostgreSQL credentials secret should be selected"
   }
 
@@ -44,4 +46,49 @@ run "alternate_postgres_connection" {
     error_message = "the generated URL secret should carry the deployment-name tag"
   }
 
+}
+
+run "host_only_override" {
+  command = plan
+
+  variables {
+    postgres_connection_override = {
+      host = "database-proxy.example.internal"
+    }
+  }
+
+  assert {
+    condition     = local.postgres_host == "database-proxy.example.internal"
+    error_message = "the host-only override should retain module-managed credentials"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret.database_url_override) == 1
+    error_message = "the host-only override should create an effective URL secret"
+  }
+}
+
+run "credentials_only_override" {
+  command = plan
+
+  variables {
+    postgres_connection_override = {
+      credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-next"
+    }
+  }
+
+  assert {
+    condition     = local.postgres_credentials_secret_arn == var.postgres_connection_override.credentials_secret_arn
+    error_message = "the credentials-only override should select the supplied credentials secret"
+  }
+}
+
+run "rejects_empty_override" {
+  command = plan
+
+  variables {
+    postgres_connection_override = {}
+  }
+
+  expect_failures = [var.postgres_connection_override]
 }

--- a/tests/postgres_overrides.tftest.hcl
+++ b/tests/postgres_overrides.tftest.hcl
@@ -1,0 +1,47 @@
+# Plan-mode smoke test for alternate PostgreSQL endpoint and credentials.
+#
+# The credentials secret is expected to contain JSON username/password fields.
+
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "random" {}
+
+mock_provider "http" {
+  source = "./tests/mocks/http"
+}
+
+variables {
+  braintrust_org_name             = "test-org"
+  primary_org_name                = "test-org"
+  deployment_name                 = "bt-test"
+  brainstore_license_key          = "test-license"
+  postgres_host                   = "database-alternate.example.internal"
+  postgres_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:database-credentials-test"
+}
+
+run "alternate_postgres_connection" {
+  command = plan
+
+  assert {
+    condition     = local.postgres_host == "database-alternate.example.internal"
+    error_message = "the alternate PostgreSQL host should be selected"
+  }
+
+  assert {
+    condition     = local.postgres_credentials_secret_arn == var.postgres_credentials_secret_arn
+    error_message = "the alternate PostgreSQL credentials secret should be selected"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret.database_url_override) == 1
+    error_message = "an effective URL secret should be created when host or credentials are overridden"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret.database_url_override[0].tags["BraintrustDeploymentName"] == var.deployment_name
+    error_message = "the generated URL secret should carry the deployment-name tag"
+  }
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -405,25 +405,41 @@ variable "postgres_version" {
   default     = "15"
 }
 
-variable "postgres_host" {
-  type        = string
-  description = "Optional PostgreSQL hostname used by services and Brainstore. Defaults to the module-managed database address."
-  default     = null
+variable "postgres_connection_override" {
+  description = <<-EOT
+    Optional PostgreSQL connection override. Omitted fields continue using the
+    module-managed database values. The credentials secret must contain JSON
+    fields named "username" and "password". If encrypted with a customer-managed
+    KMS key, it must use kms_key_arn.
+  EOT
+  type = object({
+    host                   = optional(string)
+    credentials_secret_arn = optional(string)
+  })
+  default = null
 
   validation {
-    condition     = var.postgres_host == null || try(trimspace(var.postgres_host), "") != ""
-    error_message = "postgres_host must be null or a non-empty string."
+    condition = var.postgres_connection_override == null || try(
+      var.postgres_connection_override.host != null || var.postgres_connection_override.credentials_secret_arn != null,
+      false,
+    )
+    error_message = "postgres_connection_override must specify host, credentials_secret_arn, or both."
   }
-}
-
-variable "postgres_credentials_secret_arn" {
-  type        = string
-  description = "Optional ARN of a Secrets Manager secret containing PostgreSQL credentials as JSON with username and password. Defaults to the module-managed credentials; when set, the module generates a matching URL secret. If encrypted with a customer-managed KMS key, the secret must use kms_key_arn."
-  default     = null
 
   validation {
-    condition     = var.postgres_credentials_secret_arn == null || try(trimspace(var.postgres_credentials_secret_arn), "") != ""
-    error_message = "postgres_credentials_secret_arn must be null or a non-empty string."
+    condition = var.postgres_connection_override == null || try(
+      var.postgres_connection_override.host == null || try(trimspace(var.postgres_connection_override.host), "") != "",
+      false,
+    )
+    error_message = "postgres_connection_override.host must be null or a non-empty string."
+  }
+
+  validation {
+    condition = var.postgres_connection_override == null || try(
+      var.postgres_connection_override.credentials_secret_arn == null || try(trimspace(var.postgres_connection_override.credentials_secret_arn), "") != "",
+      false,
+    )
+    error_message = "postgres_connection_override.credentials_secret_arn must be null or a non-empty string."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -405,6 +405,28 @@ variable "postgres_version" {
   default     = "15"
 }
 
+variable "postgres_host" {
+  type        = string
+  description = "Optional PostgreSQL hostname used by services and Brainstore. Defaults to the module-managed database address."
+  default     = null
+
+  validation {
+    condition     = var.postgres_host == null || try(trimspace(var.postgres_host), "") != ""
+    error_message = "postgres_host must be null or a non-empty string."
+  }
+}
+
+variable "postgres_credentials_secret_arn" {
+  type        = string
+  description = "Optional ARN of a Secrets Manager secret containing PostgreSQL credentials as JSON with username and password. Defaults to the module-managed credentials; when set, the module generates a matching URL secret. If encrypted with a customer-managed KMS key, the secret must use kms_key_arn."
+  default     = null
+
+  validation {
+    condition     = var.postgres_credentials_secret_arn == null || try(trimspace(var.postgres_credentials_secret_arn), "") != ""
+    error_message = "postgres_credentials_secret_arn must be null or a non-empty string."
+  }
+}
+
 variable "postgres_multi_az" {
   description = "Specifies if the RDS instance is multi-AZ. Increases cost but provides higher availability. Recommended for production environments."
   type        = bool


### PR DESCRIPTION
## Summary

Adds unified PostgreSQL connection overrides for deployments that need to use an alternate endpoint, such as RDS Proxy, or independently managed database credentials.

## Changes

- Adds `postgres_connection_override.host` to override the PostgreSQL endpoint used by all services.
- Adds `postgres_connection.override.credentials_secret_arn` for using different credentials. The Secrets Manager secret needs to contain:

```
{
  "username": "...",
  "password": "..."
}
```

- Generates a matching PostgreSQL URL secret for ECS API and Loop Runtime when either override is configured.
- Applies the effective host and credentials consistently across Lambda, ECS API, Loop Runtime, Brainstore, and remote-support workloads.
- Safely percent-encodes credentials embedded in PostgreSQL connection URLs.
- Tags generated secrets with BraintrustDeploymentName.
- Updates all root-module examples and adds plan-mode test coverage.

External secrets using customer-managed encryption must use the deployment’s kms_key_arn. Secrets using the AWS-managed Secrets Manager key require no additional configuration.

## Compatibility

When neither override is configured, existing deployments continue using the module-managed database endpoint, credentials secret, and URL secret without changes.

The module-managed RDS instance is still created; these inputs only override the connection settings used by workloads.

## Validation

- terraform validate
- PostgreSQL override Terraform tests
- tflint --recursive
- Terraform formatting and diff checks
- Sandbox with RDS Proxy endpoint and non-default postgres user
