### PR TITLE
Add Secrets Manager VPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,18 @@ The module creates these AWS service endpoints in VPCs it manages:
 | --- | --- | --- | --- |
 | S3 | Gateway | Always, in both main and quarantine VPCs when created; attached to their private route tables | Not applicable |
 | SSM (`ssm`, `ssmmessages`, `ec2messages`) | Interface | Main VPC with `enable_brainstore_ec2_ssm = true` (default `false`) | Enabled |
-| Secrets Manager | Interface | Main VPC with `create_secrets_manager_vpc_endpoint = true` (default `false`) | Enabled |
+| Secrets Manager | Interface | Main VPC with `create_secrets_manager_vpc_endpoint = true` (default `true`) | Enabled |
 
 SSM and Secrets Manager endpoints span all three private subnets and share a
 security group allowing HTTPS (TCP 443) from the VPC CIDR. Private DNS lets
 existing SDK and CLI calls use the endpoints without URL overrides. Interface
 endpoint charges apply.
 
-The Secrets Manager option is independent of SSM and requires `create_vpc = true`.
+Secrets Manager is enabled by default independently of SSM. Upgrading a deployment
+with a module-managed main VPC adds the endpoint and redirects regional Secrets
+Manager calls through it. Set `create_secrets_manager_vpc_endpoint = false` to
+retain the previous network path and avoid the additional endpoint charges.
+The option has no effect when `create_vpc = false`.
 The module does not create these AWS service endpoints inside supplied existing
 VPCs. With `create_vpc = false`, it can still create an S3 endpoint in a separate,
 module-managed quarantine VPC.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,31 @@ This module creates two VPCs by default:
 - `main` VPC: This is the main VPC that contains the Braintrust services.
 - `quarantine` VPC: This is a "quarantine" VPC where user defined functions run in an isolated environment. The Braintrust API server spawns lambda functions in this VPC.
 
