### PR TITLE
BYOC management role self deny

### DIFF
--- a/managed-byoc/README.md
+++ b/managed-byoc/README.md
@@ -23,12 +23,16 @@ The script requires the AWS CLI, `jq`, and `uuidgen`.
 
 The script sets an ExternalId in the role trust policy for cross-account protection. On first create it auto-generates a value in the form `braintrust-<uuid>`. Re-running against an existing role generates a new ExternalId if it doesn't exist, or preserves the existing ExternalId.
 
+The script injects the management role's exact ARN into its inline policy at runtime. An explicit deny prevents the role from directly modifying, deleting, or passing itself.
+
+When updating an existing installation, pass the role's current name with `--role-name`. This is required for installations using a non-default name, including `BraintrustExternalAccessRole`.
+
 When the script completes, share the printed **Role ARN** and **External ID** with Braintrust.
 
 This role and policy set is the required baseline for managed BYOC. You can review the Trust Policy and Inline Policy in the following files:
 
 - Trust Policy: `managed-byoc/policies/management-role-trust-policy.json` (base policy; ExternalId is always injected by the script at runtime)
-- Inline Policy: `managed-byoc/policies/management-role-policy.json`
+- Inline Policy: `managed-byoc/policies/management-role-policy.json` (base policy; the management role ARN is always injected by the script at runtime)
 
 ## 3) Optional: Organization Service Control Policy (SCP) guardrail
 

--- a/managed-byoc/create-management-role.sh
+++ b/managed-byoc/create-management-role.sh
@@ -56,7 +56,7 @@ resolve_external_id() {
     existing="$(aws iam get-role \
       --profile "$PROFILE" \
       --role-name "$ROLE_NAME" \
-      --output json | jq -r '.Role.AssumeRolePolicyDocument | fromjson | .Statement[0].Condition.StringEquals."sts:ExternalId" // empty')"
+      --output json | jq -r '.Role.AssumeRolePolicyDocument | (if type == "string" then fromjson else . end) | .Statement[0].Condition.StringEquals."sts:ExternalId" // empty')"
     if [[ -n "$existing" && "$existing" != "null" ]]; then
       EXTERNAL_ID="$existing"
       return

--- a/managed-byoc/create-management-role.sh
+++ b/managed-byoc/create-management-role.sh
@@ -71,7 +71,7 @@ build_trust_policy() {
     "$TRUST_POLICY_PATH"
 }
 