+#### VPC endpoints
+
+The module creates these AWS service endpoints in VPCs it manages:
+
+| Service | Type | Created when | Private DNS |
+| --- | --- | --- | --- |
+| S3 | Gateway | Always, in both main and quarantine VPCs when created; attached to their private route tables | Not applicable |
+| SSM (`ssm`, `ssmmessages`, `ec2messages`) | Interface | Main VPC with `enable_brainstore_ec2_ssm = true` (default `false`) | Enabled |
+| Secrets Manager | Interface | Main VPC with `create_secrets_manager_vpc_endpoint = true` (default `false`) | Enabled |
+
+SSM and Secrets Manager endpoints span all three private subnets and share a
+security group allowing HTTPS (TCP 443) from the VPC CIDR. Private DNS lets
+existing SDK and CLI calls use the endpoints without URL overrides. Interface
+endpoint charges apply.
+
+The Secrets Manager option is independent of SSM and requires `create_vpc = true`.
+The module does not create these AWS service endpoints inside supplied existing
+VPCs. With `create_vpc = false`, it can still create an S3 endpoint in a separate,
+module-managed quarantine VPC.
+
+Separately, `use_private_gateway_quarantine_proxy` can create an interface endpoint
+in quarantine for the private gateway when both VPCs are module-managed and the
+private gateway is enabled for this path. It uses its endpoint-specific DNS name
+with Private DNS disabled; the global gateway origin skips this PrivateLink setup.
+
 ### Tagging and Naming
 
 If you have requirements to add custom tags to resources created by the module, you can do so by setting the `default_tags` variable on the AWS provider. The example directory [`examples/braintrust-data-plane`](examples/braintrust-data-plane) shows how to do this.

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -141,9 +141,9 @@ module "braintrust-data-plane" {
   # You might need to adjust this so it does not conflict with any other VPC CIDR blocks you intend to peer with Braintrust.
   # vpc_cidr = "10.175.0.0/21"
 
-  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Secrets Manager endpoint is enabled by default in a module-managed main VPC.
   # Adds interface endpoint charges; Private DNS redirects regional API calls.
-  # create_secrets_manager_vpc_endpoint = true
+  # create_secrets_manager_vpc_endpoint = false # Opt out.
 
   ### Tagging
   # Optionally add any custom AWS tags you want to apply to all resources created by the module

--- a/examples/braintrust-data-plane-external-eks-quarantine/main.tf
+++ b/examples/braintrust-data-plane-external-eks-quarantine/main.tf
@@ -141,6 +141,10 @@ module "braintrust-data-plane" {
   # You might need to adjust this so it does not conflict with any other VPC CIDR blocks you intend to peer with Braintrust.
   # vpc_cidr = "10.175.0.0/21"
 
+  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Adds interface endpoint charges; Private DNS redirects regional API calls.
+  # create_secrets_manager_vpc_endpoint = true
+
   ### Tagging
   # Optionally add any custom AWS tags you want to apply to all resources created by the module
   # custom_tags = {

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -138,9 +138,9 @@ module "braintrust-data-plane" {
   # vpc_cidr            = "10.175.0.0/21"
   # quarantine_vpc_cidr = "10.175.8.0/21"
 
-  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Secrets Manager endpoint is enabled by default in a module-managed main VPC.
   # Adds interface endpoint charges; Private DNS redirects regional API calls.
-  # create_secrets_manager_vpc_endpoint = true
+  # create_secrets_manager_vpc_endpoint = false # Opt out.
 
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.

--- a/examples/braintrust-data-plane-sandbox/main.tf
+++ b/examples/braintrust-data-plane-sandbox/main.tf
@@ -137,6 +137,11 @@ module "braintrust-data-plane" {
   # peer with other VPCs and the default CIDRs conflict.
   # vpc_cidr            = "10.175.0.0/21"
   # quarantine_vpc_cidr = "10.175.8.0/21"
+
+  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Adds interface endpoint charges; Private DNS redirects regional API calls.
+  # create_secrets_manager_vpc_endpoint = true
+
   ### S3 CORS configuration
   # Additional CORS origins for the code bundle and lambda responses buckets.
   # Use s3_additional_allowed_origins to apply the same origins to both buckets,

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -127,6 +127,10 @@ module "braintrust-data-plane" {
   # You might need to adjust this so it does not conflict with any other VPC CIDR blocks you intend to peer with Braintrust
   # quarantine_vpc_cidr                   = "10.175.8.0/21"
 
+  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Adds interface endpoint charges; Private DNS redirects regional API calls.
+  # create_secrets_manager_vpc_endpoint = true
+
   # VPC Flow Logs (disabled by default; only applied to VPCs this module creates).
   # Configure the main and quarantine VPCs separately.
   #

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -127,9 +127,9 @@ module "braintrust-data-plane" {
   # You might need to adjust this so it does not conflict with any other VPC CIDR blocks you intend to peer with Braintrust
   # quarantine_vpc_cidr                   = "10.175.8.0/21"
 
-  # Optional: private Secrets Manager access in a module-managed main VPC.
+  # Secrets Manager endpoint is enabled by default in a module-managed main VPC.
   # Adds interface endpoint charges; Private DNS redirects regional API calls.
-  # create_secrets_manager_vpc_endpoint = true
+  # create_secrets_manager_vpc_endpoint = false # Opt out.
 
   # VPC Flow Logs (disabled by default; only applied to VPCs this module creates).
   # Configure the main and quarantine VPCs separately.

--- a/examples/cloudfront-logging/main.tf
+++ b/examples/cloudfront-logging/main.tf
@@ -14,7 +14,8 @@ module "braintrust-data-plane" {
   enable_loop_runtime              = false
   loop_runtime_sandbox_egress_mode = "internet"
 
-  # Optional URL-security inputs are shown in examples/braintrust-data-plane/main.tf.
+  # Optional networking inputs, including create_secrets_manager_vpc_endpoint,
+  # and URL-security inputs are shown in examples/braintrust-data-plane/main.tf.
 }
 
 ###############################################################################

--- a/main.tf
+++ b/main.tf
@@ -187,6 +187,7 @@ module "main_vpc" {
   private_subnet_2_az                  = local.private_subnet_2_az
   private_subnet_3_cidr                = cidrsubnet(var.vpc_cidr, 3, 3)
   private_subnet_3_az                  = local.private_subnet_3_az
+  create_secrets_manager_vpc_endpoint  = var.create_secrets_manager_vpc_endpoint
   enable_brainstore_ec2_ssm            = var.enable_brainstore_ec2_ssm
   s3_vpc_endpoint_resource_org_ids     = var.s3_vpc_endpoint_resource_org_ids
   s3_vpc_endpoint_resource_account_ids = var.s3_vpc_endpoint_resource_account_ids

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -273,7 +273,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_security_group" "vpc_endpoints_tls" {
-  count       = var.enable_brainstore_ec2_ssm ? 1 : 0
+  count       = var.enable_brainstore_ec2_ssm || var.create_secrets_manager_vpc_endpoint ? 1 : 0
   name        = "${var.deployment_name}-${var.vpc_name}-vpc-endpoints"
   description = "Allow TLS inbound traffic from within VPC"
   vpc_id      = aws_vpc.vpc.id
@@ -285,6 +285,8 @@ resource "aws_security_group" "vpc_endpoints_tls" {
     protocol    = "tcp"
     cidr_blocks = [var.vpc_cidr]
   }
+
+  tags = local.common_tags
 }
 
 resource "aws_vpc_endpoint" "ec2_ssm_endpoint" {
@@ -306,5 +308,24 @@ resource "aws_vpc_endpoint" "ec2_ssm_endpoint" {
 
   tags = merge({
     Name = "${var.deployment_name}-${var.vpc_name}-${each.key}-endpoint"
+  }, local.common_tags)
+}
+
+resource "aws_vpc_endpoint" "secrets_manager" {
+  count             = var.create_secrets_manager_vpc_endpoint ? 1 : 0
+  vpc_id            = aws_vpc.vpc.id
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.secretsmanager"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = [aws_security_group.vpc_endpoints_tls[0].id]
+  private_dns_enabled = true
+  subnet_ids = [
+    aws_subnet.private_subnet_1.id,
+    aws_subnet.private_subnet_2.id,
+    aws_subnet.private_subnet_3.id,
+  ]
+
+  tags = merge({
+    Name = "${var.deployment_name}-${var.vpc_name}-secretsmanager-endpoint"
   }, local.common_tags)
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -286,7 +286,9 @@ resource "aws_security_group" "vpc_endpoints_tls" {
     cidr_blocks = [var.vpc_cidr]
   }
 
-  tags = local.common_tags
+  tags = merge({
+    Name = "${var.deployment_name}-${var.vpc_name}-vpc-endpoints"
+  }, local.common_tags)
 }
 
 resource "aws_vpc_endpoint" "ec2_ssm_endpoint" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -162,6 +162,7 @@ variable "flow_log" {
 
 variable "create_secrets_manager_vpc_endpoint" {
   description = "Create a Secrets Manager interface endpoint with Private DNS in all three private subnets."
-  type        = bool
-  default     = false
+  # The root enables this by default only for main; quarantine keeps it disabled.
+  type    = bool
+  default = false
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -159,3 +159,9 @@ variable "flow_log" {
     error_message = "flow_log.retention_in_days must be >= 0 for S3, or a valid CloudWatch Logs retention value (0 = never expire) for cloud-watch-logs."
   }
 }
+
+variable "create_secrets_manager_vpc_endpoint" {
+  description = "Create a Secrets Manager interface endpoint with Private DNS in all three private subnets."
+  type        = bool
+  default     = false
+}

--- a/tests/secrets_manager_endpoint.tftest.hcl
+++ b/tests/secrets_manager_endpoint.tftest.hcl
@@ -1,5 +1,5 @@
-# Mocked plans verify the endpoint works independently of SSM and rejects
-# existing-VPC configurations where this module cannot create the endpoint.
+# Mocked plans cover default enablement, SSM independence, opt-out, and
+# existing-VPC compatibility where the main VPC module is not instantiated.
 mock_provider "aws" {
   source = "./tests/mocks/aws"
 }
@@ -11,11 +11,10 @@ mock_provider "http" {
 }
 
 variables {
-  braintrust_org_name                 = "test-org"
-  primary_org_name                    = "test-org"
-  deployment_name                     = "bt-test"
-  brainstore_license_key              = "test-license"
-  create_secrets_manager_vpc_endpoint = true
+  braintrust_org_name    = "test-org"
+  primary_org_name       = "test-org"
+  deployment_name        = "bt-test"
+  brainstore_license_key = "test-license"
 }
 
 run "secrets_manager_without_ssm" {
@@ -34,7 +33,15 @@ run "secrets_manager_with_ssm" {
   }
 }
 
-run "existing_vpc_rejected" {
+run "secrets_manager_opt_out" {
+  command = plan
+
+  variables {
+    create_secrets_manager_vpc_endpoint = false
+  }
+}
+
+run "existing_vpc_skips_endpoint" {
   command = plan
 
   variables {
@@ -46,5 +53,8 @@ run "existing_vpc_rejected" {
     existing_public_subnet_1_id  = "subnet-44444444"
   }
 
-  expect_failures = [var.create_secrets_manager_vpc_endpoint]
+  assert {
+    condition     = length(module.main_vpc) == 0
+    error_message = "An existing main VPC must not instantiate the VPC module or its endpoints."
+  }
 }

--- a/tests/secrets_manager_endpoint.tftest.hcl
+++ b/tests/secrets_manager_endpoint.tftest.hcl
@@ -1,0 +1,50 @@
+# Mocked plans verify the endpoint works independently of SSM and rejects
+# existing-VPC configurations where this module cannot create the endpoint.
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "random" {}
+
+mock_provider "http" {
+  source = "./tests/mocks/http"
+}
+
+variables {
+  braintrust_org_name                 = "test-org"
+  primary_org_name                    = "test-org"
+  deployment_name                     = "bt-test"
+  brainstore_license_key              = "test-license"
+  create_secrets_manager_vpc_endpoint = true
+}
+
+run "secrets_manager_without_ssm" {
+  command = plan
+
+  variables {
+    enable_brainstore_ec2_ssm = false
+  }
+}
+
+run "secrets_manager_with_ssm" {
+  command = plan
+
+  variables {
+    enable_brainstore_ec2_ssm = true
+  }
+}
+
+run "existing_vpc_rejected" {
+  command = plan
+
+  variables {
+    create_vpc                   = false
+    existing_vpc_id              = "vpc-12345678"
+    existing_private_subnet_1_id = "subnet-11111111"
+    existing_private_subnet_2_id = "subnet-22222222"
+    existing_private_subnet_3_id = "subnet-33333333"
+    existing_public_subnet_1_id  = "subnet-44444444"
+  }
+
+  expect_failures = [var.create_secrets_manager_vpc_endpoint]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,17 @@ variable "create_vpc" {
   description = "Whether to create a new VPC. If false, existing VPC details must be provided."
 }
 
+variable "create_secrets_manager_vpc_endpoint" {
+  type        = bool
+  default     = false
+  description = "Create a Secrets Manager interface endpoint with Private DNS in all three main VPC private subnets. Requires create_vpc; does not create an endpoint in quarantine. Adds interface endpoint charges and routes the standard regional Secrets Manager hostname through the endpoint for callers using VPC DNS."
+
+  validation {
+    condition     = !var.create_secrets_manager_vpc_endpoint || var.create_vpc
+    error_message = "create_secrets_manager_vpc_endpoint requires create_vpc = true. For an existing VPC, manage the Secrets Manager endpoint outside this module."
+  }
+}
+
 variable "vpc_cidr" {
   type        = string
   default     = "10.175.0.0/21"

--- a/variables.tf
+++ b/variables.tf
@@ -113,13 +113,8 @@ variable "create_vpc" {
 
 variable "create_secrets_manager_vpc_endpoint" {
   type        = bool
-  default     = false
-  description = "Create a Secrets Manager interface endpoint with Private DNS in all three main VPC private subnets. Requires create_vpc; does not create an endpoint in quarantine. Adds interface endpoint charges and routes the standard regional Secrets Manager hostname through the endpoint for callers using VPC DNS."
-
-  validation {
-    condition     = !var.create_secrets_manager_vpc_endpoint || var.create_vpc
-    error_message = "create_secrets_manager_vpc_endpoint requires create_vpc = true. For an existing VPC, manage the Secrets Manager endpoint outside this module."
-  }
+  default     = true
+  description = "Create a Secrets Manager interface endpoint with Private DNS in all three main VPC private subnets. Only applies when create_vpc is true; does not create an endpoint in quarantine or an existing VPC. Adds interface endpoint charges and routes the standard regional Secrets Manager hostname through the endpoint for callers using VPC DNS. Set false to opt out."
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
## Description

Adds Secrets Manager VPC endpoint support via `create_secrets_manager_vpc_endpoint` (default `true`).

When enabled, creates an interface endpoint with Private DNS across all three private subnets of the module-managed main VPC. Shares the SSM endpoint security group, allowing HTTPS from the VPC CIDR, and also adds `Name` tag to the security group.

Only applies when `create_vpc = true`; does not add a quarantine endpoint. Existing deployments with module-managed main VPCs use the endpoint unless explicitly disabled. Enabling redirects standard regional Secrets Manager calls through the endpoint and adds interface endpoint charges.

Updates the README endpoint overview and example networking sections.

## Context

Allows workloads to retrieve secrets privately without requiring NAT for Secrets Manager access. Follows the existing SSM endpoint configuration while allowing independent toggling.

## Testing

- Terraform validation, formatting, and recursive TFLint passed.
- Mocked plans passed for Secrets Manager with SSM enabled and disabled, rejection with an existing main VPC, and default deployment behavior.
- Sandbox reader and writer instances passed EC2 and load-balancer health checks.
- CloudTrail confirmed successful `GetSecretValue` calls from both Brainstore instance roles through the new endpoint.
- Verified the endpoint was available with Private DNS enabled.