-# Renders the inline policy, replacing MANAGEMENT_ROLE_ARN_PLACEHOLDER with the
+# Renders the inline policy, replacing {{management_role_arn}} with the
 # exact ARN AWS returned for this role so the self-modification deny targets it.
 build_role_policy() {
   if [[ "$MANAGEMENT_ROLE_ARN" != arn:* ]]; then
@@ -80,9 +80,9 @@ build_role_policy() {
   fi
   local rendered
   rendered="$(jq --arg role_arn "$MANAGEMENT_ROLE_ARN" \
-    '(.Statement[] | select(.Resource == "MANAGEMENT_ROLE_ARN_PLACEHOLDER") | .Resource) = $role_arn' \
+    '(.Statement[] | select(.Resource == "{{management_role_arn}}") | .Resource) = $role_arn' \
     "$ROLE_POLICY_PATH")"
-  if grep -q 'MANAGEMENT_ROLE_ARN_PLACEHOLDER' <<<"$rendered" || ! grep -qF "\"$MANAGEMENT_ROLE_ARN\"" <<<"$rendered"; then
+  if grep -qF '{{management_role_arn}}' <<<"$rendered" || ! grep -qF "\"$MANAGEMENT_ROLE_ARN\"" <<<"$rendered"; then
     echo "Failed to inject management role ARN into $ROLE_POLICY_PATH." >&2
     exit 1
   fi

--- a/managed-byoc/create-management-role.sh
+++ b/managed-byoc/create-management-role.sh
@@ -10,7 +10,7 @@ PROFILE="${AWS_PROFILE:-default}"
 INLINE_POLICY_NAME="${INLINE_POLICY_NAME:-BraintrustManagementRolePolicy}"
 EXTERNAL_ID=""
 MANAGEMENT_ROLE_ARN=""
-MAX_SESSION_DURATION_SECONDS=14400
+MAX_SESSION_DURATION_SECONDS=3600
 
 usage() {
   cat <<'EOF'
@@ -159,7 +159,7 @@ if aws iam get-role --profile "$PROFILE" --role-name "$ROLE_NAME" >/dev/null 2>&
     --role-name "$ROLE_NAME" \
     --policy-document "$TRUST_POLICY_DOCUMENT" \
     >/dev/null
-  echo "Updating max session duration to 4 hours..."
+  echo "Updating max session duration to 1 hour..."
   aws iam update-role \
     --profile "$PROFILE" \
     --role-name "$ROLE_NAME" \

--- a/managed-byoc/create-management-role.sh
+++ b/managed-byoc/create-management-role.sh
@@ -9,6 +9,7 @@ ROLE_NAME="${ROLE_NAME:-BraintrustManagementRole}"
 PROFILE="${AWS_PROFILE:-default}"
 INLINE_POLICY_NAME="${INLINE_POLICY_NAME:-BraintrustManagementRolePolicy}"
 EXTERNAL_ID=""
+MANAGEMENT_ROLE_ARN=""
 MAX_SESSION_DURATION_SECONDS=14400
 
 usage() {
@@ -18,7 +19,8 @@ Usage:
 
 Options:
   --profile, -p    AWS profile to use (default: AWS_PROFILE env var, else "default")
-  --role-name, -r  IAM role name to create (default: BraintrustManagementRole)
+  --role-name, -r  IAM role name to create or update (default: BraintrustManagementRole).
+                   When updating an existing installation, pass the role's current name.
   --help, -h       Show this help
 
 Environment:
@@ -67,6 +69,24 @@ build_trust_policy() {
   jq --arg external_id "$EXTERNAL_ID" \
     '.Statement[0].Condition = {"StringEquals": {"sts:ExternalId": $external_id}}' \
     "$TRUST_POLICY_PATH"
+}
+
+# Renders the inline policy, replacing MANAGEMENT_ROLE_ARN_PLACEHOLDER with the
+# exact ARN AWS returned for this role so the self-modification deny targets it.
+build_role_policy() {
+  if [[ "$MANAGEMENT_ROLE_ARN" != arn:* ]]; then
+    echo "Failed to resolve management role ARN (got '$MANAGEMENT_ROLE_ARN')." >&2
+    exit 1
+  fi
+  local rendered
+  rendered="$(jq --arg role_arn "$MANAGEMENT_ROLE_ARN" \
+    '(.Statement[] | select(.Resource == "MANAGEMENT_ROLE_ARN_PLACEHOLDER") | .Resource) = $role_arn' \
+    "$ROLE_POLICY_PATH")"
+  if grep -q 'MANAGEMENT_ROLE_ARN_PLACEHOLDER' <<<"$rendered" || ! grep -qF "\"$MANAGEMENT_ROLE_ARN\"" <<<"$rendered"; then
+    echo "Failed to inject management role ARN into $ROLE_POLICY_PATH." >&2
+    exit 1
+  fi
+  printf '%s\n' "$rendered"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -145,26 +165,34 @@ if aws iam get-role --profile "$PROFILE" --role-name "$ROLE_NAME" >/dev/null 2>&
     --role-name "$ROLE_NAME" \
     --max-session-duration "$MAX_SESSION_DURATION_SECONDS" \
     >/dev/null
+  MANAGEMENT_ROLE_ARN="$(aws iam get-role \
+    --profile "$PROFILE" \
+    --role-name "$ROLE_NAME" \
+    --query 'Role.Arn' \
+    --output text)"
 else
   echo "Creating role '$ROLE_NAME'..."
-  aws iam create-role \
+  MANAGEMENT_ROLE_ARN="$(aws iam create-role \
     --profile "$PROFILE" \
     --role-name "$ROLE_NAME" \
     --assume-role-policy-document "$TRUST_POLICY_DOCUMENT" \
     --max-session-duration "$MAX_SESSION_DURATION_SECONDS" \
-    >/dev/null
+    --query 'Role.Arn' \
+    --output text)"
 fi
+
+ROLE_POLICY_DOCUMENT="$(build_role_policy)"
 
 echo "Applying inline permissions policy '$INLINE_POLICY_NAME'..."
 aws iam put-role-policy \
   --profile "$PROFILE" \
   --role-name "$ROLE_NAME" \
   --policy-name "$INLINE_POLICY_NAME" \
-  --policy-document "file://$ROLE_POLICY_PATH" \
+  --policy-document "$ROLE_POLICY_DOCUMENT" \
   >/dev/null
 
 echo "Done. Role '$ROLE_NAME' is configured in account $ACCOUNT_ID."
-echo "Role ARN: arn:aws:iam::$ACCOUNT_ID:role/$ROLE_NAME"
+echo "Role ARN: $MANAGEMENT_ROLE_ARN"
 echo
 echo "Share this External ID with Braintrust:"
 echo "  $EXTERNAL_ID"

--- a/managed-byoc/policies/management-role-policy.json
+++ b/managed-byoc/policies/management-role-policy.json
@@ -157,6 +157,26 @@
       }
     },
     {
+      "Sid": "DenyManagementRoleSelfModification",
+      "Effect": "Deny",
+      "Action": [
+        "iam:AttachRolePolicy",
+        "iam:DeleteRole",
+        "iam:DeleteRolePermissionsBoundary",
+        "iam:DeleteRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:PassRole",
+        "iam:PutRolePermissionsBoundary",
+        "iam:PutRolePolicy",
+        "iam:TagRole",
+        "iam:UntagRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:UpdateRole",
+        "iam:UpdateRoleDescription"
+      ],
+      "Resource": "MANAGEMENT_ROLE_ARN_PLACEHOLDER"
+    },
+    {
       "Sid": "AllowReadOnlyAccountContext",
       "Effect": "Allow",
       "Action": [

--- a/managed-byoc/policies/management-role-policy.json
+++ b/managed-byoc/policies/management-role-policy.json
@@ -174,7 +174,7 @@
         "iam:UpdateRole",
         "iam:UpdateRoleDescription"
       ],
-      "Resource": "MANAGEMENT_ROLE_ARN_PLACEHOLDER"
+      "Resource": "{{management_role_arn}}"
     },
     {
       "Sid": "AllowReadOnlyAccountContext",


### PR DESCRIPTION
## Description
Adds an explicit deny preventing the BYOC management role from directly modifying or deleting itself, or being passed to an AWS service. The setup script inserts the role’s exact ARN into the policy, including when a custom role name is used.

Also:
- Handles both string and object trust policy responses when preserving the External ID
- Reduces the maximum role session duration from four hours to one hour to match AWS STS’s one-hour limit for role chaining

Existing installations can apply these changes by rerunning the setup script. If the BYOC management role uses a custom name (rather than the default `BraintrustManagementRole`), specify it with `--role-name`.

## Context
Adds a targeted safeguard around the management role while preserving its ability to manage infrastructure roles and their policies.


## Testing 
- Ran `create-management-role.sh` and verified templating syntax - BYOC management role created successfully.
- Completed a Terraform apply - successful data plane deployment.
- Successfully ran a Terraform destroy.
- Confirmed the assumed management role identity through CloudTrail.
- IAM policy simulation returned an explicit deny for `iam:PutRolePolicy` on the management role.
- Shell syntax, template rendering checks, and `mise run lint` passed.
